### PR TITLE
Introducing mutex support for feature tests

### DIFF
--- a/optimizely/decision/bucketer/experiment_bucketer.go
+++ b/optimizely/decision/bucketer/experiment_bucketer.go
@@ -56,8 +56,8 @@ func (b MurmurhashBucketer) Bucket(bucketingID string, experiment entities.Exper
 		bucketKey := bucketingID + group.ID
 		bucketedExperimentID := b.bucketToEntity(bucketKey, group.TrafficAllocation)
 		if bucketedExperimentID == "" || bucketedExperimentID != experiment.ID {
-			// User is not bucketed into an experiment in the exclusion group, return nil variation
-			return nil, reasons.NotInGroup, nil
+			// User is not bucketed into provided experiment in mutex group
+			return nil, reasons.NotBucketedIntoVariation, nil
 		}
 	}
 

--- a/optimizely/decision/bucketer/experiment_bucketer_test.go
+++ b/optimizely/decision/bucketer/experiment_bucketer_test.go
@@ -114,5 +114,5 @@ func TestBucketExclusionGroups(t *testing.T) {
 	// since the bucket value maps to experiment 1, the user will not be bucketed for experiment 2
 	bucketedVariation, reason, _ = bucketer.Bucket("ppid2", experiment2, exclusionGroup)
 	assert.Nil(t, bucketedVariation)
-	assert.Equal(t, reasons.NotInGroup, reason)
+	assert.Equal(t, reasons.NotBucketedIntoVariation, reason)
 }

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -46,9 +46,8 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 
 	// Check if user is bucketed in feature experiment
 	if f.featureExperimentService != nil && len(feature.FeatureExperiments) > 0 {
-		// @TODO this can be improved by getting group ID first and determining experiment ID and then bucketing in experiment ID
-		for idx := 0; idx < len(feature.FeatureExperiments); idx++ {
-			experiment := feature.FeatureExperiments[idx]
+		// @TODO this can be improved by getting group ID first and determining experiment and then bucketing in experiment
+		for _, experiment := range feature.FeatureExperiments {
 			experimentDecisionContext := ExperimentDecisionContext{
 				Experiment:    &experiment,
 				ProjectConfig: decisionContext.ProjectConfig,

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -48,8 +48,9 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 	if f.featureExperimentService != nil && len(feature.FeatureExperiments) > 0 {
 		// @TODO this can be improved by getting group ID first and determining experiment and then bucketing in experiment
 		for _, experiment := range feature.FeatureExperiments {
+			featureExperiment := experiment
 			experimentDecisionContext := ExperimentDecisionContext{
-				Experiment:    &experiment,
+				Experiment:    &featureExperiment,
 				ProjectConfig: decisionContext.ProjectConfig,
 			}
 

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -46,30 +46,32 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 
 	// Check if user is bucketed in feature experiment
 	if f.featureExperimentService != nil && len(feature.FeatureExperiments) > 0 {
-		// @TODO: add in a feature decision service that takes into account multiple experiments (via group mutex)
-		experiment := feature.FeatureExperiments[0]
-		experimentDecisionContext := ExperimentDecisionContext{
-			Experiment:    &experiment,
-			ProjectConfig: decisionContext.ProjectConfig,
-		}
-
-		experimentDecision, err := f.featureExperimentService.GetDecision(experimentDecisionContext, userContext)
-		// Variation not nil means we got a decision and should return it
-		if experimentDecision.Variation != nil {
-			featureDecision := FeatureDecision{
-				Experiment: experiment,
-				Decision:   experimentDecision.Decision,
-				Variation:  experimentDecision.Variation,
-				Source:     FeatureTest,
+		// @TODO this can be improved by getting group ID first and determining experiment ID and then bucketing in experiment ID
+		for idx := 0; idx < len(feature.FeatureExperiments); idx++ {
+			experiment := feature.FeatureExperiments[idx]
+			experimentDecisionContext := ExperimentDecisionContext{
+				Experiment:    &experiment,
+				ProjectConfig: decisionContext.ProjectConfig,
 			}
 
-			cfLogger.Debug(fmt.Sprintf(
-				`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
-				feature.Key,
-				userContext.ID,
-				featureDecision.Reason,
-			))
-			return featureDecision, err
+			experimentDecision, err := f.featureExperimentService.GetDecision(experimentDecisionContext, userContext)
+			// Variation not nil means we got a decision and should return it
+			if experimentDecision.Variation != nil {
+				featureDecision := FeatureDecision{
+					Experiment: experiment,
+					Decision:   experimentDecision.Decision,
+					Variation:  experimentDecision.Variation,
+					Source:     FeatureTest,
+				}
+
+				cfLogger.Debug(fmt.Sprintf(
+					`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
+					feature.Key,
+					userContext.ID,
+					featureDecision.Reason,
+				))
+				return featureDecision, err
+			}
 		}
 	}
 

--- a/optimizely/decision/composite_feature_service_test.go
+++ b/optimizely/decision/composite_feature_service_test.go
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package decision
+
+import (
+	"github.com/optimizely/go-sdk/optimizely/entities"
+	"testing"
+)
+
+func TestCompositeFeatureServiceGetDecisionFeatureExperiment(t *testing.T) {
+	mockProjectConfig := new(mockProjectConfig)
+	testDecisionContext := FeatureDecisionContext{
+		Feature:       &testFeat3335,
+		ProjectConfig: mockProjectConfig,
+	}
+
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+}
+
+func TestCompositeFeatureServiceGetDecisionRollout(t *testing.T) {
+
+}

--- a/optimizely/decision/composite_feature_service_test.go
+++ b/optimizely/decision/composite_feature_service_test.go
@@ -17,22 +17,100 @@
 package decision
 
 import (
+	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
 	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestCompositeFeatureServiceGetDecisionFeatureExperiment(t *testing.T) {
 	mockProjectConfig := new(mockProjectConfig)
-	testDecisionContext := FeatureDecisionContext{
+	testFeatureDecisionContext := FeatureDecisionContext{
 		Feature:       &testFeat3335,
 		ProjectConfig: mockProjectConfig,
+	}
+	testExperimentDecisionContext := ExperimentDecisionContext{
+		Experiment:    &testExp1113,
+		ProjectConfig: mockProjectConfig,
+	}
+	mockExperimentDecision := ExperimentDecision{
+		Decision:  Decision{reasons.BucketedIntoVariation},
+		Variation: &testExp1113Var2223,
 	}
 
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
 	}
+
+	mockExperimentService := new(MockExperimentDecisionService)
+	mockRolloutService := new(MockFeatureDecisionService)
+	// Mock to return decision from feature experiment service
+	mockExperimentService.On("GetDecision", testExperimentDecisionContext, testUserContext).Return(mockExperimentDecision, nil)
+
+	// Decision is returned from feature test evaluation
+	expectedDecision := FeatureDecision{
+		Decision:   Decision{reasons.BucketedIntoVariation},
+		Source:     FeatureTest,
+		Experiment: testExp1113,
+		Variation:  &testExp1113Var2223,
+	}
+
+	compositeFeatureService := &CompositeFeatureService{
+		featureExperimentService: mockExperimentService,
+		rolloutDecisionService:   mockRolloutService,
+	}
+	actualDecision, err := compositeFeatureService.GetDecision(testFeatureDecisionContext, testUserContext)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDecision, actualDecision)
 }
 
 func TestCompositeFeatureServiceGetDecisionRollout(t *testing.T) {
+	mockProjectConfig := new(mockProjectConfig)
+	testFeatureDecisionContext := FeatureDecisionContext{
+		Feature:       &testFeat3335,
+		ProjectConfig: mockProjectConfig,
+	}
+	testExperimentDecisionContext1 := ExperimentDecisionContext{
+		Experiment:    &testExp1113,
+		ProjectConfig: mockProjectConfig,
+	}
+	testExperimentDecisionContext2 := ExperimentDecisionContext{
+		Experiment:    &testExp1114,
+		ProjectConfig: mockProjectConfig,
+	}
 
+	// Mock to not bucket user in feature experiment
+	mockExperimentDecision := ExperimentDecision{
+		Decision:  Decision{reasons.NotBucketedIntoVariation},
+		Variation: nil,
+	}
+
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	mockFeatureDecision := FeatureDecision{
+		Decision:   Decision{reasons.BucketedIntoVariation},
+		Source:     Rollout,
+		Experiment: testExp1115,
+		Variation:  &testExp1115Var2227,
+	}
+
+	mockExperimentService := new(MockExperimentDecisionService)
+	mockRolloutService := new(MockFeatureDecisionService)
+	// Mock to return decision from feature experiment service which causes rollout service to be called
+	mockExperimentService.On("GetDecision", testExperimentDecisionContext1, testUserContext).Return(mockExperimentDecision, nil)
+	mockExperimentService.On("GetDecision", testExperimentDecisionContext2, testUserContext).Return(mockExperimentDecision, nil)
+	mockRolloutService.On("GetDecision", testFeatureDecisionContext, testUserContext).Return(mockFeatureDecision, nil)
+
+	// Decision is returned from rollout evaluation
+	expectedDecision := mockFeatureDecision
+
+	compositeFeatureService := &CompositeFeatureService{
+		featureExperimentService: mockExperimentService,
+		rolloutDecisionService:   mockRolloutService,
+	}
+	actualDecision, err := compositeFeatureService.GetDecision(testFeatureDecisionContext, testUserContext)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDecision, actualDecision)
 }

--- a/optimizely/decision/helpers_test.go
+++ b/optimizely/decision/helpers_test.go
@@ -134,3 +134,70 @@ var testFeatRollout3334 = entities.Feature{
 		Experiments: []entities.Experiment{testExp1112},
 	},
 }
+
+// Feature with test and rollout
+const testFeat3335Key = "test_feature_3335_key"
+// Will use this experiment for feature test
+const testExp1113Key = "test_experiment_1113"
+var testExp1113Var2223 = entities.Variation{ID: "2223", Key: "2223", FeatureEnabled: true}
+var testExp1113Var2224 = entities.Variation{ID: "2224", Key: "2224", FeatureEnabled: false}
+var testExp1113 = entities.Experiment{
+	ID:  "1113",
+	Key: testExp1113Key,
+	GroupID: "6666",
+	Variations: map[string]entities.Variation{
+		"2223": testExp1113Var2223,
+		"2224": testExp1113Var2224,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2223", EndOfRange: 5000},
+		entities.Range{EntityID: "2224", EndOfRange: 10000},
+	},
+}
+const testExp1114Key = "test_experiment_1114"
+var testExp1114Var2225 = entities.Variation{ID: "2225", Key: "2225", FeatureEnabled: true}
+var testExp1114Var2226 = entities.Variation{ID: "2226", Key: "2226", FeatureEnabled: false}
+var testExp1114 = entities.Experiment{
+	ID:  "1114",
+	Key: testExp1114Key,
+	GroupID: "6666",
+	Variations: map[string]entities.Variation{
+		"2225": testExp1114Var2225,
+		"2226": testExp1114Var2226,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2225", EndOfRange: 5000},
+		entities.Range{EntityID: "2226", EndOfRange: 10000},
+	},
+}
+var testGroup6666 = entities.Group{
+	ID: "6666",
+	Policy: "random",
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "1113", EndOfRange: 3000},
+		entities.Range{EntityID: "1114", EndOfRange: 6000},
+	},
+}
+
+// Will use this experiment for rollout
+const testExp1115Key = "test_experiment_1115"
+var testExp1115Var2227 = entities.Variation{ID: "2227", Key: "2227", FeatureEnabled: true}
+var testExp1115 = entities.Experiment{
+	ID:  "1115",
+	Key: testExp1115Key,
+	Variations: map[string]entities.Variation{
+		"2227": testExp1115Var2227,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2227", EndOfRange: 5000},
+	},
+}
+var testFeat3335 = entities.Feature{
+	ID: "3335",
+	Key: testFeat3335Key,
+	FeatureExperiments: []entities.Experiment{testExp1113, testExp1114},
+	Rollout: entities.Rollout{
+    	ID:          "4445",
+	    Experiments: []entities.Experiment{testExp1115},
+	},
+}


### PR DESCRIPTION
This change introduces support for feature tests belonging to the same mutex group.

NOTE: The current change avoids refactoring a lot of the code as the ideal way to do this is to bucket into group to determine experiment and then bucket into experiment. 
For eg. let's say there are N experiments in a mutex group. In the current scenario we will bucket N times to evaluate feature tests, but we only need to bucket 2 times: once for group and once for experiment.

That will come as an enhancement to this code.