### PR TITLE
Replace isValidClient with GetProjectConfig.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ before_install:
   - go get github.com/mattn/goveralls
 git:
   depth: 1
-
-before_script:
-  - go get -u golang.org/x/lint/golint
 script:
-  - golint ./...
   - go test -v -race ./... -coverprofile=profile.cov
   - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
 stages:
@@ -24,7 +20,6 @@ jobs:
         - go get github.com/golangci/golangci-lint/cmd/golangci-lint
       script:
         - golangci-lint run --out-format=tab --tests=false optimizely/...
-
     - stage: 'Integration Tests'
       merge_mode: replace
       env: SDK=go

--- a/optimizely/client/client.go
+++ b/optimizely/client/client.go
@@ -266,8 +266,7 @@ func (o *OptimizelyClient) getFeatureVariable(featureKey, variableKey string, us
 // GetProjectConfig returns the current ProjectConfig or nil if the instance is not valid
 func (o *OptimizelyClient) GetProjectConfig() (projectConfig optimizely.ProjectConfig, err error) {
 	if !o.isValid {
-		err := fmt.Errorf("optimizely instance is not valid")
-		return nil, err
+		return nil, fmt.Errorf("optimizely instance is not valid")
 	}
 
 	projectConfig, err = o.configManager.GetConfig()

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -54,12 +54,23 @@ func (c *MockProjectConfig) GetEventByKey(string) (entities.Event, error) {
 }
 
 type MockProjectConfigManager struct {
+	projectConfig optimizely.ProjectConfig
 	mock.Mock
 }
 
-func (p *MockProjectConfigManager) GetConfig() optimizely.ProjectConfig {
+func (p *MockProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
+	if p.projectConfig != nil {
+		return p.projectConfig, nil
+	}
+
 	args := p.Called()
-	return args.Get(0).(optimizely.ProjectConfig)
+	return args.Get(0).(optimizely.ProjectConfig), args.Error(1)
+}
+
+func ValidProjectConfigManager() *MockProjectConfigManager {
+	p := new(MockProjectConfigManager)
+	p.projectConfig = new(TestConfig)
+	return p
 }
 
 type MockDecisionService struct {
@@ -123,14 +134,10 @@ func (TestConfig) GetClientVersion() string {
 
 func TestTrack(t *testing.T) {
 	mockProcessor := &MockProcessor{}
-
-	mockConfig := new(TestConfig)
-	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
 	mockDecisionService := new(MockDecisionService)
 
 	client := OptimizelyClient{
-		configManager:   mockConfigManager,
+		configManager:   ValidProjectConfigManager(),
 		decisionService: mockDecisionService,
 		eventProcessor:  mockProcessor,
 		isValid:         true,
@@ -147,14 +154,10 @@ func TestTrack(t *testing.T) {
 
 func TestTrackFail(t *testing.T) {
 	mockProcessor := &MockProcessor{}
-
-	mockConfig := new(TestConfig)
-	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
 	mockDecisionService := new(MockDecisionService)
 
 	client := OptimizelyClient{
-		configManager:   mockConfigManager,
+		configManager:   ValidProjectConfigManager(),
 		decisionService: mockDecisionService,
 		eventProcessor:  mockProcessor,
 		isValid:         true,
@@ -169,14 +172,10 @@ func TestTrackFail(t *testing.T) {
 
 func TestTrackInvalid(t *testing.T) {
 	mockProcessor := &MockProcessor{}
-
-	mockConfig := new(TestConfig)
-	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
 	mockDecisionService := new(MockDecisionService)
 
 	client := OptimizelyClient{
-		configManager:   mockConfigManager,
+		configManager:   ValidProjectConfigManager(),
 		decisionService: mockDecisionService,
 		eventProcessor:  mockProcessor,
 		isValid:         false,
@@ -210,7 +209,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 	mockConfig := new(MockProjectConfig)
 	mockConfig.On("GetFeatureByKey", testFeatureKey).Return(testFeature, nil)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 	// Set up the mock decision service and its return value
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -242,7 +241,9 @@ func TestIsFeatureEnabledErrorCases(t *testing.T) {
 	testFeatureKey := "test_feature_key"
 
 	// Test instance invalid
+	mockConfig := new(MockProjectConfig)
 	mockConfigManager := new(MockProjectConfigManager)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 	mockDecisionService := new(MockDecisionService)
 
 	client := OptimizelyClient{
@@ -252,16 +253,16 @@ func TestIsFeatureEnabledErrorCases(t *testing.T) {
 	}
 	result, _ := client.IsFeatureEnabled(testFeatureKey, testUserContext)
 	assert.False(t, result)
-	mockConfigManager.AssertNotCalled(t, "GetFeatureByKey")
+	mockConfig.AssertNotCalled(t, "GetFeatureByKey")
 	mockDecisionService.AssertNotCalled(t, "GetFeatureDecision")
 
 	// Test invalid feature key
 	expectedError := errors.New("Invalid feature key")
-	mockConfig := new(MockProjectConfig)
+	mockConfig = new(MockProjectConfig)
 	mockConfig.On("GetFeatureByKey", testFeatureKey).Return(entities.Feature{}, expectedError)
 
 	mockConfigManager = new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 	mockDecisionService = new(MockDecisionService)
 	client = OptimizelyClient{
 		configManager:   mockConfigManager,
@@ -338,7 +339,7 @@ func TestGetEnabledFeatures(t *testing.T) {
 	mockConfig.On("GetFeatureByKey", testFeatureDisabledKey).Return(testFeatureDisabled, nil)
 	mockConfig.On("GetFeatureList").Return(featureList)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 	// Set up the mock decision service and its return value
 	testDecisionContextEnabled := decision.FeatureDecisionContext{
 		Feature:       &testFeatureEnabled,
@@ -1210,7 +1211,7 @@ func TestGetFeatureVariableStringWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1256,7 +1257,7 @@ func TestGetFeatureVariableStringWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1303,7 +1304,7 @@ func TestGetFeatureVariableStringWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1419,6 +1420,32 @@ func TestGetFeatureVariableErrorCases(t *testing.T) {
 	mockConfigManager.AssertNotCalled(t, "GetFeatureByKey")
 	mockConfigManager.AssertNotCalled(t, "GetVariableByKey")
 	mockDecisionService.AssertNotCalled(t, "GetFeatureDecision")
+}
+
+func TestGetProjectConfigIsValid(t *testing.T) {
+	mockConfigManager := ValidProjectConfigManager()
+
+	client := OptimizelyClient{
+		configManager: mockConfigManager,
+		isValid:       true,
+	}
+
+	actual, err := client.GetProjectConfig()
+
+	assert.Nil(t, err)
+	assert.Equal(t, mockConfigManager.projectConfig, actual)
+}
+
+func TestGetProjectConfigInvalid(t *testing.T) {
+	client := OptimizelyClient{
+		configManager: ValidProjectConfigManager(),
+		isValid:       false,
+	}
+
+	actual, err := client.GetProjectConfig()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, actual)
 }
 
 // Helper Methods

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -209,7 +209,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 	mockConfig := new(MockProjectConfig)
 	mockConfig.On("GetFeatureByKey", testFeatureKey).Return(testFeature, nil)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 	// Set up the mock decision service and its return value
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -243,7 +243,7 @@ func TestIsFeatureEnabledErrorCases(t *testing.T) {
 	// Test instance invalid
 	mockConfig := new(MockProjectConfig)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 	mockDecisionService := new(MockDecisionService)
 
 	client := OptimizelyClient{
@@ -262,7 +262,7 @@ func TestIsFeatureEnabledErrorCases(t *testing.T) {
 	mockConfig.On("GetFeatureByKey", testFeatureKey).Return(entities.Feature{}, expectedError)
 
 	mockConfigManager = new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 	mockDecisionService = new(MockDecisionService)
 	client = OptimizelyClient{
 		configManager:   mockConfigManager,
@@ -339,7 +339,7 @@ func TestGetEnabledFeatures(t *testing.T) {
 	mockConfig.On("GetFeatureByKey", testFeatureDisabledKey).Return(testFeatureDisabled, nil)
 	mockConfig.On("GetFeatureList").Return(featureList)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 	// Set up the mock decision service and its return value
 	testDecisionContextEnabled := decision.FeatureDecisionContext{
 		Feature:       &testFeatureEnabled,
@@ -440,7 +440,7 @@ func TestGetFeatureVariableBooleanWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -486,7 +486,7 @@ func TestGetFeatureVariableBooleanWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -533,7 +533,7 @@ func TestGetFeatureVariableBooleanWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -580,7 +580,7 @@ func TestGetFeatureVariableBooleanWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -627,7 +627,7 @@ func TestGetFeatureVariableBooleanReturnsDefaultValueIfFeatureNotEnabled(t *test
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -697,7 +697,7 @@ func TestGetFeatureVariableDoubleWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -743,7 +743,7 @@ func TestGetFeatureVariableDoubleWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -790,7 +790,7 @@ func TestGetFeatureVariableDoubleWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -837,7 +837,7 @@ func TestGetFeatureVariableDoubleWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -884,7 +884,7 @@ func TestGetFeatureVariableDoubleReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -954,7 +954,7 @@ func TestGetFeatureVariableIntegerWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1000,7 +1000,7 @@ func TestGetFeatureVariableIntegerWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1047,7 +1047,7 @@ func TestGetFeatureVariableIntegerWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1094,7 +1094,7 @@ func TestGetFeatureVariableIntegerWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1141,7 +1141,7 @@ func TestGetFeatureVariableIntegerReturnsDefaultValueIfFeatureNotEnabled(t *test
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1211,7 +1211,7 @@ func TestGetFeatureVariableStringWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1257,7 +1257,7 @@ func TestGetFeatureVariableStringWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1304,7 +1304,7 @@ func TestGetFeatureVariableStringWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error)(nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1351,7 +1351,7 @@ func TestGetFeatureVariableStringReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
+	mockConfigManager.On("GetConfig").Return(mockConfig, nil)
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -440,7 +440,7 @@ func TestGetFeatureVariableBooleanWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -486,7 +486,7 @@ func TestGetFeatureVariableBooleanWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -533,7 +533,7 @@ func TestGetFeatureVariableBooleanWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -580,7 +580,7 @@ func TestGetFeatureVariableBooleanWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -627,7 +627,7 @@ func TestGetFeatureVariableBooleanReturnsDefaultValueIfFeatureNotEnabled(t *test
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -697,7 +697,7 @@ func TestGetFeatureVariableDoubleWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -743,7 +743,7 @@ func TestGetFeatureVariableDoubleWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -790,7 +790,7 @@ func TestGetFeatureVariableDoubleWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -837,7 +837,7 @@ func TestGetFeatureVariableDoubleWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -884,7 +884,7 @@ func TestGetFeatureVariableDoubleReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -954,7 +954,7 @@ func TestGetFeatureVariableIntegerWithValidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1000,7 +1000,7 @@ func TestGetFeatureVariableIntegerWithInvalidValue(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1047,7 +1047,7 @@ func TestGetFeatureVariableIntegerWithInvalidValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1094,7 +1094,7 @@ func TestGetFeatureVariableIntegerWithEmptyValueType(t *testing.T) {
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1141,7 +1141,7 @@ func TestGetFeatureVariableIntegerReturnsDefaultValueIfFeatureNotEnabled(t *test
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,
@@ -1351,7 +1351,7 @@ func TestGetFeatureVariableStringReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	testFeature := getTestFeature(testFeatureKey, testExperiment)
 	mockConfig := getMockConfig(testFeatureKey, testVariableKey, testFeature, testVariable)
 	mockConfigManager := new(MockProjectConfigManager)
-	mockConfigManager.On("GetConfig").Return(mockConfig)
+	mockConfigManager.On("GetConfig").Return(mockConfig, (error) (nil))
 
 	testDecisionContext := decision.FeatureDecisionContext{
 		Feature:       &testFeature,

--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -48,6 +48,7 @@ type PollingProjectConfigManager struct {
 	pollingInterval time.Duration
 	projectConfig   optimizely.ProjectConfig
 	configLock      sync.RWMutex
+	err             error
 
 	ctx context.Context // context used for cancellation
 }
@@ -75,6 +76,7 @@ func (cm *PollingProjectConfigManager) activate(initialPayload []byte, init bool
 
 		cm.configLock.Lock()
 		cm.projectConfig = projectConfig
+		cm.err = err
 		cm.configLock.Unlock()
 	}
 
@@ -127,8 +129,8 @@ func NewPollingProjectConfigManager(ctx context.Context, sdkKey string) *Polling
 }
 
 // GetConfig returns the project config
-func (cm *PollingProjectConfigManager) GetConfig() optimizely.ProjectConfig {
+func (cm *PollingProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
 	cm.configLock.RLock()
 	defer cm.configLock.RUnlock()
-	return cm.projectConfig
+	return cm.projectConfig, cm.err
 }

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -49,5 +49,25 @@ func TestNewPollingProjectConfigManagerWithOptions(t *testing.T) {
 	}
 	configManager := NewPollingProjectConfigManagerWithOptions(context.Background(), sdkKey, options)
 	mockRequester.AssertExpectations(t)
-	assert.Equal(t, projectConfig, configManager.GetConfig())
+
+	actual, err := configManager.GetConfig()
+	assert.NotNil(t, err)
+	assert.Equal(t, projectConfig, actual)
+}
+
+func TestNewPollingProjectConfigManagerWithNull(t *testing.T) {
+	mockDatafile := []byte("NOT-VALID")
+	mockRequester := new(MockRequester)
+	mockRequester.On("Get", []Header(nil)).Return(mockDatafile, 200, nil)
+
+	// Test we fetch using requester
+	sdkKey := "test_sdk_key"
+	options := PollingProjectConfigManagerOptions{
+		Requester: mockRequester,
+	}
+	configManager := NewPollingProjectConfigManagerWithOptions(context.Background(), sdkKey, options)
+	mockRequester.AssertExpectations(t)
+
+	_, err := configManager.GetConfig()
+	assert.NotNil(t, err)
 }

--- a/optimizely/config/static_manager.go
+++ b/optimizely/config/static_manager.go
@@ -82,8 +82,8 @@ func NewStaticProjectConfigManager(config optimizely.ProjectConfig) *StaticProje
 }
 
 // GetConfig returns the project config
-func (cm *StaticProjectConfigManager) GetConfig() optimizely.ProjectConfig {
+func (cm *StaticProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
 	cm.configLock.Lock()
 	defer cm.configLock.Unlock()
-	return cm.projectConfig
+	return cm.projectConfig, nil
 }

--- a/optimizely/config/static_manager_test.go
+++ b/optimizely/config/static_manager_test.go
@@ -26,5 +26,7 @@ import (
 func TestNewStaticProjectConfigManager(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
 	configManager := NewStaticProjectConfigManager(projectConfig)
-	assert.Equal(t, projectConfig, configManager.GetConfig())
+
+	actual, _ := configManager.GetConfig()
+	assert.Equal(t, projectConfig, actual)
 }

--- a/optimizely/interface.go
+++ b/optimizely/interface.go
@@ -42,5 +42,5 @@ type ProjectConfig interface {
 
 // ProjectConfigManager manages the config
 type ProjectConfigManager interface {
-	GetConfig() ProjectConfig
+	GetConfig() (ProjectConfig, error)
 }


### PR DESCRIPTION
## Summary
- Update `ProjectConfigManager#GetConfig` also return err
- Update `ProjectConfigManager` implementations with the new signature
- Replace `isClientValid` with standard `GetProjectConfig`
- Slight refactor of the `MockProjectConfigManager` to be a bit more flexible
- Add tests to maintain coverage

When exposing ProjectConfig I felt that the use of `isValidClient` was better served with the "comma-err" idiom. So I replaced that initial check with a common method `GetProjectConfig` with is used internally and externally to get a project config.

Note: this replaces https://github.com/optimizely/go-sdk/pull/82