### PR TITLE
refac(config-manager): simplifies the creation of polling config manager with options

### DIFF
--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -26,8 +26,6 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/decision"
 )
 
-const datafileURLTemplate = "https://cdn.optimizely.com/datafiles/%s.json"
-
 // Options are used to create an instance of the OptimizelyClient with custom configuration
 type Options struct {
 	Context              context.Context
@@ -45,7 +43,7 @@ func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 	var configManager optimizely.ProjectConfigManager
 
 	if f.SDKKey != "" {
-		url := fmt.Sprintf(datafileURLTemplate, f.SDKKey)
+		url := fmt.Sprintf(config.DatafileURLTemplate, f.SDKKey)
 		staticConfigManager, err := config.NewStaticProjectConfigManagerFromURL(url)
 
 		if err != nil {
@@ -91,9 +89,10 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 	if clientOptions.ProjectConfigManager != nil {
 		client.configManager = clientOptions.ProjectConfigManager
 	} else if f.SDKKey != "" {
-		url := fmt.Sprintf(datafileURLTemplate, f.SDKKey)
-		request := config.NewRequester(url)
-		client.configManager = config.NewPollingProjectConfigManager(ctx, request, f.Datafile, 0)
+		options := config.PollingProjectConfigManagerOptions{
+			FallbackDatafile: f.Datafile,
+		}
+		client.configManager = config.NewPollingProjectConfigManagerWithOptions(ctx, f.SDKKey, options)
 	} else if f.Datafile != nil {
 		staticConfigManager, _ := config.NewStaticProjectConfigManagerFromPayload(f.Datafile)
 		client.configManager = staticConfigManager

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -94,7 +94,7 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 		client.configManager = clientOptions.ProjectConfigManager
 	} else if f.SDKKey != "" {
 		options := config.PollingProjectConfigManagerOptions{
-			FallbackDatafile: f.Datafile,
+			Datafile: f.Datafile,
 		}
 		client.configManager = config.NewPollingProjectConfigManagerWithOptions(ctx, f.SDKKey, options)
 	} else if f.Datafile != nil {

--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -36,9 +36,9 @@ var cmLogger = logging.GetLogger("PollingConfigManager")
 
 // PollingProjectConfigManagerOptions used to create an instance with custom configuration
 type PollingProjectConfigManagerOptions struct {
-	FallbackDatafile []byte
-	PollingInterval  time.Duration
-	Requester        Requester
+	Datafile        []byte
+	PollingInterval time.Duration
+	Requester       Requester
 }
 
 // PollingProjectConfigManager maintains a dynamic copy of the project config
@@ -111,7 +111,7 @@ func NewPollingProjectConfigManagerWithOptions(ctx context.Context, sdkKey strin
 
 	pollingProjectConfigManager := PollingProjectConfigManager{requester: requester, pollingInterval: pollingInterval, ctx: ctx}
 
-	pollingProjectConfigManager.activate(options.FallbackDatafile, true) // initial poll
+	pollingProjectConfigManager.activate(options.Datafile, true) // initial poll
 
 	cmLogger.Debug("Polling Config Manager Initiated")
 	go pollingProjectConfigManager.activate([]byte{}, false)

--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -33,7 +33,7 @@ var cmLogger = logging.GetLogger("PollingConfigManager")
 
 // PollingProjectConfigManager maintains a dynamic copy of the project config
 type PollingProjectConfigManager struct {
-	requester     *Requester
+	requester     Requester
 	pollingWait   time.Duration
 	projectConfig optimizely.ProjectConfig
 	configLock    sync.RWMutex
@@ -84,7 +84,7 @@ func (cm *PollingProjectConfigManager) activate(initialPayload []byte, init bool
 }
 
 // NewPollingProjectConfigManager returns new instance of PollingProjectConfigManager
-func NewPollingProjectConfigManager(ctx context.Context, requester *Requester, initialPayload []byte, pollingWait time.Duration) *PollingProjectConfigManager {
+func NewPollingProjectConfigManager(ctx context.Context, requester Requester, initialPayload []byte, pollingWait time.Duration) *PollingProjectConfigManager {
 
 	if pollingWait == 0 {
 		pollingWait = defaultPollingWait

--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -27,16 +27,26 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
-const defaultPollingWait = time.Duration(5 * time.Minute) // default 5 minutes for polling wait
+const defaultPollingInterval = time.Duration(5 * time.Minute) // default to 5 minutes for polling
+
+// DatafileURLTemplate is used to construct the endpoint for retrieving the datafile from the CDN
+const DatafileURLTemplate = "https://cdn.optimizely.com/datafiles/%s.json"
 
 var cmLogger = logging.GetLogger("PollingConfigManager")
 
+// PollingProjectConfigManagerOptions used to create an instance with custom configuration
+type PollingProjectConfigManagerOptions struct {
+	FallbackDatafile []byte
+	PollingInterval  time.Duration
+	Requester        Requester
+}
+
 // PollingProjectConfigManager maintains a dynamic copy of the project config
 type PollingProjectConfigManager struct {
-	requester     Requester
-	pollingWait   time.Duration
-	projectConfig optimizely.ProjectConfig
-	configLock    sync.RWMutex
+	requester       Requester
+	pollingInterval time.Duration
+	projectConfig   optimizely.ProjectConfig
+	configLock      sync.RWMutex
 
 	ctx context.Context // context used for cancellation
 }
@@ -71,7 +81,7 @@ func (cm *PollingProjectConfigManager) activate(initialPayload []byte, init bool
 		update()
 		return
 	}
-	t := time.NewTicker(cm.pollingWait)
+	t := time.NewTicker(cm.pollingInterval)
 	for {
 		select {
 		case <-t.C:
@@ -83,20 +93,36 @@ func (cm *PollingProjectConfigManager) activate(initialPayload []byte, init bool
 	}
 }
 
-// NewPollingProjectConfigManager returns new instance of PollingProjectConfigManager
-func NewPollingProjectConfigManager(ctx context.Context, requester Requester, initialPayload []byte, pollingWait time.Duration) *PollingProjectConfigManager {
+// NewPollingProjectConfigManagerWithOptions returns new instance of PollingProjectConfigManager with the given options
+func NewPollingProjectConfigManagerWithOptions(ctx context.Context, sdkKey string, options PollingProjectConfigManagerOptions) *PollingProjectConfigManager {
 
-	if pollingWait == 0 {
-		pollingWait = defaultPollingWait
+	var requester Requester
+	if options.Requester != nil {
+		requester = options.Requester
+	} else {
+		url := fmt.Sprintf(DatafileURLTemplate, sdkKey)
+		requester = NewHTTPRequester(url)
 	}
 
-	pollingProjectConfigManager := PollingProjectConfigManager{requester: requester, pollingWait: pollingWait, ctx: ctx}
+	pollingInterval := options.PollingInterval
+	if pollingInterval == 0 {
+		pollingInterval = defaultPollingInterval
+	}
 
-	pollingProjectConfigManager.activate(initialPayload, true) // initial poll
+	pollingProjectConfigManager := PollingProjectConfigManager{requester: requester, pollingInterval: pollingInterval, ctx: ctx}
+
+	pollingProjectConfigManager.activate(options.FallbackDatafile, true) // initial poll
 
 	cmLogger.Debug("Polling Config Manager Initiated")
 	go pollingProjectConfigManager.activate([]byte{}, false)
 	return &pollingProjectConfigManager
+}
+
+// NewPollingProjectConfigManager returns an instance of the polling config manager with the default configuration
+func NewPollingProjectConfigManager(ctx context.Context, sdkKey string) *PollingProjectConfigManager {
+	options := PollingProjectConfigManagerOptions{}
+	configManager := NewPollingProjectConfigManagerWithOptions(ctx, sdkKey, options)
+	return configManager
 }
 
 // GetConfig returns the project config

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -22,20 +22,28 @@ import (
 
 	"github.com/optimizely/go-sdk/optimizely/config/datafileprojectconfig"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
+type MockRequester struct {
+	Requester
+	mock.Mock
+}
+
+func (m *MockRequester) Get(headers ...Header) (response []byte, code int, err error) {
+	args := m.Called(headers)
+	return args.Get(0).([]byte), args.Int(1), args.Error(2)
+}
+
 func TestNewPollingProjectConfigManager(t *testing.T) {
-	URL := "https://cdn.optimizely.com/datafiles/4SLpaJA1r1pgE6T2CoMs9q_bad.json"
 	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig([]byte{})
-	request := NewRequester(URL)
+	request := new(MockRequester)
 
 	// Bad SDK Key test
 	configManager := NewPollingProjectConfigManager(context.Background(), request, []byte{}, 0)
 	assert.Equal(t, projectConfig, configManager.GetConfig())
 
 	// Good SDK Key test
-	URL = "https://cdn.optimizely.com/datafiles/4SLpaJA1r1pgE6T2CoMs9q.json"
-	request = NewRequester(URL)
 	configManager = NewPollingProjectConfigManager(context.Background(), request, []byte{}, 0)
 	newConfig := configManager.GetConfig()
 

--- a/optimizely/config/requester_test.go
+++ b/optimizely/config/requester_test.go
@@ -42,13 +42,13 @@ func TestGet(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	var httpreq *Requester
-	httpreq = NewRequester(ts.URL + "/good")
+	var httpreq Requester
+	httpreq = NewHTTPRequester(ts.URL + "/good")
 	resp, code, err := httpreq.Get()
 	assert.Nil(t, err)
 	assert.Equal(t, "Hello, client\n", string(resp))
 
-	httpreq = NewRequester(ts.URL + "/bad")
+	httpreq = NewHTTPRequester(ts.URL + "/bad")
 	_, code, err = httpreq.Get()
 	assert.Equal(t, errors.New("400 Bad Request"), err)
 	assert.Equal(t, code, 400)
@@ -72,8 +72,8 @@ func TestGetObj(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	var httpreq *Requester
-	httpreq = NewRequester(ts.URL + "/good")
+	var httpreq Requester
+	httpreq = NewHTTPRequester(ts.URL + "/good")
 	r := resp{}
 	err := httpreq.GetObj(&r)
 	assert.Nil(t, err)
@@ -81,7 +81,7 @@ func TestGetObj(t *testing.T) {
 }
 
 func TestGetBad(t *testing.T) {
-	httpreq := NewRequester("blah12345/good")
+	httpreq := NewHTTPRequester("blah12345/good")
 	_, _, err := httpreq.Get()
 	_, ok := err.(*url.Error)
 	assert.True(t, ok, "url error")
@@ -101,7 +101,7 @@ func TestGetBadWithResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	httpreq := NewRequester(ts.URL+"/bad", Retries(1))
+	httpreq := NewHTTPRequester(ts.URL+"/bad", Retries(1))
 	data, _, err := httpreq.Get()
 	assert.Equal(t, "400 Bad Request", err.Error())
 	assert.Equal(t, "bad bad response\n", string(data))
@@ -130,7 +130,7 @@ func TestGetRetry(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	httpreq := NewRequester(ts.URL+"/test", Retries(10))
+	httpreq := NewHTTPRequester(ts.URL+"/test", Retries(10))
 
 	st := time.Now()
 	resp, _, err := httpreq.Get()
@@ -141,19 +141,19 @@ func TestGetRetry(t *testing.T) {
 
 	assert.True(t, elapsed >= 400*5*time.Millisecond && elapsed <= 510*5*time.Second, "took %s", elapsed)
 
-	httpreq = NewRequester(ts.URL+"/test", Retries(3))
+	httpreq = NewHTTPRequester(ts.URL+"/test", Retries(3))
 	called = 0
 	_, _, err = httpreq.Get()
 	assert.Equal(t, errors.New("400 Bad Request"), err)
 	assert.Equal(t, 3, called, "called 3 retries")
 
-	httpreq = NewRequester(ts.URL+"/test", Retries(1))
+	httpreq = NewHTTPRequester(ts.URL+"/test", Retries(1))
 	called = 0
 	_, _, err = httpreq.Get()
 	assert.Equal(t, errors.New("400 Bad Request"), err)
 	assert.Equal(t, 1, called, "called 1 retries")
 
-	httpreq = NewRequester(ts.URL + "/test")
+	httpreq = NewHTTPRequester(ts.URL + "/test")
 	called = 0
 	_, _, err = httpreq.Get()
 	assert.Equal(t, errors.New("400 Bad Request"), err)
@@ -161,7 +161,7 @@ func TestGetRetry(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	assert.Equal(t, "{url: 127.0.0.1/blah, timeout: 5s, retries: 1}", NewRequester("127.0.0.1/blah").String())
+	assert.Equal(t, "{url: 127.0.0.1/blah, timeout: 5s, retries: 1}", NewHTTPRequester("127.0.0.1/blah").String())
 	assert.Equal(t, "{url: 127.0.0.1/blah, timeout: 19s, retries: 10}",
-		NewRequester("127.0.0.1/blah", Retries(10), Timeout(time.Duration(19)*time.Second)).String())
+		NewHTTPRequester("127.0.0.1/blah", Retries(10), Timeout(time.Duration(19)*time.Second)).String())
 }


### PR DESCRIPTION
# Summary
- Allows creation of polling config manager with defaults instead of having to always pass in a requester object

# Tests
- Unit tests