### PR TITLE
feat(err): Panic handling in the IsFeatureEnabled API.

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -13,8 +13,7 @@ import (
 func main() {
 	logging.SetLogLevel(logging.LogLevelDebug)
 	optimizelyFactory := &client.OptimizelyFactory{
-		SDKKey:   "4SLpaJA1r1pgE6T2CoMs9q",
-		Datafile: []byte("datafile_string"),
+		SDKKey: "4SLpaJA1r1pgE6T2CoMs9q",
 	}
 	client, err := optimizelyFactory.Client()
 
@@ -31,7 +30,7 @@ func main() {
 		},
 	}
 
-	enabled, _ := client.IsFeatureEnabled("binary_feature", user)
+	enabled, _ := client.IsFeatureEnabled("mutext_feat", user)
 	fmt.Printf("Is feature enabled? %v", enabled)
 
 	processor := event.NewEventProcessor(100, 100)

--- a/optimizely/client/client.go
+++ b/optimizely/client/client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/optimizely/go-sdk/optimizely"
 	"github.com/optimizely/go-sdk/optimizely/decision"
@@ -36,7 +37,7 @@ type OptimizelyClient struct {
 }
 
 // IsFeatureEnabled returns true if the feature is enabled for the given user
-func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entities.UserContext) (bool, error) {
+func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entities.UserContext) (result bool, err error) {
 	if !o.isValid {
 		errorMessage := "Optimizely instance is not valid. Failing IsFeatureEnabled."
 		err := errors.New(errorMessage)
@@ -44,11 +45,20 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 		return false, err
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			errorMessage := fmt.Sprintf(`Optimizely SDK is panicking with the error "%s"`, string(debug.Stack()))
+			err = errors.New(errorMessage)
+			logger.Error(errorMessage, err)
+			result = false
+		}
+	}()
+
 	projectConfig := o.configManager.GetConfig()
 	feature, err := projectConfig.GetFeatureByKey(featureKey)
 	if err != nil {
 		logger.Error("Error retrieving feature", err)
-		return false, err
+		return result, err
 	}
 	featureDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &feature,
@@ -60,17 +70,18 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 	featureDecision, err := o.decisionService.GetFeatureDecision(featureDecisionContext, userContext)
 	if err != nil {
 		logger.Error("Received an error while computing feature decision", err)
-		return false, err
+		return result, err
 	}
 
 	logger.Debug(fmt.Sprintf(`Decision made for feature "%s" for user "%s" with the following reason: "%s". Source: "%s".`, featureKey, userID, featureDecision.Reason, featureDecision.Source))
 
 	if featureDecision.Variation.FeatureEnabled == true {
+		result = true
 		logger.Info(fmt.Sprintf(`Feature "%s" is enabled for user "%s".`, featureKey, userID))
 	} else {
 		logger.Info(fmt.Sprintf(`Feature "%s" is not enabled for user "%s".`, featureKey, userID))
 	}
 
 	// @TODO(mng): send impression event
-	return featureDecision.Variation.FeatureEnabled, nil
+	return result, nil
 }

--- a/optimizely/client/client.go
+++ b/optimizely/client/client.go
@@ -50,7 +50,6 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 			errorMessage := fmt.Sprintf(`Optimizely SDK is panicking with the error "%s"`, string(debug.Stack()))
 			err = errors.New(errorMessage)
 			logger.Error(errorMessage, err)
-			result = false
 		}
 	}()
 


### PR DESCRIPTION
# Summary
- Introduces a top-level defer guard to ensure we recover from any panicking when using the IsFeatureEnabled API

# Tests
- Unit tests