### PR TITLE
ci(versionsupport): adding golang version for 1.8 - WIP (trying one more thing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     go: "1.8.x"
   - name: "Master unit test"
     go: "master"
-    script:
-      - echo "Sohail"
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -debug -- -coverpkg=./... -race -v -ignore=[.git,cmd,examples]
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,.cmd,.examples] -- -coverpkg=./... -race -v 
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -ignore=[.git,vendor,cmd,examples] -- -coverpkg=./...
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,vendor,cmd,examples] -- -coverpkg=./...  -race -v
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug -- -coverpkg=./... -race -v
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,15 @@ go:
   - 1.8.x
   - master
 before_install:
+  - go get go get golang.org/x/tools/cmd/cover
+  - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls
 git:
   depth: 1
 script:
-  - go test -v -race ./... -coverprofile=profile.cov
-  - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
+  - go test ./...
+  - gover
+  - goveralls -coverprofile=gover.coverprofile -service=travis-ci
 stages:
   - 'Lint'
   - 'Integration tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     go: "1.12"
   - name: "1.8 unit test"
     go: "1.8.x"
-  - name: "master unit test"
+  - name: "Master unit test"
     go: "master"
     script:
       - echo "Sohail"
@@ -23,7 +23,7 @@ script:
 stages:
   - 'Lint'
   - 'Integration tests'
-  - 'Test'
+  - 'Master unit test'
 jobs:
   include:
     - stage: 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 git:
   depth: 1
 script:
-  - go test ./...
+  - go test -v -race ./...
   - $GOPATH/bin/gover
   - $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ go:
   - 1.8.x
   - master
 before_install:
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/modocache/gover
+  - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls
 git:
   depth: 1
 script:
-  - go test -v -race ./...
-  - $GOPATH/bin/gover
-  - $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug -- -coverpkg=./...
+  - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'
   - 'Integration tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,.cmd,.examples] -- -coverpkg=./... -race -v 
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,cmd,examples] -- -coverpkg=./... -race -v 
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 env:
   - GO111MODULE=on
-
 language: go
 matrix:
   include:
-  - name: "1.12 unit test"
-    go: "1.12"
-  - name: "1.8 unit test"
-    go: "1.8.x"
-  - name: "Master unit test"
-    go: "master"
+  - go: "1.12"
+  - go: "1.8.x"
+  - go: "master"
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ go:
   - 1.8.x
   - master
 before_install:
-  - go get go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get github.com/modocache/gover
   - go get github.com/mattn/goveralls
 git:
   depth: 1
 script:
   - go test ./...
-  - gover
-  - goveralls -coverprofile=gover.coverprofile -service=travis-ci
+  - $GOPATH/bin/gover
+  - $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service=travis-ci
 stages:
   - 'Lint'
   - 'Integration tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,cmd,examples] -- -coverpkg=./... -race -v 
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -ignore=[.git,vendor,cmd,examples] -- -coverpkg=./...
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 env:
   - GO111MODULE=on
 language: go
-matrix:
-  include:
-  - go: "1.12"
-  - go: "1.8.x"
-  - go: "master"
+go:
+  - 1.12.x
+  - 1.8.x
+  - master
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 env:
   - GO111MODULE=on
 language: go
-go:
-  - 1.12.x
-  - 1.8.x
-  - master
+matrix:
+  include:
+  - go: 1.12.x
+  - go: 1.8.x
+  - go: master
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -debug -- -coverpkg=./... -race -v
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -debug -- -coverpkg=./... -race -v -ignore=[.git,cmd,examples]
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 env:
   - GO111MODULE=on
 language: go
-matrix:
-  include:
-  - name: 'Test'
-    go: 1.12.x
-  - name: 'Test'
-    go: 1.8.x
-  - name: 'Test'
-    go: master
+go:
+  - 1.12.x
+  - 1.8.x
+  - master
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls
 git:
   depth: 1
 script:
+  - echo $GOROOT
   - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -ignore=[.git,vendor,cmd,examples] -- -coverpkg=./...  -race -v
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug -- -coverpkg=./...
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ env:
   - GO111MODULE=on
 
 language: go
-go:
-  - 1.12.x
-  - 1.8.x
-  - master
+matrix:
+  include:
+  - name: "1.12 unit test"
+    go: "1.12"
+  - name: "1.8 unit test"
+    go: "1.8.x"
+  - name: "master unit test"
+    go: "master"
+    script:
+      - echo "Sohail"
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ env:
 language: go
 matrix:
   include:
-  - go: 1.12.x
-  - go: 1.8.x
-  - go: master
+  - name: 'Test'
+    go: 1.12.x
+  - name: 'Test'
+    go: 1.8.x
+  - name: 'Test'
+    go: master
 before_install:
   - go get github.com/go-playground/overalls
   - go get github.com/mattn/goveralls
@@ -17,7 +20,7 @@ script:
 stages:
   - 'Lint'
   - 'Integration tests'
-  - 'Master unit test'
+  - 'Test'
 jobs:
   include:
     - stage: 'Lint'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
 language: go
 go:
   - 1.12.x
+  - 1.8.x
   - master
 before_install:
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 git:
   depth: 1
 script:
-  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=count -debug -- -coverpkg=./... -race -v
+  - $GOPATH/bin/overalls -project=github.com/optimizely/go-sdk -covermode=atomic -debug -- -coverpkg=./... -race -v
   - $GOPATH/bin/goveralls -coverprofile=overalls.coverprofile -service=travis-ci
 stages:
   - 'Lint'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Optimizely Go SDK
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/optimizely/go-sdk)](https://goreportcard.com/report/github.com/optimizely/go-sdk)
-[![Coverage Status](https://coveralls.io/repos/github/optimizely/go-sdk/badge.svg?branch=go-alpha)](https://coveralls.io/github/optimizely/go-sdk?branch=go-alpha)
+[![Coverage Status](https://coveralls.io/repos/github/optimizely/go-sdk/badge.svg?branch=master)](https://coveralls.io/github/optimizely/go-sdk?branch=master)
 
 ## Usage
 


### PR DESCRIPTION
- Added support to generate coverage profile for multiple packages on GO 1.8.x using `https://github.com/go-playground/overalls` since it is not natively supported by GO 1.8.x.
-  Changed coveralls report branch in Readme.md from `go-alpha` to `master`.