### PR TITLE
feat(event): Use the cancelable context in the event processor.

### DIFF
--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -118,7 +118,6 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 	}
 
 	// @TODO: allow event processor to be passed in
-	// @TODO: pass the context object to the event processor
 	client.eventProcessor = event.NewEventProcessor(ctx, defaultEventQueueSize, defaultEventFlushInterval)
 	client.isValid = true
 	return client, nil

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -119,7 +119,7 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 
 	// @TODO: allow event processor to be passed in
 	// @TODO: pass the context object to the event processor
-	client.eventProcessor = event.NewEventProcessor(defaultEventQueueSize, defaultEventFlushInterval)
+	client.eventProcessor = event.NewEventProcessor(ctx, defaultEventQueueSize, defaultEventFlushInterval)
 	client.isValid = true
 	return client, nil
 }

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -88,10 +89,11 @@ func BuildTestConversionEvent() UserEvent {
 }
 
 func TestCreateAndSendImpressionEvent(t *testing.T) {
+	ctx := context.Background()
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(100, 100)
+	processor := NewEventProcessor(ctx, 100, 100)
 
 	processor.ProcessEvent(impressionUserEvent)
 
@@ -103,10 +105,11 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 }
 
 func TestCreateAndSendConversionEvent(t *testing.T) {
+	ctx := context.Background()
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(100, 100)
+	processor := NewEventProcessor(ctx, 100, 100)
 
 	processor.ProcessEvent(conversionUserEvent)
 

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -3,7 +3,6 @@ package event
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -130,7 +129,6 @@ func (p *QueueingEventProcessor) FlushEvents() {
 						batchEventCount = 1
 					} else if !p.canBatch(&batchEvent, userEvent) {
 						// this could happen if the project config was updated for instance.
-						fmt.Printf("Can batch? %+v ------- %+v", batchEvent, userEvent)
 						pLogger.Info("Can't batch last event. Sending current batch.")
 						break
 					} else {

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
-// 	ctx := context.Background()
+func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
+	ctx := context.Background()
 
-// 	processor := NewEventProcessor(ctx, 100, 100)
+	processor := NewEventProcessor(ctx, 100, 100)
 
-// 	impression := BuildTestImpressionEvent()
+	impression := BuildTestImpressionEvent()
 
-// 	processor.ProcessEvent(impression)
+	processor.ProcessEvent(impression)
 
-// 	assert.Equal(t, 1, processor.EventsCount())
+	assert.Equal(t, 1, processor.EventsCount())
 
-// 	time.Sleep(200 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
-// 	assert.NotNil(t, processor.Ticker)
+	assert.NotNil(t, processor.Ticker)
 
-// 	assert.Equal(t, 0, processor.EventsCount())
-// }
+	assert.Equal(t, 0, processor.EventsCount())
+}
 
 type MockDispatcher struct {
 	Events []LogEvent

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -41,10 +41,9 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 		FlushInterval:   100,
 		Q:               NewInMemoryQueue(100),
 		EventDispatcher: &MockDispatcher{},
-		ctx:             context.Background(),
 	}
 	processor.BatchSize = 10
-	processor.StartTicker()
+	processor.StartTicker(context.TODO())
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -78,10 +77,9 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 		FlushInterval:   30 * time.Second,
 		Q:               NewInMemoryQueue(100),
 		EventDispatcher: &MockDispatcher{},
-		ctx:             ctx,
 	}
 	processor.BatchSize = 10
-	processor.StartTicker()
+	processor.StartTicker(ctx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -109,10 +107,9 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 		FlushInterval:   100,
 		Q:               NewInMemoryQueue(100),
 		EventDispatcher: &MockDispatcher{},
-		ctx:             context.Background(),
 	}
 	processor.BatchSize = 10
-	processor.StartTicker()
+	processor.StartTicker(context.TODO())
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -146,10 +143,9 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 		FlushInterval:   100,
 		Q:               NewInMemoryQueue(100),
 		EventDispatcher: &MockDispatcher{},
-		ctx:             context.Background(),
 	}
 	processor.BatchSize = 10
-	processor.StartTicker()
+	processor.StartTicker(context.TODO())
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()


### PR DESCRIPTION
# Summary
- Passes the cancelable context from the client down to the event processor

# Tests
- Unit