### PR TITLE
chore(release): Bump version and add release notes for 0.2.0.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Changes that have landed but are not yet released.
 - Support for running full feature tests with the SDK.
 
+## [0.2.0] - September 11th, 2019
+This release of the SDK introduces Feature Management capabilities for running both Feature Rollouts as well as Feature Tests using Optimizely Feature Management.
+
+### New Features
+- Introduces feature variable getters via `GetFeatureVariable*` for parameterizing your feature tests.
+- Introduces the `Track` API call for sending conversion events to Optimizely.
+- The `IsFeatureEnabled` API will now send impression events if there is a feature test attached to the feature being accessed.
+
+### Breaking Changes
+- Vendored packages have been removed in favor of declaring dependencies and their versions using `go.mod`.
+
 ## [0.1.0-beta] - August 23rd, 2019
 This is the initial release of the SDK, which includes support for running Feature Rollouts using Optimizely Feature Management.
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ module mymodule
 go 1.12
 
 require (
-	github.com/optimizely/go-sdk v0.1.0
+	github.com/optimizely/go-sdk v0.2.0
 )
 ```
 
 If you are already using `go.mod` in your application you can run the following:
 
 ```
-go mod edit -require github.com/optimizely/go-sdk@v0.1.0
+go mod edit -require github.com/optimizely/go-sdk@v0.2.0
 ```
 
 NOTE:

--- a/optimizely/version.go
+++ b/optimizely/version.go
@@ -18,7 +18,7 @@
 package optimizely
 
 // Version is the current version of the client
-const Version = "0.1.0-beta"
+const Version = "0.2.0"
 
 // ClientName is the name of the client
 const ClientName = "go-sdk"


### PR DESCRIPTION
# Summary
- Bumps the client version to 0.2.0
- Adds release notes for the new release 0.2.0