### PR TITLE
refac(event): Return success value instead of using callback in dispatcher interface

### DIFF
--- a/optimizely/client/factory_test.go
+++ b/optimizely/client/factory_test.go
@@ -30,9 +30,9 @@ type MockDispatcher struct {
 	Events []event.LogEvent
 }
 
-func (f *MockDispatcher) DispatchEvent(event event.LogEvent, callback func(success bool)) {
+func (f *MockDispatcher) DispatchEvent(event event.LogEvent) (bool, error) {
 	f.Events = append(f.Events, event)
-	callback(true)
+	return true, nil
 }
 
 func TestFactoryClientReturnsDefaultClient(t *testing.T) {

--- a/optimizely/event/dispatcher.go
+++ b/optimizely/event/dispatcher.go
@@ -30,7 +30,7 @@ const jsonContentType = "application/json"
 
 // Dispatcher dispatches events
 type Dispatcher interface {
-	DispatchEvent(event LogEvent, callback func(success bool))
+	DispatchEvent(event LogEvent) (bool, error)
 }
 
 // HTTPEventDispatcher is the HTTP implementation of the Dispatcher interface
@@ -40,7 +40,7 @@ type HTTPEventDispatcher struct {
 var dispatcherLogger = logging.GetLogger("EventDispatcher")
 
 // DispatchEvent dispatches event with callback
-func (*HTTPEventDispatcher) DispatchEvent(event LogEvent, callback func(bool)) {
+func (*HTTPEventDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 	jsonValue, _ := json.Marshal(event.Event)
 	resp, err := http.Post(event.EndPoint, jsonContentType, bytes.NewBuffer(jsonValue))
@@ -54,10 +54,9 @@ func (*HTTPEventDispatcher) DispatchEvent(event LogEvent, callback func(bool)) {
 		if resp.StatusCode == 204 {
 			success = true
 		} else {
-			fmt.Printf("http.Post invalid response %d", resp.StatusCode)
+			dispatcherLogger.Error(fmt.Sprintf("http.Post invalid response %d", resp.StatusCode), err)
 			success = false
 		}
 	}
-	callback(success)
-
+	return success, err
 }

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -174,15 +174,16 @@ func (p *QueueingEventProcessor) FlushEvents() {
 			}
 		}
 		if batchEventCount > 0 {
-			p.EventDispatcher.DispatchEvent(createLogEvent(batchEvent), func(success bool) {
-				if success {
-					p.Remove(batchEventCount)
-					batchEventCount = 0
-					batchEvent = Batch{}
-				} else {
-					failedToSend = true
-				}
-			})
+			// TODO: figure out what to do with the error
+			if success, _ := p.EventDispatcher.DispatchEvent(createLogEvent(batchEvent)); success {
+				pLogger.Debug("Dispatched event successfully")
+				p.Remove(batchEventCount)
+				batchEventCount = 0
+				batchEvent = Batch{}
+			} else {
+				pLogger.Warning("Failed to dispatch event successfully")
+				failedToSend = true
+			}
 		}
 	}
 	p.Mux.Unlock()

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -30,9 +30,9 @@ type MockDispatcher struct {
 	Events []LogEvent
 }
 
-func (f *MockDispatcher) DispatchEvent(event LogEvent, callback func(success bool)) {
+func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 	f.Events = append(f.Events, event)
-	callback(true)
+	return true, nil
 }
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {


### PR DESCRIPTION
# Summary
- Refactors the event dispatcher interface to return the success arg instead of taking a callback since the dispatchEvent method itself is a blocking operation