### PR TITLE
feat(decision): Add Substring Matcher 

### DIFF
--- a/optimizely/decision/evaluator/condition.go
+++ b/optimizely/decision/evaluator/condition.go
@@ -18,15 +18,17 @@ package evaluator
 
 import (
 	"fmt"
+
 	"github.com/optimizely/go-sdk/optimizely/decision/evaluator/matchers"
 	"github.com/optimizely/go-sdk/optimizely/entities"
 )
 
 const (
-	exactMatchType  = "exact"
-	existsMatchType = "exists"
-	ltMatchType     = "lt"
-	gtMatchType     = "gt"
+	exactMatchType     = "exact"
+	existsMatchType    = "exists"
+	ltMatchType        = "lt"
+	gtMatchType        = "gt"
+	substringMatchType = "substring"
 )
 
 // ItemEvaluator evaluates a condition against the given user's attributes
@@ -62,6 +64,10 @@ func (c CustomAttributeConditionEvaluator) Evaluate(condition entities.Condition
 		}
 	case gtMatchType:
 		matcher = matchers.GtMatcher{
+			Condition: condition,
+		}
+	case substringMatchType:
+		matcher = matchers.SubstringMatcher{
 			Condition: condition,
 		}
 	default:

--- a/optimizely/decision/evaluator/matchers/substring.go
+++ b/optimizely/decision/evaluator/matchers/substring.go
@@ -1,0 +1,43 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package matchers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+)
+
+// SubstringMatcher matches against the "substring" match type
+type SubstringMatcher struct {
+	Condition entities.Condition
+}
+
+// Match returns true if the user's attribute is a substring of the condition's string value
+func (m SubstringMatcher) Match(user entities.UserContext) (bool, error) {
+
+	if stringValue, ok := m.Condition.Value.(string); ok {
+		attributeValue, err := user.GetStringAttribute(m.Condition.Name)
+		if err != nil {
+			return false, err
+		}
+		return strings.Contains(stringValue, attributeValue), nil
+	}
+
+	return false, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", m.Condition.Name)
+}

--- a/optimizely/decision/evaluator/matchers/substring_test.go
+++ b/optimizely/decision/evaluator/matchers/substring_test.go
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package matchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+)
+
+func TestSubstringMatcher(t *testing.T) {
+	matcher := SubstringMatcher{
+		Condition: entities.Condition{
+			Match: "substring",
+			Value: "foobar",
+			Name:  "string_foo",
+		},
+	}
+
+	// Test match
+	user := entities.UserContext{
+		Attributes: map[string]interface{}{
+			"string_foo": "foo",
+		},
+	}
+
+	result, err := matcher.Match(user)
+	assert.NoError(t, err)
+	assert.True(t, result)
+
+	// Test no match
+	user = entities.UserContext{
+		Attributes: map[string]interface{}{
+			"string_foo": "not_foobar",
+		},
+	}
+
+	result, err = matcher.Match(user)
+	assert.NoError(t, err)
+	assert.False(t, result)
+
+	// Test error case
+	user = entities.UserContext{
+		Attributes: map[string]interface{}{
+			"not_string_foo": "foo",
+		},
+	}
+
+	_, err = matcher.Match(user)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
# Summary
- Enables `substring` as a condition match type in `condition.go`
- Adds substring matcher functionality in `substring.go`

# Tests
- Unit tests in `substring_test.go`

## Issues
[OASIS-4941](https://optimizely.atlassian.net/browse/OASIS-4941)