### PR TITLE
refac(api): Flatten out user attributes entity.

### DIFF
--- a/cmd/is_feature_enabled.go
+++ b/cmd/is_feature_enabled.go
@@ -18,13 +18,14 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/optimizely/go-sdk/optimizely/client"
 	"github.com/optimizely/go-sdk/optimizely/entities"
 	"github.com/spf13/cobra"
 )
 
 var (
-	userId string
+	userId      string
 	featurekKey string
 )
 
@@ -46,7 +47,7 @@ var isFeatureEnabledCmd = &cobra.Command{
 
 		user := entities.UserContext{
 			ID:         userId,
-			Attributes: entities.UserAttributes{},
+			Attributes: map[string]interface{}{},
 		}
 
 		enabled, _ := client.IsFeatureEnabled(featurekKey, user)

--- a/examples/main.go
+++ b/examples/main.go
@@ -22,8 +22,11 @@ func main() {
 	}
 
 	user := entities.UserContext{
-		ID:         "mike ng",
-		Attributes: entities.UserAttributes{},
+		ID: "mike ng",
+		Attributes: map[string]interface{}{
+			"country":      "Unknown",
+			"likes_donuts": true,
+		},
 	}
 
 	enabled, _ := client.IsFeatureEnabled("go_sdk", user)

--- a/optimizely/decision/evaluator/condition_test.go
+++ b/optimizely/decision/evaluator/condition_test.go
@@ -34,10 +34,8 @@ func TestCustomAttributeConditionEvaluator(t *testing.T) {
 
 	// Test condition passes
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
 		},
 	}
 
@@ -47,10 +45,8 @@ func TestCustomAttributeConditionEvaluator(t *testing.T) {
 
 	// Test condition fails
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not_foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not_foo",
 		},
 	}
 	result, _ = conditionEvaluator.Evaluate(condition, condTreeParams)

--- a/optimizely/decision/evaluator/condition_tree_test.go
+++ b/optimizely/decision/evaluator/condition_tree_test.go
@@ -42,10 +42,8 @@ func TestConditionTreeEvaluateSimpleCondition(t *testing.T) {
 
 	// Test match
 	user := e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
 		},
 	}
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
@@ -54,10 +52,8 @@ func TestConditionTreeEvaluateSimpleCondition(t *testing.T) {
 
 	// Test no match
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -80,10 +76,8 @@ func TestConditionTreeEvaluateMultipleOrConditions(t *testing.T) {
 
 	// Test match string
 	user := e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
 		},
 	}
 
@@ -93,10 +87,8 @@ func TestConditionTreeEvaluateMultipleOrConditions(t *testing.T) {
 
 	// Test match bool
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"bool_true": true,
-			},
+		Attributes: map[string]interface{}{
+			"bool_true": true,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -104,11 +96,9 @@ func TestConditionTreeEvaluateMultipleOrConditions(t *testing.T) {
 
 	// Test match both
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  true,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  true,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -116,11 +106,9 @@ func TestConditionTreeEvaluateMultipleOrConditions(t *testing.T) {
 
 	// Test no match
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-				"bool_true":  false,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
+			"bool_true":  false,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -143,10 +131,8 @@ func TestConditionTreeEvaluateMultipleAndConditions(t *testing.T) {
 
 	// Test only string match with NULL bubbling
 	user := e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
 		},
 	}
 
@@ -156,10 +142,8 @@ func TestConditionTreeEvaluateMultipleAndConditions(t *testing.T) {
 
 	// Test only bool match with NULL bubbling
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"bool_true": true,
-			},
+		Attributes: map[string]interface{}{
+			"bool_true": true,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -167,11 +151,9 @@ func TestConditionTreeEvaluateMultipleAndConditions(t *testing.T) {
 
 	// Test match both
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  true,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  true,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -179,11 +161,9 @@ func TestConditionTreeEvaluateMultipleAndConditions(t *testing.T) {
 
 	// Test no match
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-				"bool_true":  false,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
+			"bool_true":  false,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -217,10 +197,8 @@ func TestConditionTreeEvaluateNotCondition(t *testing.T) {
 
 	// Test match string
 	user := e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
 		},
 	}
 
@@ -230,10 +208,8 @@ func TestConditionTreeEvaluateNotCondition(t *testing.T) {
 
 	// Test match bool
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"bool_true": false,
-			},
+		Attributes: map[string]interface{}{
+			"bool_true": false,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -241,11 +217,9 @@ func TestConditionTreeEvaluateNotCondition(t *testing.T) {
 
 	// Test match both
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-				"bool_true":  false,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
+			"bool_true":  false,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -253,11 +227,9 @@ func TestConditionTreeEvaluateNotCondition(t *testing.T) {
 
 	// Test no match
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  true,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  true,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -302,12 +274,10 @@ func TestConditionTreeEvaluateMultipleMixedConditions(t *testing.T) {
 
 	// Test only match AND condition
 	user := e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  true,
-				"int_42":     43,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  true,
+			"int_42":     43,
 		},
 	}
 
@@ -317,12 +287,10 @@ func TestConditionTreeEvaluateMultipleMixedConditions(t *testing.T) {
 
 	// Test only match the NOT condition
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not foo",
-				"bool_true":  true,
-				"int_42":     43,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not foo",
+			"bool_true":  true,
+			"int_42":     43,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -330,12 +298,10 @@ func TestConditionTreeEvaluateMultipleMixedConditions(t *testing.T) {
 
 	// Test only match the int condition
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  false,
-				"int_42":     42,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  false,
+			"int_42":     42,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
@@ -343,12 +309,10 @@ func TestConditionTreeEvaluateMultipleMixedConditions(t *testing.T) {
 
 	// Test no match
 	user = e.UserContext{
-		Attributes: e.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-				"bool_true":  false,
-				"int_42":     43,
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+			"bool_true":  false,
+			"int_42":     43,
 		},
 	}
 	result = conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)

--- a/optimizely/decision/evaluator/matchers/exact.go
+++ b/optimizely/decision/evaluator/matchers/exact.go
@@ -31,7 +31,7 @@ type ExactMatcher struct {
 // Match returns true if the user's attribute match the condition's string value
 func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	if stringValue, ok := m.Condition.Value.(string); ok {
-		attributeValue, err := user.Attributes.GetString(m.Condition.Name)
+		attributeValue, err := user.GetStringAttribute(m.Condition.Name)
 		if err != nil {
 			return false, err
 		}
@@ -39,7 +39,7 @@ func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	}
 
 	if boolValue, ok := m.Condition.Value.(bool); ok {
-		attributeValue, err := user.Attributes.GetBool(m.Condition.Name)
+		attributeValue, err := user.GetBoolAttribute(m.Condition.Name)
 		if err != nil {
 			return false, err
 		}
@@ -47,7 +47,7 @@ func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	}
 
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
-		attributeValue, err := user.Attributes.GetFloat(m.Condition.Name)
+		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
 			return false, err
 		}

--- a/optimizely/decision/evaluator/matchers/exact_test.go
+++ b/optimizely/decision/evaluator/matchers/exact_test.go
@@ -35,10 +35,8 @@ func TestExactMatcherString(t *testing.T) {
 
 	// Test match
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
 		},
 	}
 	result, err := matcher.Match(user)
@@ -47,10 +45,8 @@ func TestExactMatcherString(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "not_foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "not_foo",
 		},
 	}
 
@@ -60,10 +56,8 @@ func TestExactMatcherString(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_not_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_not_foo": "foo",
 		},
 	}
 
@@ -82,10 +76,8 @@ func TestExactMatcherBool(t *testing.T) {
 
 	// Test match
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"bool_true": true,
-			},
+		Attributes: map[string]interface{}{
+			"bool_true": true,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -94,10 +86,8 @@ func TestExactMatcherBool(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"bool_true": false,
-			},
+		Attributes: map[string]interface{}{
+			"bool_true": false,
 		},
 	}
 
@@ -107,10 +97,8 @@ func TestExactMatcherBool(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"not_bool_true": true,
-			},
+		Attributes: map[string]interface{}{
+			"not_bool_true": true,
 		},
 	}
 
@@ -129,10 +117,8 @@ func TestExactMatcherInt(t *testing.T) {
 
 	// Test match - same type
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 42,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 42,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -141,10 +127,8 @@ func TestExactMatcherInt(t *testing.T) {
 
 	// Test match int to float
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 42.0,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 42.0,
 		},
 	}
 
@@ -154,10 +138,8 @@ func TestExactMatcherInt(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 43,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 43,
 		},
 	}
 
@@ -167,10 +149,8 @@ func TestExactMatcherInt(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_43": 42,
-			},
+		Attributes: map[string]interface{}{
+			"int_43": 42,
 		},
 	}
 
@@ -189,10 +169,8 @@ func TestExactMatcherFloat(t *testing.T) {
 
 	// Test match
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.2,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -201,10 +179,8 @@ func TestExactMatcherFloat(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.3,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.3,
 		},
 	}
 
@@ -214,10 +190,8 @@ func TestExactMatcherFloat(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_3": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_3": 4.2,
 		},
 	}
 

--- a/optimizely/decision/evaluator/matchers/exists.go
+++ b/optimizely/decision/evaluator/matchers/exists.go
@@ -28,7 +28,7 @@ type ExistsMatcher struct {
 // Match returns true if the user's attribute is in the condition
 func (m ExistsMatcher) Match(user entities.UserContext) (bool, error) {
 
-	_, err := user.Attributes.GetString(m.Condition.Name)
+	_, err := user.GetStringAttribute(m.Condition.Name)
 	if err != nil {
 		return false, nil
 	}

--- a/optimizely/decision/evaluator/matchers/exists_test.go
+++ b/optimizely/decision/evaluator/matchers/exists_test.go
@@ -34,10 +34,8 @@ func TestExistsMatcher(t *testing.T) {
 
 	// Test match
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo": "any_value",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo": "any_value",
 		},
 	}
 	result, err := matcher.Match(user)
@@ -46,10 +44,8 @@ func TestExistsMatcher(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"string_foo1": "not_foo",
-			},
+		Attributes: map[string]interface{}{
+			"string_foo1": "not_foo",
 		},
 	}
 
@@ -59,12 +55,9 @@ func TestExistsMatcher(t *testing.T) {
 
 	// Test null case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{},
-		},
+		Attributes: map[string]interface{}{},
 	}
 	result, err = matcher.Match(user)
 	assert.NoError(t, err)
 	assert.False(t, result)
 }
-

--- a/optimizely/decision/evaluator/matchers/gt.go
+++ b/optimizely/decision/evaluator/matchers/gt.go
@@ -32,7 +32,7 @@ type GtMatcher struct {
 func (m GtMatcher) Match(user entities.UserContext) (bool, error) {
 
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
-		attributeValue, err := user.Attributes.GetFloat(m.Condition.Name)
+		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
 			return false, err
 		}

--- a/optimizely/decision/evaluator/matchers/gt_test.go
+++ b/optimizely/decision/evaluator/matchers/gt_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/entities"
 )
 
-
-
-
 func TestGtMatcherInt(t *testing.T) {
 	matcher := GtMatcher{
 		Condition: entities.Condition{
@@ -38,10 +35,8 @@ func TestGtMatcherInt(t *testing.T) {
 
 	// Test match - same type
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 43,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 43,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -50,10 +45,8 @@ func TestGtMatcherInt(t *testing.T) {
 
 	// Test match int to float
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 42.9999,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 42.9999,
 		},
 	}
 
@@ -63,10 +56,8 @@ func TestGtMatcherInt(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 42.00000,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 42.00000,
 		},
 	}
 
@@ -74,13 +65,10 @@ func TestGtMatcherInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 41,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 41,
 		},
 	}
 
@@ -90,10 +78,8 @@ func TestGtMatcherInt(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_43": 42,
-			},
+		Attributes: map[string]interface{}{
+			"int_43": 42,
 		},
 	}
 
@@ -112,10 +98,8 @@ func TestGtMatcherFloat(t *testing.T) {
 
 	// Test match float to int
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 5,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 5,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -124,10 +108,8 @@ func TestGtMatcherFloat(t *testing.T) {
 
 	// Test match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.29999,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.29999,
 		},
 	}
 	result, err = matcher.Match(user)
@@ -136,10 +118,8 @@ func TestGtMatcherFloat(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.2,
 		},
 	}
 
@@ -149,10 +129,8 @@ func TestGtMatcherFloat(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_3": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_3": 4.2,
 		},
 	}
 

--- a/optimizely/decision/evaluator/matchers/lt.go
+++ b/optimizely/decision/evaluator/matchers/lt.go
@@ -32,7 +32,7 @@ type LtMatcher struct {
 func (m LtMatcher) Match(user entities.UserContext) (bool, error) {
 
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
-		attributeValue, err := user.Attributes.GetFloat(m.Condition.Name)
+		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
 			return false, err
 		}

--- a/optimizely/decision/evaluator/matchers/lt_test.go
+++ b/optimizely/decision/evaluator/matchers/lt_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/entities"
 )
 
-
-
-
 func TestLtMatcherInt(t *testing.T) {
 	matcher := LtMatcher{
 		Condition: entities.Condition{
@@ -38,10 +35,8 @@ func TestLtMatcherInt(t *testing.T) {
 
 	// Test match - same type
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 41,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 41,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -50,10 +45,8 @@ func TestLtMatcherInt(t *testing.T) {
 
 	// Test match int to float
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 41.9999,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 41.9999,
 		},
 	}
 
@@ -63,10 +56,8 @@ func TestLtMatcherInt(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 42.00000,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 42.00000,
 		},
 	}
 
@@ -74,13 +65,10 @@ func TestLtMatcherInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_42": 43,
-			},
+		Attributes: map[string]interface{}{
+			"int_42": 43,
 		},
 	}
 
@@ -90,10 +78,8 @@ func TestLtMatcherInt(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"int_43": 42,
-			},
+		Attributes: map[string]interface{}{
+			"int_43": 42,
 		},
 	}
 
@@ -112,10 +98,8 @@ func TestLtMatcherFloat(t *testing.T) {
 
 	// Test match float to int
 	user := entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4,
 		},
 	}
 	result, err := matcher.Match(user)
@@ -124,10 +108,8 @@ func TestLtMatcherFloat(t *testing.T) {
 
 	// Test match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.19999,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.19999,
 		},
 	}
 	result, err = matcher.Match(user)
@@ -136,10 +118,8 @@ func TestLtMatcherFloat(t *testing.T) {
 
 	// Test no match
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_2": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_2": 4.2,
 		},
 	}
 
@@ -149,10 +129,8 @@ func TestLtMatcherFloat(t *testing.T) {
 
 	// Test error case
 	user = entities.UserContext{
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"float_4_3": 4.2,
-			},
+		Attributes: map[string]interface{}{
+			"float_4_3": 4.2,
 		},
 	}
 

--- a/optimizely/decision/experiment_targeting_service_test.go
+++ b/optimizely/decision/experiment_targeting_service_test.go
@@ -67,10 +67,8 @@ func TestExperimentTargetingGetDecisionNoAudienceCondTree(t *testing.T) {
 	// test does not pass audience evaluation
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"s_foo": "not foo",
-			},
+		Attributes: map[string]interface{}{
+			"s_foo": "not foo",
 		},
 	}
 	expectedExperimentDecision := ExperimentDecision{
@@ -92,10 +90,8 @@ func TestExperimentTargetingGetDecisionNoAudienceCondTree(t *testing.T) {
 	// test passes evaluation, no decision is made
 	testUserContext = entities.UserContext{
 		ID: "test_user_1",
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"s_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"s_foo": "foo",
 		},
 	}
 	expectedExperimentDecision = ExperimentDecision{
@@ -149,10 +145,8 @@ func TestExperimentTargetingGetDecisionWithAudienceCondTree(t *testing.T) {
 	// test does not pass audience evaluation
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"s_foo": "not_foo",
-			},
+		Attributes: map[string]interface{}{
+			"s_foo": "not_foo",
 		},
 	}
 	expectedExperimentDecision := ExperimentDecision{
@@ -174,10 +168,8 @@ func TestExperimentTargetingGetDecisionWithAudienceCondTree(t *testing.T) {
 
 	testUserContext = entities.UserContext{
 		ID: "test_user_1",
-		Attributes: entities.UserAttributes{
-			Attributes: map[string]interface{}{
-				"s_foo": "foo",
-			},
+		Attributes: map[string]interface{}{
+			"s_foo": "foo",
 		},
 	}
 

--- a/optimizely/entities/user_context.go
+++ b/optimizely/entities/user_context.go
@@ -18,7 +18,8 @@ package entities
 
 import (
 	"fmt"
-	"reflect"
+
+	"github.com/optimizely/go-sdk/optimizely/utils"
 )
 
 const bucketingIDAttributeName = "$opt_bucketing_id"
@@ -26,60 +27,51 @@ const bucketingIDAttributeName = "$opt_bucketing_id"
 // UserContext holds information about a user
 type UserContext struct {
 	ID         string
-	Attributes UserAttributes
-}
-
-// UserAttributes holds information about the user's attributes
-type UserAttributes struct {
 	Attributes map[string]interface{}
 }
 
-var floatType = reflect.TypeOf(float64(0))
-var intType = reflect.TypeOf(int64(0))
-
-// GetString returns the string value for the specified attribute name in the attributes map. Returns error if not found.
-func (u UserAttributes) GetString(attrName string) (string, error) {
+// GetStringAttribute returns the string value for the specified attribute name in the attributes map. Returns error if not found.
+func (u UserContext) GetStringAttribute(attrName string) (string, error) {
 	if value, ok := u.Attributes[attrName]; ok {
-		v := reflect.ValueOf(value)
-		if v.Type().String() == "string" {
-			return v.String(), nil
+		stringVal, err := utils.GetStringValue(value)
+		if err == nil {
+			return stringVal, nil
 		}
 	}
 
 	return "", fmt.Errorf(`No string attribute named "%s"`, attrName)
 }
 
-// GetBool returns the bool value for the specified attribute name in the attributes map. Returns error if not found.
-func (u UserAttributes) GetBool(attrName string) (bool, error) {
+// GetBoolAttribute returns the bool value for the specified attribute name in the attributes map. Returns error if not found.
+func (u UserContext) GetBoolAttribute(attrName string) (bool, error) {
 	if value, ok := u.Attributes[attrName]; ok {
-		v := reflect.ValueOf(value)
-		if v.Type().String() == "bool" {
-			return v.Bool(), nil
+		boolVal, err := utils.GetBoolValue(value)
+		if err == nil {
+			return boolVal, nil
 		}
 	}
 
 	return false, fmt.Errorf(`No bool attribute named "%s"`, attrName)
 }
 
-// GetFloat returns the float64 value for the specified attribute name in the attributes map. Returns error if not found.
-func (u UserAttributes) GetFloat(attrName string) (float64, error) {
+// GetFloatAttribute returns the float64 value for the specified attribute name in the attributes map. Returns error if not found.
+func (u UserContext) GetFloatAttribute(attrName string) (float64, error) {
 	if value, ok := u.Attributes[attrName]; ok {
-		v := reflect.ValueOf(value)
-		if v.Type().String() == "float64" || v.Type().ConvertibleTo(floatType) {
-			floatValue := v.Convert(floatType).Float()
-			return floatValue, nil
+		floatVal, err := utils.GetFloatValue(value)
+		if err == nil {
+			return floatVal, nil
 		}
 	}
 
 	return 0, fmt.Errorf(`No float attribute named "%s"`, attrName)
 }
 
-func (u UserAttributes) GetInt(attrName string) (int64, error) {
+// GetIntAttribute returns the int64 value for the specified attribute name in the attributes map. Returns error if not found.
+func (u UserContext) GetIntAttribute(attrName string) (int64, error) {
 	if value, ok := u.Attributes[attrName]; ok {
-		v := reflect.ValueOf(value)
-		if v.Type().String() == "int64" || v.Type().ConvertibleTo(intType) {
-			intValue := v.Convert(intType).Int()
-			return intValue, nil
+		intVal, err := utils.GetIntValue(value)
+		if err == nil {
+			return intVal, nil
 		}
 	}
 
@@ -92,8 +84,8 @@ func (u UserContext) GetBucketingID() (string, error) {
 	bucketingID := u.ID
 
 	// If the bucketing ID key is defined in attributes, than use that in place of the user ID
-	if value, ok := u.Attributes.Attributes[bucketingIDAttributeName]; ok {
-		customBucketingID, err := u.Attributes.GetString(bucketingIDAttributeName)
+	if value, ok := u.Attributes[bucketingIDAttributeName]; ok {
+		customBucketingID, err := u.GetStringAttribute(bucketingIDAttributeName)
 		if err != nil {
 			return bucketingID, fmt.Errorf(`Invalid bucketing ID provided: "%s"`, value)
 		}

--- a/optimizely/entities/user_context_test.go
+++ b/optimizely/entities/user_context_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUserAttributesGetString(t *testing.T) {
-	userAttributes := UserAttributes{
+func TestUserAttributesGetStringAttribute(t *testing.T) {
+	userContext := UserContext{
 		Attributes: map[string]interface{}{
 			"string_foo": "foo",
 			"bool_true":  true,
@@ -15,11 +15,11 @@ func TestUserAttributesGetString(t *testing.T) {
 	}
 
 	// Test happy path
-	stringAttribute, _ := userAttributes.GetString("string_foo")
+	stringAttribute, _ := userContext.GetStringAttribute("string_foo")
 	assert.Equal(t, "foo", stringAttribute)
 
 	// Test non-existent attr name
-	_, err := userAttributes.GetString("string_bar")
+	_, err := userContext.GetStringAttribute("string_bar")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No string attribute named "string_bar"`)
 	} else {
@@ -27,7 +27,7 @@ func TestUserAttributesGetString(t *testing.T) {
 	}
 
 	// Test non-string attribute
-	_, err = userAttributes.GetString("bool_true")
+	_, err = userContext.GetStringAttribute("bool_true")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No string attribute named "bool_true"`)
 	} else {
@@ -35,8 +35,8 @@ func TestUserAttributesGetString(t *testing.T) {
 	}
 }
 
-func TestUserAttributesGetBool(t *testing.T) {
-	userAttributes := UserAttributes{
+func TestUserAttributesGetBoolAttribute(t *testing.T) {
+	userContext := UserContext{
 		Attributes: map[string]interface{}{
 			"string_foo": "foo",
 			"bool_true":  true,
@@ -44,18 +44,18 @@ func TestUserAttributesGetBool(t *testing.T) {
 	}
 
 	// Test happy path
-	boolAttribute, _ := userAttributes.GetBool("bool_true")
+	boolAttribute, _ := userContext.GetBoolAttribute("bool_true")
 	assert.Equal(t, true, boolAttribute)
 
 	// Test non-existent attr name
-	_, err := userAttributes.GetBool("bool_false")
+	_, err := userContext.GetBoolAttribute("bool_false")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No bool attribute named "bool_false"`)
 	} else {
 		assert.Fail(t, "Error should have been thrown")
 	}
 
-	_, err = userAttributes.GetBool("string_foo")
+	_, err = userContext.GetBoolAttribute("string_foo")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No bool attribute named "string_foo"`)
 	} else {
@@ -63,8 +63,8 @@ func TestUserAttributesGetBool(t *testing.T) {
 	}
 }
 
-func TestUserAttributesGetFloat(t *testing.T) {
-	userAttributes := UserAttributes{
+func TestUserAttributesGetFloatAttribute(t *testing.T) {
+	userContext := UserContext{
 		Attributes: map[string]interface{}{
 			"int_42":    42,
 			"float_4_2": 42.0,
@@ -72,20 +72,20 @@ func TestUserAttributesGetFloat(t *testing.T) {
 	}
 
 	// Test happy path
-	floatAttribute1, _ := userAttributes.GetFloat("int_42")
-	floatAttribute2, _ := userAttributes.GetFloat("float_4_2")
+	floatAttribute1, _ := userContext.GetFloatAttribute("int_42")
+	floatAttribute2, _ := userContext.GetFloatAttribute("float_4_2")
 	assert.Equal(t, 42.0, floatAttribute1)
 	assert.Equal(t, 42.0, floatAttribute2)
 
 	// Test non-existent attr name
-	_, err := userAttributes.GetFloat("bool_false")
+	_, err := userContext.GetFloatAttribute("bool_false")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No float attribute named "bool_false"`)
 	} else {
 		assert.Fail(t, "Error should have been thrown")
 	}
 
-	_, err = userAttributes.GetFloat("string_foo")
+	_, err = userContext.GetFloatAttribute("string_foo")
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), `No float attribute named "string_foo"`)
 	} else {

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -1,11 +1,12 @@
 package event
 
 import (
-	"github.com/optimizely/go-sdk/optimizely/entities"
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestConfig struct {
@@ -15,26 +16,26 @@ func (TestConfig) GetEventByKey(string) (entities.Event, error) {
 	return entities.Event{ExperimentIds: []string{"15402980349"}, ID: "15368860886", Key: "sample_conversion"}, nil
 }
 
-func (TestConfig)GetFeatureByKey(string) (entities.Feature, error) {
+func (TestConfig) GetFeatureByKey(string) (entities.Feature, error) {
 	return entities.Feature{}, nil
 }
 
-func (TestConfig)GetProjectID() string {
+func (TestConfig) GetProjectID() string {
 	return "15389410617"
 }
-func (TestConfig)GetRevision()  string {
+func (TestConfig) GetRevision() string {
 	return "7"
 }
-func (TestConfig)GetAccountID() string {
+func (TestConfig) GetAccountID() string {
 	return "8362480420"
 }
-func (TestConfig)GetAnonymizeIP() bool {
+func (TestConfig) GetAnonymizeIP() bool {
 	return true
 }
-func (TestConfig)GetAttributeID(key string) string { // returns "" if there is no id
+func (TestConfig) GetAttributeID(key string) string { // returns "" if there is no id
 	return ""
 }
-func (TestConfig)GetBotFiltering() bool {
+func (TestConfig) GetBotFiltering() bool {
 	return false
 }
 
@@ -42,13 +43,16 @@ func RandomString(len int) string {
 	bytes := make([]byte, len)
 	rand.Seed(time.Now().UnixNano())
 	for i := 0; i < len; i++ {
-		bytes[i] = byte(65 + rand.Intn(25))  //A=65 and Z = 65+25
+		bytes[i] = byte(65 + rand.Intn(25)) //A=65 and Z = 65+25
 	}
 	return string(bytes)
 }
 
-var userId = RandomString(10)
-var userContext = entities.UserContext{userId, entities.UserAttributes{make(map[string]interface{})}}
+var userID = RandomString(10)
+var userContext = entities.UserContext{
+	ID:         userID,
+	Attributes: make(map[string]interface{}),
+}
 
 func BuildTestImpressionEvent() UserEvent {
 	config := TestConfig{}
@@ -72,7 +76,7 @@ func BuildTestConversionEvent() UserEvent {
 	config := TestConfig{}
 	context := CreateEventContext(config.GetProjectID(), config.GetRevision(), config.GetAccountID(), config.GetAnonymizeIP(), config.GetBotFiltering(), make(map[string]string))
 
-	conversionUserEvent := CreateConversionUserEvent(context, entities.Event{ExperimentIds: []string{"15402980349"}, ID: "15368860886", Key: "sample_conversion"}, userContext,make(map[string]string), make(map[string]interface{}))
+	conversionUserEvent := CreateConversionUserEvent(context, entities.Event{ExperimentIds: []string{"15402980349"}, ID: "15368860886", Key: "sample_conversion"}, userContext, make(map[string]string), make(map[string]interface{}))
 
 	return conversionUserEvent
 }
@@ -116,11 +120,11 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 }
 
 func TestCreateConversionEventRevenue(t *testing.T) {
-	eventTags := map[string]interface{}{"revenue":55.0, "value":25.1}
+	eventTags := map[string]interface{}{"revenue": 55.0, "value": 25.1}
 	config := TestConfig{}
 	context := CreateEventContext(config.GetProjectID(), config.GetRevision(), config.GetAccountID(), config.GetAnonymizeIP(), config.GetBotFiltering(), make(map[string]string))
 
-	conversionUserEvent := CreateConversionUserEvent(context, entities.Event{ExperimentIds: []string{"15402980349"}, ID: "15368860886", Key: "sample_conversion"}, userContext,make(map[string]string), eventTags)
+	conversionUserEvent := CreateConversionUserEvent(context, entities.Event{ExperimentIds: []string{"15402980349"}, ID: "15368860886", Key: "sample_conversion"}, userContext, make(map[string]string), eventTags)
 
 	assert.Equal(t, int64(55), *conversionUserEvent.Conversion.Revenue)
 	assert.Equal(t, 25.1, *conversionUserEvent.Conversion.Value)
@@ -128,6 +132,5 @@ func TestCreateConversionEventRevenue(t *testing.T) {
 	batch := createConversionBatchEvent(conversionUserEvent)
 	assert.Equal(t, int64(55), *batch.Visitors[0].Snapshots[0].Events[0].Revenue)
 	assert.Equal(t, 25.1, *batch.Visitors[0].Snapshots[0].Events[0].Value)
-
 
 }

--- a/optimizely/utils/types.go
+++ b/optimizely/utils/types.go
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package utils
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var floatType = reflect.TypeOf(float64(0))
+var intType = reflect.TypeOf(int64(0))
+
+// GetBoolValue will attempt to convert the given value to a bool
+func GetBoolValue(value interface{}) (bool, error) {
+	v := reflect.ValueOf(value)
+	if v.Type().String() == "bool" {
+		return v.Bool(), nil
+	}
+
+	return false, fmt.Errorf(`Value "%v" could not be converted to bool`, value)
+}
+
+// GetFloatValue will attempt to convert the given value to a float64
+func GetFloatValue(value interface{}) (float64, error) {
+	v := reflect.ValueOf(value)
+	if v.Type().String() == "float64" || v.Type().ConvertibleTo(floatType) {
+		floatValue := v.Convert(floatType).Float()
+		return floatValue, nil
+	}
+
+	return 0, fmt.Errorf(`Value "%v" could not be converted to float`, value)
+}
+
+// GetIntValue will attempt to convert the given value to an int64
+func GetIntValue(value interface{}) (int64, error) {
+	v := reflect.ValueOf(value)
+	if v.Type().String() == "int64" || v.Type().ConvertibleTo(intType) {
+		intValue := v.Convert(intType).Int()
+		return intValue, nil
+	}
+
+	return 0, fmt.Errorf(`Value "%v" could not be converted to int`, value)
+}
+
+// GetStringValue will attempt to convert the given value to a string
+func GetStringValue(value interface{}) (string, error) {
+	v := reflect.ValueOf(value)
+	if v.Type().String() == "string" {
+		return v.String(), nil
+	}
+
+	return "", fmt.Errorf(`Value "%v" could not be converted to string`, value)
+}


### PR DESCRIPTION
# Summary
- Make the top level `Attributes` property in the `UserContext` a map of string to interface to simplify this input param.