### PR TITLE
feat: Hook up event processor to IsFeatureEnabled.

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/optimizely/go-sdk/optimizely/client"
 	"github.com/optimizely/go-sdk/optimizely/entities"
-	"github.com/optimizely/go-sdk/optimizely/event"
 	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
@@ -37,18 +36,6 @@ func main() {
 	enabled, _ := app.IsFeatureEnabled("mutext_feat", user)
 	fmt.Printf("Is feature enabled? %v\n", enabled)
 
-	processor := event.NewEventProcessor(100, 100)
-
-	impression := event.UserEvent{}
-
-	processor.ProcessEvent(impression)
-
-	_, ok := processor.(*event.QueueingEventProcessor)
-
-	if ok {
-		time.Sleep(1000 * time.Millisecond)
-		fmt.Println("\nending")
-	}
 	fmt.Println()
 
 	/************* ClientWithOptions - custom context  ********************/

--- a/optimizely/client/client.go
+++ b/optimizely/client/client.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"runtime/debug"
 
+	"github.com/optimizely/go-sdk/optimizely/event"
+
 	"github.com/optimizely/go-sdk/optimizely"
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/entities"
@@ -35,6 +37,7 @@ var logger = logging.GetLogger("Client")
 type OptimizelyClient struct {
 	configManager   optimizely.ProjectConfigManager
 	decisionService decision.DecisionService
+	eventProcessor  event.Processor
 	isValid         bool
 
 	cancelFunc context.CancelFunc
@@ -80,8 +83,6 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 		return result, err
 	}
 
-	logger.Debug(fmt.Sprintf(`Decision made for feature "%s" for user "%s" with the following reason: "%s". Source: "%s".`, featureKey, userID, featureDecision.Reason, featureDecision.Source))
-
 	if featureDecision.Variation.FeatureEnabled == true {
 		result = true
 		logger.Info(fmt.Sprintf(`Feature "%s" is enabled for user "%s".`, featureKey, userID))
@@ -89,7 +90,11 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 		logger.Info(fmt.Sprintf(`Feature "%s" is not enabled for user "%s".`, featureKey, userID))
 	}
 
-	// @TODO(mng): send impression event
+	if featureDecision.Source == decision.FeatureTest {
+		// send impression event for feature tests
+		impressionEvent := event.CreateImpressionUserEvent(projectConfig, featureDecision.Experiment, featureDecision.Variation, userContext)
+		o.eventProcessor.ProcessEvent(impressionEvent)
+	}
 	return result, nil
 }
 

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/optimizely/go-sdk/optimizely/event"
 
@@ -44,7 +45,7 @@ type OptimizelyFactory struct {
 }
 
 const defaultEventQueueSize = 10
-const defaultEventFlushInterval = 30000
+const defaultEventFlushInterval = 30 * time.Second
 
 // StaticClient returns a client initialized with a static project config
 func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -116,6 +116,8 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 		client.decisionService = decision.NewCompositeService(notificationCenter)
 	}
 
+	// @TODO: allow event processor to be passed in
+	// @TODO: pass the context object to the event processor
 	client.eventProcessor = event.NewEventProcessor(defaultEventQueueSize, defaultEventFlushInterval)
 	client.isValid = true
 	return client, nil

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/optimizely/go-sdk/optimizely/event"
+
 	"github.com/optimizely/go-sdk/optimizely/notification"
 
 	"github.com/optimizely/go-sdk/optimizely"
@@ -40,6 +42,9 @@ type OptimizelyFactory struct {
 	SDKKey   string
 	Datafile []byte
 }
+
+const defaultEventQueueSize = 10
+const defaultEventFlushInterval = 30000
 
 // StaticClient returns a client initialized with a static project config
 func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
@@ -111,6 +116,7 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 		client.decisionService = decision.NewCompositeService(notificationCenter)
 	}
 
+	client.eventProcessor = event.NewEventProcessor(defaultEventQueueSize, defaultEventFlushInterval)
 	client.isValid = true
 	return client, nil
 }

--- a/optimizely/config/datafileprojectconfig/config.go
+++ b/optimizely/config/datafileprojectconfig/config.go
@@ -84,17 +84,17 @@ func NewDatafileProjectConfig(jsonDatafile []byte) (*DatafileProjectConfig, erro
 	}
 
 	attributeMap, attributeKeyToIDMap := mappers.MapAttributes(datafile.Attributes)
-	experiments, experimentKeyMap := mappers.MapExperiments(datafile.Experiments)
+	experimentMap, experimentKeyMap := mappers.MapExperiments(datafile.Experiments)
 	rolloutMap := mappers.MapRollouts(datafile.Rollouts)
 	mergedAudiences := append(datafile.TypedAudiences, datafile.Audiences...)
 	config := &DatafileProjectConfig{
 		audienceMap:          mappers.MapAudiences(mergedAudiences),
 		attributeMap:         attributeMap,
 		attributeKeyToIDMap:  attributeKeyToIDMap,
-		experimentMap:        experiments,
+		experimentMap:        experimentMap,
 		experimentKeyToIDMap: experimentKeyMap,
 		rolloutMap:           rolloutMap,
-		featureMap:           mappers.MapFeatureFlags(datafile.FeatureFlags, rolloutMap),
+		featureMap:           mappers.MapFeatureFlags(datafile.FeatureFlags, rolloutMap, experimentMap),
 	}
 
 	logger.Info("Datafile is valid.")

--- a/optimizely/config/datafileprojectconfig/mappers/feature.go
+++ b/optimizely/config/datafileprojectconfig/mappers/feature.go
@@ -22,11 +22,14 @@ import (
 )
 
 // MapFeatureFlags maps the raw datafile feature flag entities to SDK Feature entities
-func MapFeatureFlags(featureFlags []datafileEntities.FeatureFlag, rolloutMap map[string]entities.Rollout) map[string]entities.Feature {
+func MapFeatureFlags(
+	featureFlags []datafileEntities.FeatureFlag,
+	rolloutMap map[string]entities.Rollout,
+	experimentMap map[string]entities.Experiment,
+) map[string]entities.Feature {
 
 	featureMap := make(map[string]entities.Feature)
 	for _, featureFlag := range featureFlags {
-		// @TODO(mng): include experiments in the Feature
 		feature := entities.Feature{
 			Key: featureFlag.Key,
 			ID:  featureFlag.ID,
@@ -34,6 +37,14 @@ func MapFeatureFlags(featureFlags []datafileEntities.FeatureFlag, rolloutMap map
 		if rollout, ok := rolloutMap[featureFlag.RolloutID]; ok {
 			feature.Rollout = rollout
 		}
+		featureExperiments := []entities.Experiment{}
+		for _, experimentID := range featureFlag.ExperimentIDs {
+			if experiment, ok := experimentMap[experimentID]; ok {
+				featureExperiments = append(featureExperiments, experiment)
+			}
+		}
+
+		feature.FeatureExperiments = featureExperiments
 		featureMap[featureFlag.Key] = feature
 	}
 	return featureMap

--- a/optimizely/config/datafileprojectconfig/mappers/feature_test.go
+++ b/optimizely/config/datafileprojectconfig/mappers/feature_test.go
@@ -29,7 +29,8 @@ func TestMapFeatures(t *testing.T) {
 	const testFeatureFlagString = `{
 		"id": "21111",
 		"key": "test_feature_21111",
-		"rolloutId": "41111"
+		"rolloutId": "41111",
+		"experimentIds": ["31111", "31112"]
 	}`
 
 	var rawFeatureFlag datafileEntities.FeatureFlag
@@ -40,12 +41,19 @@ func TestMapFeatures(t *testing.T) {
 	rolloutMap := map[string]entities.Rollout{
 		"41111": rollout,
 	}
-	featureMap := MapFeatureFlags(rawFeatureFlags, rolloutMap)
+	experiment31111 := entities.Experiment{ID: "31111"}
+	experiment31112 := entities.Experiment{ID: "31112"}
+	experimentMap := map[string]entities.Experiment{
+		"31111": experiment31111,
+		"31112": experiment31112,
+	}
+	featureMap := MapFeatureFlags(rawFeatureFlags, rolloutMap, experimentMap)
 	expectedFeatureMap := map[string]entities.Feature{
 		"test_feature_21111": entities.Feature{
-			ID:      "21111",
-			Key:     "test_feature_21111",
-			Rollout: rollout,
+			ID:                 "21111",
+			Key:                "test_feature_21111",
+			Rollout:            rollout,
+			FeatureExperiments: []entities.Experiment{experiment31111, experiment31112},
 		},
 	}
 

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -23,7 +23,7 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
-var cfLogger = logging.GetLogger("ComposuteFeatureService")
+var cfLogger = logging.GetLogger("CompositeFeatureService")
 
 // CompositeFeatureService is the default out-of-the-box feature decision service
 type CompositeFeatureService struct {
@@ -53,7 +53,8 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		}
 
 		experimentDecision, err := f.experimentDecisionService.GetDecision(experimentDecisionContext, userContext)
-		// only return the decision if we have a valid variation
+		// If we get an empty string Variation ID it means that the user is assigned no variation, hence we
+		// move onto Rollout evaluation
 		if experimentDecision.Variation.ID != "" {
 			featureDecision := FeatureDecision{
 				Experiment: experiment,

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -54,7 +54,6 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 
 		experimentDecision, err := f.experimentDecisionService.GetDecision(experimentDecisionContext, userContext)
 		// only return the decision if we have a valid variation
-		// @TODO: log the decision made here as debug
 		if experimentDecision.Variation.ID != "" {
 			featureDecision := FeatureDecision{
 				Experiment: experiment,

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -17,8 +17,13 @@
 package decision
 
 import (
+	"fmt"
+
 	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/optimizely/go-sdk/optimizely/logging"
 )
+
+var cfLogger = logging.GetLogger("ComposuteFeatureService")
 
 // CompositeFeatureService is the default out-of-the-box feature decision service
 type CompositeFeatureService struct {
@@ -29,7 +34,8 @@ type CompositeFeatureService struct {
 // NewCompositeFeatureService returns a new instance of the CompositeFeatureService
 func NewCompositeFeatureService() *CompositeFeatureService {
 	return &CompositeFeatureService{
-		rolloutDecisionService: NewRolloutService(),
+		experimentDecisionService: NewCompositeExperimentService(),
+		rolloutDecisionService:    NewRolloutService(),
 	}
 }
 
@@ -47,12 +53,24 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		}
 
 		experimentDecision, err := f.experimentDecisionService.GetDecision(experimentDecisionContext, userContext)
-		featureDecision := FeatureDecision{
-			Experiment: experiment,
-			Decision:   experimentDecision.Decision,
-			Variation:  experimentDecision.Variation,
+		// only return the decision if we have a valid variation
+		// @TODO: log the decision made here as debug
+		if experimentDecision.Variation.ID != "" {
+			featureDecision := FeatureDecision{
+				Experiment: experiment,
+				Decision:   experimentDecision.Decision,
+				Variation:  experimentDecision.Variation,
+				Source:     FeatureTest,
+			}
+
+			cfLogger.Debug(fmt.Sprintf(
+				`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
+				feature.Key,
+				userContext.ID,
+				featureDecision.Reason,
+			))
+			return featureDecision, err
 		}
-		return featureDecision, err
 	}
 
 	featureDecisionContext := FeatureDecisionContext{
@@ -61,5 +79,12 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 	}
 	featureDecision, err := f.rolloutDecisionService.GetDecision(featureDecisionContext, userContext)
 	featureDecision.Source = Rollout
+	cfLogger.Debug(fmt.Sprintf(
+		`Decision made for feature rollout with key "%s" for user "%s" with the following reason: "%s".`,
+		feature.Key,
+		userContext.ID,
+		featureDecision.Reason,
+	))
+
 	return featureDecision, err
 }

--- a/optimizely/decision/entities.go
+++ b/optimizely/decision/entities.go
@@ -40,6 +40,8 @@ type Source string
 const (
 	// Rollout - the decision came from a rollout
 	Rollout Source = "rollout"
+	// FeatureTest - the decision came from a feature test
+	FeatureTest Source = "feature-test"
 )
 
 // Decision contains base information about a decision

--- a/optimizely/event/dispatcher.go
+++ b/optimizely/event/dispatcher.go
@@ -9,6 +9,8 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
+const jsonContenType = "application/json"
+
 // Dispatcher dispatches events
 type Dispatcher interface {
 	DispatchEvent(event LogEvent, callback func(success bool))
@@ -24,7 +26,7 @@ var dispatcherLogger = logging.GetLogger("EventDispatcher")
 func (*HTTPEventDispatcher) DispatchEvent(event LogEvent, callback func(success bool)) {
 
 	jsonValue, _ := json.Marshal(event.event)
-	resp, err := http.Post(event.endPoint, "application/json", bytes.NewBuffer(jsonValue))
+	resp, err := http.Post(event.endPoint, jsonContenType, bytes.NewBuffer(jsonValue))
 	// also check response codes
 	// resp.StatusCode == 400 is an error
 	success := true

--- a/optimizely/event/dispatcher.go
+++ b/optimizely/event/dispatcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
-const jsonContenType = "application/json"
+const jsonContentType = "application/json"
 
 // Dispatcher dispatches events
 type Dispatcher interface {
@@ -26,7 +26,7 @@ var dispatcherLogger = logging.GetLogger("EventDispatcher")
 func (*HTTPEventDispatcher) DispatchEvent(event LogEvent, callback func(success bool)) {
 
 	jsonValue, _ := json.Marshal(event.event)
-	resp, err := http.Post(event.endPoint, jsonContenType, bytes.NewBuffer(jsonValue))
+	resp, err := http.Post(event.endPoint, jsonContentType, bytes.NewBuffer(jsonValue))
 	// also check response codes
 	// resp.StatusCode == 400 is an error
 	success := true

--- a/optimizely/event/dispatcher.go
+++ b/optimizely/event/dispatcher.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/optimizely/go-sdk/optimizely/logging"
 	"net/http"
+
+	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
 // Dispatcher dispatches events
@@ -23,7 +24,7 @@ var dispatcherLogger = logging.GetLogger("EventDispatcher")
 func (*HTTPEventDispatcher) DispatchEvent(event LogEvent, callback func(success bool)) {
 
 	jsonValue, _ := json.Marshal(event.event)
-	resp, err := http.Post( event.endPoint, "application/json", bytes.NewBuffer(jsonValue))
+	resp, err := http.Post(event.endPoint, "application/json", bytes.NewBuffer(jsonValue))
 	// also check response codes
 	// resp.StatusCode == 400 is an error
 	success := true

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -95,15 +95,11 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	processor.ProcessEvent(impressionUserEvent)
 
-	result, ok := processor.(*QueueingEventProcessor)
+	assert.Equal(t, 1, processor.EventsCount())
 
-	if ok {
-		assert.Equal(t, 1, result.EventsCount())
+	time.Sleep(2000 * time.Millisecond)
 
-		time.Sleep(2000 * time.Millisecond)
-
-		assert.Equal(t, 0, result.EventsCount())
-	}
+	assert.Equal(t, 0, processor.EventsCount())
 }
 
 func TestCreateAndSendConversionEvent(t *testing.T) {
@@ -114,15 +110,11 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	processor.ProcessEvent(conversionUserEvent)
 
-	result, ok := processor.(*QueueingEventProcessor)
+	assert.Equal(t, 1, processor.EventsCount())
 
-	if ok {
-		assert.Equal(t, 1, result.EventsCount())
+	time.Sleep(2000 * time.Millisecond)
 
-		time.Sleep(2000 * time.Millisecond)
-
-		assert.Equal(t, 0, result.EventsCount())
-	}
+	assert.Equal(t, 0, processor.EventsCount())
 }
 
 func TestCreateConversionEventRevenue(t *testing.T) {

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -2,9 +2,10 @@ package event
 
 import (
 	"errors"
-	"github.com/optimizely/go-sdk/optimizely/logging"
 	"sync"
 	"time"
+
+	"github.com/optimizely/go-sdk/optimizely/logging"
 )
 
 // Processor processes events
@@ -26,8 +27,8 @@ type QueueingEventProcessor struct {
 var pLogger = logging.GetLogger("EventProcessor")
 
 // NewEventProcessor returns a new instance of QueueingEventProcessor with queueSize and flushInterval
-func NewEventProcessor(queueSize int, flushInterval time.Duration ) Processor {
-	p := &QueueingEventProcessor{MaxQueueSize: queueSize, FlushInterval:flushInterval, Q:NewInMemoryQueue(queueSize), EventDispatcher:&HTTPEventDispatcher{}}
+func NewEventProcessor(queueSize int, flushInterval time.Duration) *QueueingEventProcessor {
+	p := &QueueingEventProcessor{MaxQueueSize: queueSize, FlushInterval: flushInterval, Q: NewInMemoryQueue(queueSize), EventDispatcher: &HTTPEventDispatcher{}}
 	p.BatchSize = 10
 	p.StartTicker()
 	return p

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -1,11 +1,11 @@
 package event
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-)
 
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	processor := NewEventProcessor(100, 100)
@@ -14,19 +14,13 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 	processor.ProcessEvent(impression)
 
-	result, ok := processor.(*QueueingEventProcessor)
+	assert.Equal(t, 1, processor.EventsCount())
 
-	if ok {
-		assert.Equal(t, 1, result.EventsCount())
+	time.Sleep(200 * time.Millisecond)
 
-		time.Sleep(2000 * time.Millisecond)
+	assert.NotNil(t, processor.Ticker)
 
-		assert.NotNil(t, result.Ticker)
-
-		assert.Equal(t, 0, result.EventsCount())
-	} else {
-		assert.Equal(t, true, false)
-	}
+	assert.Equal(t, 0, processor.EventsCount())
 
 }
 
@@ -34,7 +28,7 @@ type MockDispatcher struct {
 	Events []LogEvent
 }
 
-func (f *MockDispatcher)DispatchEvent(event LogEvent, callback func(success bool)) {
+func (f *MockDispatcher) DispatchEvent(event LogEvent, callback func(success bool)) {
 	f.Events = append(f.Events, event)
 	callback(true)
 }
@@ -54,7 +48,7 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 	assert.Equal(t, 4, processor.EventsCount())
 
-	time.Sleep(2000 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	assert.NotNil(t, processor.Ticker)
 
@@ -85,7 +79,7 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 	assert.Equal(t, 4, processor.EventsCount())
 
-	time.Sleep(2000 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	assert.NotNil(t, processor.Ticker)
 
@@ -116,7 +110,7 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 	assert.Equal(t, 4, processor.EventsCount())
 
-	time.Sleep(2000 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	assert.NotNil(t, processor.Ticker)
 


### PR DESCRIPTION
# Summary

This PR enables sending impressions for features tests from the `IsFeatureEnabled` API: 

- Adds experiments to the feature model in the project config
- Re-enabled the experiment decision service in the composite feature service to evaluate feature tests
- Integrate the event processor with the Optimizely client and send event to it from the IsFeatureEnabled API

# Tests
- Unit