### PR TITLE
refac(decision): moved various components around.

### DIFF
--- a/optimizely/decision/composite_experiment_service_test.go
+++ b/optimizely/decision/composite_experiment_service_test.go
@@ -45,7 +45,7 @@ func (s *CompositeExperimentTestSuite) SetupTest() {
 }
 
 func (s *CompositeExperimentTestSuite) TestGetDecision() {
-	// test that we return out of the decision making and the next one doesn't get called
+	// test that we return out of the decision making and the next one does not get called
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
 	}
@@ -68,7 +68,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecision() {
 }
 
 func (s *CompositeExperimentTestSuite) TestGetDecisionFallthrough() {
-	// test that we move on to the next decision service if no decision is made
+	// test that we move onto the next decision service if no decision is made
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
 	}

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -50,5 +50,5 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		}
 	}
 
-	return FeatureDecision{}, fmt.Errorf("No decision was made for feature %s", decisionContext.Feature.Key)
+	return FeatureDecision{}, fmt.Errorf("no decision was made for feature %s", decisionContext.Feature.Key)
 }

--- a/optimizely/decision/composite_feature_service_test.go
+++ b/optimizely/decision/composite_feature_service_test.go
@@ -98,6 +98,14 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionFallthrough() {
 	s.mockFeatureService2.AssertExpectations(s.T())
 }
 
+func (s *CompositeFeatureServiceTestSuite) TestNewCompositeFeatureService() {
+	// Assert that the service is instantiated with the correct child services in the right order
+	compositeFeatureService := NewCompositeFeatureService()
+	s.Equal(2, len(compositeFeatureService.featureServices))
+	s.IsType(&FeatureExperimentService{}, compositeFeatureService.featureServices[0])
+	s.IsType(&RolloutService{}, compositeFeatureService.featureServices[1])
+}
+
 func TestCompositeFeatureTestSuite(t *testing.T) {
 	suite.Run(t, new(CompositeFeatureServiceTestSuite))
 }

--- a/optimizely/decision/composite_service.go
+++ b/optimizely/decision/composite_service.go
@@ -29,36 +29,26 @@ var csLogger = logging.GetLogger("CompositeDecisionService")
 
 // CompositeService is the entrypoint into the decision service. It provides out of the box decision making for Features and Experiments.
 type CompositeService struct {
-	// experimentDecisionServices []ExperimentDecisionService
-	featureDecisionServices []FeatureService
-	notificationCenter      notification.Center
+	compositeExperimentService ExperimentService
+	compositeFeatureService    FeatureService
+	notificationCenter         notification.Center
 }
 
-// NewCompositeService returns a new instance of the DefeaultDecisionEngine
+// NewCompositeService returns a new instance of the CompositeService with the defaults
 func NewCompositeService(notificationCenter notification.Center) *CompositeService {
-	featureDecisionService := NewCompositeFeatureService()
+	// @TODO: add factory method with option funcs to accept custom feature and experiment services
+	compositeFeatureDecisionService := NewCompositeFeatureService()
+	compositeExperimentService := NewCompositeExperimentService()
 	return &CompositeService{
-		featureDecisionServices: []FeatureService{featureDecisionService},
-		notificationCenter:      notificationCenter,
+		compositeExperimentService: compositeExperimentService,
+		compositeFeatureService:    compositeFeatureDecisionService,
+		notificationCenter:         notificationCenter,
 	}
 }
 
 // GetFeatureDecision returns a decision for the given feature key
 func (s CompositeService) GetFeatureDecision(featureDecisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
-	var featureDecision FeatureDecision
-	var err error
-	// loop through the different features decision services until we get a decision
-	for _, decisionService := range s.featureDecisionServices {
-		featureDecision, err = decisionService.GetDecision(featureDecisionContext, userContext)
-		if err != nil {
-			// @TODO: log error
-			func() {}() // cheat linters
-		}
-
-		if featureDecision.Variation != nil {
-			break
-		}
-	}
+	featureDecision, err := s.compositeFeatureService.GetDecision(featureDecisionContext, userContext)
 
 	// @TODO: add errors
 	if s.notificationCenter != nil {

--- a/optimizely/decision/composite_service_test.go
+++ b/optimizely/decision/composite_service_test.go
@@ -25,14 +25,14 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/notification"
 )
 
-type FeatureTestSuite struct {
+type CompositeServiceTestSuite struct {
 	suite.Suite
 	decisionContext    FeatureDecisionContext
 	mockFeatureService *MockFeatureDecisionService
 	testUserContext    entities.UserContext
 }
 
-func (s *FeatureTestSuite) SetupTest() {
+func (s *CompositeServiceTestSuite) SetupTest() {
 	mockConfig := new(mockProjectConfig)
 	s.decisionContext = FeatureDecisionContext{
 		Feature:       &testFeat3333,
@@ -44,7 +44,7 @@ func (s *FeatureTestSuite) SetupTest() {
 	}
 }
 
-func (s *FeatureTestSuite) TestGetFeatureDecision() {
+func (s *CompositeServiceTestSuite) TestGetFeatureDecision() {
 	expectedFeatureDecision := FeatureDecision{
 		Experiment: testExp1111,
 		Variation:  &testExp1111Var2222,
@@ -61,7 +61,7 @@ func (s *FeatureTestSuite) TestGetFeatureDecision() {
 	s.mockFeatureService.AssertExpectations(s.T())
 }
 
-func (s *FeatureTestSuite) TestDecisionListeners() {
+func (s *CompositeServiceTestSuite) TestDecisionListeners() {
 	expectedFeatureDecision := FeatureDecision{
 		Experiment: testExp1111,
 		Variation:  &testExp1111Var2222,
@@ -89,6 +89,15 @@ func (s *FeatureTestSuite) TestDecisionListeners() {
 	decisionService.GetFeatureDecision(s.decisionContext, s.testUserContext)
 	s.Equal(numberOfCalls, 1)
 }
-func TestFeatureTestSuite(t *testing.T) {
-	suite.Run(t, new(FeatureTestSuite))
+
+func (s *CompositeServiceTestSuite) TestNewCompositeService() {
+	notificationCenter := notification.NewNotificationCenter()
+	compositeService := NewCompositeService(notificationCenter)
+	s.Equal(notificationCenter, compositeService.notificationCenter)
+	s.IsType(&CompositeExperimentService{}, compositeService.compositeExperimentService)
+	s.IsType(&CompositeFeatureService{}, compositeService.compositeFeatureService)
+}
+
+func TestCompositeServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(CompositeServiceTestSuite))
 }

--- a/optimizely/decision/feature_experiment_service.go
+++ b/optimizely/decision/feature_experiment_service.go
@@ -39,8 +39,7 @@ func NewFeatureExperimentService() *FeatureExperimentService {
 func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
 	feature := decisionContext.Feature
 	// @TODO this can be improved by getting group ID first and determining experiment and then bucketing in experiment
-	for _, experiment := range feature.FeatureExperiments {
-		featureExperiment := experiment
+	for _, featureExperiment := range feature.FeatureExperiments {
 		experimentDecisionContext := ExperimentDecisionContext{
 			Experiment:    &featureExperiment,
 			ProjectConfig: decisionContext.ProjectConfig,
@@ -50,7 +49,7 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		// Variation not nil means we got a decision and should return it
 		if experimentDecision.Variation != nil {
 			featureDecision := FeatureDecision{
-				Experiment: experiment,
+				Experiment: featureExperiment,
 				Decision:   experimentDecision.Decision,
 				Variation:  experimentDecision.Variation,
 				Source:     FeatureTest,

--- a/optimizely/decision/feature_experiment_service.go
+++ b/optimizely/decision/feature_experiment_service.go
@@ -40,8 +40,9 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 	feature := decisionContext.Feature
 	// @TODO this can be improved by getting group ID first and determining experiment and then bucketing in experiment
 	for _, featureExperiment := range feature.FeatureExperiments {
+		experiment := featureExperiment
 		experimentDecisionContext := ExperimentDecisionContext{
-			Experiment:    &featureExperiment,
+			Experiment:    &experiment,
 			ProjectConfig: decisionContext.ProjectConfig,
 		}
 
@@ -49,7 +50,7 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		// Variation not nil means we got a decision and should return it
 		if experimentDecision.Variation != nil {
 			featureDecision := FeatureDecision{
-				Experiment: featureExperiment,
+				Experiment: experiment,
 				Decision:   experimentDecision.Decision,
 				Variation:  experimentDecision.Variation,
 				Source:     FeatureTest,

--- a/optimizely/decision/feature_experiment_service_test.go
+++ b/optimizely/decision/feature_experiment_service_test.go
@@ -1,0 +1,80 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package decision
+
+import (
+	"testing"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/stretchr/testify/suite"
+)
+
+type FeatureExperimentServiceTestSuite struct {
+	suite.Suite
+	testFeatureDecisionContext    FeatureDecisionContext
+	testExperimentDecisionContext ExperimentDecisionContext
+	mockExperimentService         *MockExperimentDecisionService
+}
+
+func (s *FeatureExperimentServiceTestSuite) SetupTest() {
+	mockProjectConfig := new(mockProjectConfig)
+	s.testFeatureDecisionContext = FeatureDecisionContext{
+		Feature:       &testFeat3335,
+		ProjectConfig: mockProjectConfig,
+	}
+
+	s.testExperimentDecisionContext = ExperimentDecisionContext{
+		Experiment:    &testExp1113,
+		ProjectConfig: mockProjectConfig,
+	}
+	s.mockExperimentService = new(MockExperimentDecisionService)
+}
+
+func (s *FeatureExperimentServiceTestSuite) TestGetDecision() {
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	expectedVariation := testExp1113.Variations["2223"]
+	returnExperimentDecision := ExperimentDecision{
+		Variation: &expectedVariation,
+	}
+	s.mockExperimentService.On("GetDecision", s.testExperimentDecisionContext, testUserContext).Return(returnExperimentDecision, nil)
+	featureExperimentService := &FeatureExperimentService{
+		compositeExperimentService: s.mockExperimentService,
+	}
+
+	expectedFeatureDecision := FeatureDecision{
+		Experiment: *s.testExperimentDecisionContext.Experiment,
+		Variation:  &expectedVariation,
+		Source:     FeatureTest,
+	}
+	decision, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext)
+	s.Equal(expectedFeatureDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+}
+
+// func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutext() {
+// 	testUserContext := entities.UserContext{
+// 		ID: "test_user_1",
+// 	}
+// }
+
+func TestFeatureExperimentServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(FeatureExperimentServiceTestSuite))
+}

--- a/optimizely/decision/feature_experiment_service_test.go
+++ b/optimizely/decision/feature_experiment_service_test.go
@@ -107,6 +107,11 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 	s.mockExperimentService.AssertExpectations(s.T())
 }
 
+func (s *FeatureExperimentServiceTestSuite) TestNewFeatureExperimentService() {
+	featureExperimentService := NewFeatureExperimentService()
+	s.IsType(&CompositeExperimentService{}, featureExperimentService.compositeExperimentService)
+}
+
 func TestFeatureExperimentServiceTestSuite(t *testing.T) {
 	suite.Run(t, new(FeatureExperimentServiceTestSuite))
 }

--- a/optimizely/decision/helpers_test.go
+++ b/optimizely/decision/helpers_test.go
@@ -137,13 +137,15 @@ var testFeatRollout3334 = entities.Feature{
 
 // Feature with test and rollout
 const testFeat3335Key = "test_feature_3335_key"
+
 // Will use this experiment for feature test
 const testExp1113Key = "test_experiment_1113"
+
 var testExp1113Var2223 = entities.Variation{ID: "2223", Key: "2223", FeatureEnabled: true}
 var testExp1113Var2224 = entities.Variation{ID: "2224", Key: "2224", FeatureEnabled: false}
 var testExp1113 = entities.Experiment{
-	ID:  "1113",
-	Key: testExp1113Key,
+	ID:      "1113",
+	Key:     testExp1113Key,
 	GroupID: "6666",
 	Variations: map[string]entities.Variation{
 		"2223": testExp1113Var2223,
@@ -154,12 +156,14 @@ var testExp1113 = entities.Experiment{
 		entities.Range{EntityID: "2224", EndOfRange: 10000},
 	},
 }
+
 const testExp1114Key = "test_experiment_1114"
+
 var testExp1114Var2225 = entities.Variation{ID: "2225", Key: "2225", FeatureEnabled: true}
 var testExp1114Var2226 = entities.Variation{ID: "2226", Key: "2226", FeatureEnabled: false}
 var testExp1114 = entities.Experiment{
-	ID:  "1114",
-	Key: testExp1114Key,
+	ID:      "1114",
+	Key:     testExp1114Key,
 	GroupID: "6666",
 	Variations: map[string]entities.Variation{
 		"2225": testExp1114Var2225,
@@ -171,7 +175,7 @@ var testExp1114 = entities.Experiment{
 	},
 }
 var testGroup6666 = entities.Group{
-	ID: "6666",
+	ID:     "6666",
 	Policy: "random",
 	TrafficAllocation: []entities.Range{
 		entities.Range{EntityID: "1113", EndOfRange: 3000},
@@ -181,6 +185,7 @@ var testGroup6666 = entities.Group{
 
 // Will use this experiment for rollout
 const testExp1115Key = "test_experiment_1115"
+
 var testExp1115Var2227 = entities.Variation{ID: "2227", Key: "2227", FeatureEnabled: true}
 var testExp1115 = entities.Experiment{
 	ID:  "1115",
@@ -193,11 +198,27 @@ var testExp1115 = entities.Experiment{
 	},
 }
 var testFeat3335 = entities.Feature{
-	ID: "3335",
-	Key: testFeat3335Key,
+	ID:                 "3335",
+	Key:                testFeat3335Key,
 	FeatureExperiments: []entities.Experiment{testExp1113, testExp1114},
 	Rollout: entities.Rollout{
-    	ID:          "4445",
-	    Experiments: []entities.Experiment{testExp1115},
+		ID:          "4445",
+		Experiments: []entities.Experiment{testExp1115},
+	},
+}
+
+// Targeted experiment
+const testTargetedExp1116Key = "test_targeted_experiment_1116"
+
+var testTargetedExp1116Var2228 = entities.Variation{ID: "2228", Key: "2228"}
+var testTargetedExp1116 = entities.Experiment{
+	AudienceConditionTree: &entities.TreeNode{Operator: "or", Item: "7771"},
+	ID:  "1116",
+	Key: testTargetedExp1116Key,
+	Variations: map[string]entities.Variation{
+		"2228": testTargetedExp1116Var2228,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2228", EndOfRange: 10000},
 	},
 }

--- a/optimizely/decision/rollout_service.go
+++ b/optimizely/decision/rollout_service.go
@@ -40,7 +40,9 @@ func NewRolloutService() *RolloutService {
 
 // GetDecision returns a decision for the given feature and user context
 func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
-	featureDecision := FeatureDecision{}
+	featureDecision := FeatureDecision{
+		Source: Rollout,
+	}
 	feature := decisionContext.Feature
 	rollout := feature.Rollout
 	if rollout.ID == "" {
@@ -75,6 +77,5 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 	featureDecision.Decision = decision.Decision
 	featureDecision.Experiment = experiment
 	featureDecision.Variation = decision.Variation
-
 	return featureDecision, nil
 }

--- a/optimizely/decision/rollout_service_test.go
+++ b/optimizely/decision/rollout_service_test.go
@@ -62,6 +62,7 @@ func TestRolloutServiceGetDecision(t *testing.T) {
 	expectedFeatureDecision := FeatureDecision{
 		Experiment: testExp1112,
 		Variation:  &testExp1112Var2222,
+		Source:     Rollout,
 	}
 	decision, _ := testRolloutService.GetDecision(testFeatureDecisionContext, testUserContext)
 	assert.Equal(t, expectedFeatureDecision, decision)
@@ -92,6 +93,7 @@ func TestRolloutServiceGetDecision(t *testing.T) {
 			Reason: reasons.NotBucketedIntoVariation,
 		},
 		Experiment: testExp1112,
+		Source:     Rollout,
 	}
 	decision, _ = testRolloutService.GetDecision(testFeatureDecisionContext, testUserContext)
 	assert.Equal(t, expectedFeatureDecision, decision)

--- a/optimizely/decision/rollout_service_test.go
+++ b/optimizely/decision/rollout_service_test.go
@@ -19,6 +19,8 @@ package decision
 import (
 	"testing"
 
+	"github.com/optimizely/go-sdk/optimizely/decision/evaluator"
+
 	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
 
 	"github.com/stretchr/testify/assert"
@@ -116,4 +118,10 @@ func TestRolloutServiceGetDecision(t *testing.T) {
 	assert.Nil(t, decision.Variation)
 	mockAudienceTreeEvaluator.AssertExpectations(t)
 	mockExperimentBucketerService.AssertNotCalled(t, "GetDecision")
+}
+
+func TestNewRolloutService(t *testing.T) {
+	rolloutService := NewRolloutService()
+	assert.IsType(t, &evaluator.MixedTreeEvaluator{}, rolloutService.audienceTreeEvaluator)
+	assert.IsType(t, &ExperimentBucketerService{}, rolloutService.experimentBucketerService)
 }


### PR DESCRIPTION
# Summary
- Moved the audience targeting logic into `ExperimentBucketerService` as it makes more sense to couple them.
- Refactored some of the tests to be organized around test `testify test suites` to simplify test setup
- `CompositeService` only has a `CompositeExperimentService` and a `CompositeFeatureService` instead of arrays for each type of decision service.
- Moved feature experiment logic from `CompositeFeatureService` into the `FeatureExperimentService` "class"

# Tests
- Unit tests
