### PR TITLE
feat(ab): Add support for Activate and GetVariation APIs.

### DIFF
--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"errors"
+
 	"github.com/optimizely/go-sdk/optimizely/utils"
 
 	"github.com/optimizely/go-sdk/optimizely/event"

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -33,9 +33,9 @@ type CompositeFeatureService struct {
 }
 
 // NewCompositeFeatureService returns a new instance of the CompositeFeatureService
-func NewCompositeFeatureService() *CompositeFeatureService {
+func NewCompositeFeatureService(compositeExperimentService *CompositeExperimentService) *CompositeFeatureService {
 	return &CompositeFeatureService{
-		experimentDecisionService: NewCompositeExperimentService(),
+		experimentDecisionService: compositeExperimentService,
 		rolloutDecisionService:    NewRolloutService(),
 	}
 }

--- a/optimizely/decision/interface.go
+++ b/optimizely/decision/interface.go
@@ -24,6 +24,7 @@ import (
 
 // Service interface is used to make a decision for a given feature or experiment
 type Service interface {
+	GetExperimentDecision(ExperimentDecisionContext, entities.UserContext) (ExperimentDecision, error)
 	GetFeatureDecision(FeatureDecisionContext, entities.UserContext) (FeatureDecision, error)
 	OnDecision(func(notification.DecisionNotification))
 }

--- a/optimizely/notification/entities.go
+++ b/optimizely/notification/entities.go
@@ -31,6 +31,8 @@ const (
 type DecisionNotificationType string
 
 const (
+	// ABTest is used when the decision is returned as part of evaluating an ab test
+	ABTest DecisionNotificationType = "ab-test"
 	// Feature is used when the decision is returned as part of evaluating a feature
 	Feature DecisionNotificationType = "feature"
 )


### PR DESCRIPTION
# Summary
- Adds the `Activate` and `GetVariation` APIs
- Hooks up the `CompositeService` to an `ExperimentService`

# Tests
- Unit tests on the way!