### PR TITLE
fix(decision): substring matcher reversal

### DIFF
--- a/optimizely/decision/evaluator/matchers/substring.go
+++ b/optimizely/decision/evaluator/matchers/substring.go
@@ -36,7 +36,7 @@ func (m SubstringMatcher) Match(user entities.UserContext) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		return strings.Contains(stringValue, attributeValue), nil
+		return strings.Contains(attributeValue, stringValue), nil
 	}
 
 	return false, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", m.Condition.Name)

--- a/optimizely/decision/evaluator/matchers/substring_test.go
+++ b/optimizely/decision/evaluator/matchers/substring_test.go
@@ -28,7 +28,7 @@ func TestSubstringMatcher(t *testing.T) {
 	matcher := SubstringMatcher{
 		Condition: entities.Condition{
 			Match: "substring",
-			Value: "foobar",
+			Value: "foo",
 			Name:  "string_foo",
 		},
 	}
@@ -36,7 +36,7 @@ func TestSubstringMatcher(t *testing.T) {
 	// Test match
 	user := entities.UserContext{
 		Attributes: map[string]interface{}{
-			"string_foo": "foo",
+			"string_foo": "foobar",
 		},
 	}
 
@@ -47,7 +47,7 @@ func TestSubstringMatcher(t *testing.T) {
 	// Test no match
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
-			"string_foo": "not_foobar",
+			"string_foo": "bar",
 		},
 	}
 


### PR DESCRIPTION
# Summary
- Fixed the substring matching logic by switching `stringValue` and `attributeValue`

# Tests
- Modified unit tests in `substring_test.go`

## Issues
[OASIS-5200](https://optimizely.atlassian.net/browse/OASIS-5200)