### PR TITLE
Add external access to the OptimizelyClient ProjectConfig.

### DIFF
--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -47,6 +47,7 @@ type PollingProjectConfigManager struct {
 	pollingInterval time.Duration
 	projectConfig   optimizely.ProjectConfig
 	configLock      sync.RWMutex
+	err             error
 
 	ctx context.Context // context used for cancellation
 }
@@ -74,6 +75,7 @@ func (cm *PollingProjectConfigManager) activate(initialPayload []byte, init bool
 
 		cm.configLock.Lock()
 		cm.projectConfig = projectConfig
+		cm.err = err
 		cm.configLock.Unlock()
 	}
 
@@ -126,8 +128,8 @@ func NewPollingProjectConfigManager(ctx context.Context, sdkKey string) *Polling
 }
 
 // GetConfig returns the project config
-func (cm *PollingProjectConfigManager) GetConfig() optimizely.ProjectConfig {
+func (cm *PollingProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
 	cm.configLock.RLock()
 	defer cm.configLock.RUnlock()
-	return cm.projectConfig
+	return cm.projectConfig, cm.err
 }

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -49,5 +49,25 @@ func TestNewPollingProjectConfigManagerWithOptions(t *testing.T) {
 	}
 	configManager := NewPollingProjectConfigManagerWithOptions(context.Background(), sdkKey, options)
 	mockRequester.AssertExpectations(t)
-	assert.Equal(t, projectConfig, configManager.GetConfig())
+
+	actual, err := configManager.GetConfig()
+	assert.NotNil(t, err)
+	assert.Equal(t, projectConfig, actual)
+}
+
+func TestNewPollingProjectConfigManagerWithNull(t *testing.T) {
+	mockDatafile := []byte("NOT-VALID")
+	mockRequester := new(MockRequester)
+	mockRequester.On("Get", []Header(nil)).Return(mockDatafile, 200, nil)
+
+	// Test we fetch using requester
+	sdkKey := "test_sdk_key"
+	options := PollingProjectConfigManagerOptions{
+		Requester: mockRequester,
+	}
+	configManager := NewPollingProjectConfigManagerWithOptions(context.Background(), sdkKey, options)
+	mockRequester.AssertExpectations(t)
+
+	_, err := configManager.GetConfig()
+	assert.NotNil(t, err)
 }

--- a/optimizely/config/static_manager.go
+++ b/optimizely/config/static_manager.go
@@ -80,8 +80,8 @@ func NewStaticProjectConfigManager(config optimizely.ProjectConfig) *StaticProje
 }
 
 // GetConfig returns the project config
-func (cm *StaticProjectConfigManager) GetConfig() optimizely.ProjectConfig {
+func (cm *StaticProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
 	cm.configLock.Lock()
 	defer cm.configLock.Unlock()
-	return cm.projectConfig
+	return cm.projectConfig, nil
 }

--- a/optimizely/config/static_manager_test.go
+++ b/optimizely/config/static_manager_test.go
@@ -26,5 +26,7 @@ import (
 func TestNewStaticProjectConfigManager(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
 	configManager := NewStaticProjectConfigManager(projectConfig)
-	assert.Equal(t, projectConfig, configManager.GetConfig())
+
+	actual, _ := configManager.GetConfig()
+	assert.Equal(t, projectConfig, actual)
 }

--- a/optimizely/interface.go
+++ b/optimizely/interface.go
@@ -41,5 +41,5 @@ type ProjectConfig interface {
 
 // ProjectConfigManager manages the config
 type ProjectConfigManager interface {
-	GetConfig() ProjectConfig
+	GetConfig() (ProjectConfig, error)
 }


### PR DESCRIPTION
## Summary
- Update `ProjectConfigManager#GetConfig` also return err
- Update `ProjectConfigManager` implementations with the new signature
- Replace `isClientValid` with standard `GetProjectConfig`
- Slight refactor of the `MockProjectConfigManager` to be a bit more flexible
- Add tests to maintain coverage

When exposing ProjectConfig I felt that the use of `isValidClient` was better served with the "comma-err" idiom. So I replaced that initial check with a common method `GetProjectConfig` with is used internally and externally to get a project config.