### PR TITLE
(feat): add a way to create a custom event processor taking advantage of Exec…

### DIFF
--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -45,8 +45,8 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	appClient := &OptimizelyClient{
 		executionCtx:    executionCtx,
 		decisionService: decision.NewCompositeService(f.SDKKey),
-		eventProcessor:  event.NewEventProcessor(executionCtx, event.ProcessorBatchSize(event.DefaultBatchSize),
-		event.ProcessorQueueSize(event.DefaultEventQueueSize), event.ProcessorFlushInterval(event.DefaultEventFlushInterval)),
+		eventProcessor:  event.NewEventProcessor(executionCtx, event.BatchSize(event.DefaultBatchSize),
+		event.QueueSize(event.DefaultEventQueueSize), event.FlushInterval(event.DefaultEventFlushInterval)),
 	}
 
 	for _, opt := range clientOptions {
@@ -98,8 +98,8 @@ func DecisionService(decisionService decision.Service) OptionFunc {
 // BatchEventProcessor sets event processor on a client
 func BatchEventProcessor(batchSize, queueSize int, flushInterval time.Duration) OptionFunc {
 	return func(f *OptimizelyClient, executionCtx utils.ExecutionCtx) {
-		f.eventProcessor = event.NewEventProcessor(executionCtx, event.ProcessorBatchSize(batchSize),
-			event.ProcessorQueueSize(queueSize), event.ProcessorFlushInterval(flushInterval))
+		f.eventProcessor = event.NewEventProcessor(executionCtx, event.BatchSize(batchSize),
+			event.QueueSize(queueSize), event.FlushInterval(flushInterval))
 	}
 }
 

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -92,7 +92,8 @@ func DecisionService(decisionService decision.Service) OptionFunc {
 // BatchEventProcessor sets event processor on a client
 func BatchEventProcessor(batchSize, queueSize int, flushInterval time.Duration) OptionFunc {
 	return func(f *OptimizelyClient, executionCtx utils.ExecutionCtx) {
-		f.eventProcessor = event.NewEventProcessor(executionCtx, batchSize, queueSize, flushInterval)
+		f.eventProcessor = event.NewEventProcessor(executionCtx, event.ProcessorBatchSize(batchSize),
+			event.ProcessorQueueSize(queueSize), event.ProcessorFlushInterval(flushInterval))
 	}
 }
 
@@ -167,7 +168,8 @@ func (f OptimizelyFactory) ClientWithOptions(clientOptions Options) (*Optimizely
 	if clientOptions.EventProcessor != nil {
 		client.eventProcessor = clientOptions.EventProcessor
 	} else {
-		client.eventProcessor = event.NewEventProcessor(executionCtx, event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval)
+		client.eventProcessor = event.NewEventProcessor(executionCtx, event.ProcessorBatchSize(event.DefaultBatchSize),
+			event.ProcessorQueueSize(event.DefaultEventQueueSize), event.ProcessorFlushInterval(event.DefaultEventFlushInterval))
 	}
 
 	return client, nil

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -104,6 +104,19 @@ func BuildTestConversionEvent() UserEvent {
 	return conversionUserEvent
 }
 
+func TestCreateEmptyEvent(t *testing.T) {
+
+	impressionUserEvent := BuildTestImpressionEvent()
+
+	impressionUserEvent.Impression = nil
+	impressionUserEvent.Conversion = nil
+
+	visitor := createVisitorFromUserEvent(impressionUserEvent)
+
+	assert.Nil(t, visitor.Snapshots)
+
+}
+
 func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -121,7 +121,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), 10, 100, 100)
+	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), ProcessorBatchSize(10), ProcessorQueueSize(100), ProcessorFlushInterval(100))
 
 	processor.ProcessEvent(impressionUserEvent)
 
@@ -136,7 +136,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), 10, 100, 100)
+	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), ProcessorFlushInterval(100))
 
 	processor.ProcessEvent(conversionUserEvent)
 

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -121,7 +121,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), ProcessorBatchSize(10), ProcessorQueueSize(100), ProcessorFlushInterval(100))
+	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), BatchSize(10), QueueSize(100), FlushInterval(100))
 
 	processor.ProcessEvent(impressionUserEvent)
 
@@ -136,7 +136,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), ProcessorFlushInterval(100))
+	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), FlushInterval(100))
 
 	processor.ProcessEvent(conversionUserEvent)
 

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -56,6 +56,7 @@ const DefaultEventFlushInterval = 30 * time.Second
 
 var pLogger = logging.GetLogger("EventProcessor")
 
+// QPOption is the QueuingProcessor options that give you the ability to add one more more options before the processor is initialized.
 type QPOption func(qp *QueueingEventProcessor)
 
 // NewEventProcessor returns a new instance of QueueingEventProcessor with queueSize and flushInterval

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -59,35 +59,35 @@ var pLogger = logging.GetLogger("EventProcessor")
 // QPConfigOption is the QueuingProcessor options that give you the ability to add one more more options before the processor is initialized.
 type QPConfigOption func(qp *QueueingEventProcessor)
 
-// ProcessorBatchSize sets the batch size as a config option to be passed into the NewProcessor method
-func ProcessorBatchSize(bsize int) QPConfigOption {
+// BatchSize sets the batch size as a config option to be passed into the NewProcessor method
+func BatchSize(bsize int) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.BatchSize = bsize
 	}
 }
 
-// ProcessorQueueSize sets the queue size as a config option to be passed into the NewProcessor method
-func ProcessorQueueSize(qsize int) QPConfigOption {
+// QueueSize sets the queue size as a config option to be passed into the NewProcessor method
+func QueueSize(qsize int) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.MaxQueueSize = qsize
 	}
 }
 
-// ProcessorFlushInterval sets the flush interval as a config option to be passed into the NewProcessor method
-func ProcessorFlushInterval(flushInterval time.Duration) QPConfigOption {
+// FlushInterval sets the flush interval as a config option to be passed into the NewProcessor method
+func FlushInterval(flushInterval time.Duration) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.FlushInterval = flushInterval
 	}
 }
 
-// ProcessorQ sets the Queue as a config option to be passed into the NewProcessor method
-func ProcessorQ(q Queue) QPConfigOption {
+// PQ sets the Processor Queue as a config option to be passed into the NewProcessor method
+func PQ(q Queue) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.Q = q
 	}
 }
-// ProcessorDispatcher sets the dispatcher as a config option to be passed into the NewProcessor method
-func ProcessorDispatcher(d Dispatcher) QPConfigOption {
+// PDispatcher sets the Processor Dispatcher as a config option to be passed into the NewProcessor method
+func PDispatcher(d Dispatcher) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.EventDispatcher = d
 	}

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -56,33 +56,37 @@ const DefaultEventFlushInterval = 30 * time.Second
 
 var pLogger = logging.GetLogger("EventProcessor")
 
-// QPOption is the QueuingProcessor options that give you the ability to add one more more options before the processor is initialized.
+// QPConfigOption is the QueuingProcessor options that give you the ability to add one more more options before the processor is initialized.
 type QPConfigOption func(qp *QueueingEventProcessor)
 
+// ProcessorBatchSize sets the batch size as a config option to be passed into the NewProcessor method
 func ProcessorBatchSize(bsize int) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.BatchSize = bsize
 	}
 }
 
+// ProcessorQueueSize sets the queue size as a config option to be passed into the NewProcessor method
 func ProcessorQueueSize(qsize int) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.MaxQueueSize = qsize
 	}
 }
 
+// ProcessorFlushInterval sets the flush interval as a config option to be passed into the NewProcessor method
 func ProcessorFlushInterval(flushInterval time.Duration) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.FlushInterval = flushInterval
 	}
 }
 
+// ProcessorQ sets the Queue as a config option to be passed into the NewProcessor method
 func ProcessorQ(q Queue) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.Q = q
 	}
 }
-
+// ProcessorDispatcher sets the dispatcher as a config option to be passed into the NewProcessor method
 func ProcessorDispatcher(d Dispatcher) QPConfigOption {
 	return func(qp *QueueingEventProcessor) {
 		qp.EventDispatcher = d

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -65,6 +65,14 @@ func NewEventProcessor(exeCtx utils.ExecutionCtx, batchSize, queueSize int, flus
 
 // NewCustomEventProcessor returns a new QueueingEventProcessor with the queue passed in and the dispatcher passed in.
 func NewCustomEventProcessor(exeCtx utils.ExecutionCtx, batchSize, queueSize int, flushInterval time.Duration, q Queue, dispatcher Dispatcher) *QueueingEventProcessor {
+	if q == nil {
+		q = NewInMemoryQueue(queueSize)
+	}
+
+	if dispatcher == nil {
+		dispatcher = NewQueueEventDispatcher(exeCtx.GetContext())
+	}
+
 	p := &QueueingEventProcessor{
 		MaxQueueSize:    queueSize,
 		FlushInterval:   flushInterval,

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -59,12 +59,7 @@ var pLogger = logging.GetLogger("EventProcessor")
 // NewEventProcessor returns a new instance of QueueingEventProcessor with queueSize and flushInterval
 func NewEventProcessor(exeCtx utils.ExecutionCtx, batchSize, queueSize int, flushInterval time.Duration) *QueueingEventProcessor {
 	p := NewCustomEventProcessor(exeCtx, batchSize, queueSize, flushInterval, NewInMemoryQueue(queueSize), NewQueueEventDispatcher(exeCtx.GetContext()))
-	p.BatchSize = DefaultBatchSize
-	if batchSize > 0 {
-		p.BatchSize = batchSize
-	}
 
-	p.StartTicker(exeCtx.GetContext())
 	return p
 }
 
@@ -77,9 +72,11 @@ func NewCustomEventProcessor(exeCtx utils.ExecutionCtx, batchSize, queueSize int
 		EventDispatcher: dispatcher,
 		wg: exeCtx.GetWaitSync(),
 	}
-	p.BatchSize = DefaultBatchSize
+
 	if batchSize > 0 {
 		p.BatchSize = batchSize
+	} else {
+		p.BatchSize = DefaultBatchSize
 	}
 
 	p.StartTicker(exeCtx.GetContext())

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -19,10 +19,8 @@ package event
 
 import (
 	"errors"
-	"github.com/segmentio/timers"
 	"testing"
 	"time"
-
 	"github.com/optimizely/go-sdk/optimizely/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +28,7 @@ import (
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100))
+	processor := NewEventProcessor(exeCtx, FlushInterval(100))
 
 	impression := BuildTestImpressionEvent()
 
@@ -47,7 +45,7 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(10), ProcessorFlushInterval(100))
+	processor := NewEventProcessor(exeCtx, QueueSize(10), FlushInterval(100))
 
 	impression := BuildTestImpressionEvent()
 
@@ -78,8 +76,8 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100), ProcessorQueueSize(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, FlushInterval(100), QueueSize(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -109,8 +107,8 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(2), ProcessorFlushInterval(100),
-		ProcessorQ( NewInMemoryQueue(2)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(2), FlushInterval(100),
+		PQ( NewInMemoryQueue(2)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -120,7 +118,7 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 	assert.Equal(t, 2, processor.EventsCount())
 
-	timers.Sleep(exeCtx.GetContext(), 100 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -150,8 +148,8 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -178,8 +176,8 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorQ(NewInMemoryQueue(100)),
-		ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), PQ(NewInMemoryQueue(100)),
+		PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -199,8 +197,8 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -231,8 +229,8 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -263,8 +261,8 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&HTTPEventDispatcher{}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&HTTPEventDispatcher{}))
 
 	impression := BuildTestImpressionEvent()
 
@@ -280,8 +278,8 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
-		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100)
+	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100))
 
 	impression := BuildTestImpressionEvent()
 
@@ -47,7 +47,7 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 10, 100)
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(10), ProcessorFlushInterval(100))
 
 	impression := BuildTestImpressionEvent()
 
@@ -78,9 +78,9 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100), ProcessorQueueSize(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(qp.MaxQueueSize)}
 	})
 
 	impression := BuildTestImpressionEvent()
@@ -111,7 +111,7 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 2, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(2), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(2)
 		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
 	})
@@ -154,7 +154,7 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}
 	})
@@ -184,7 +184,7 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 30 * time.Second, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
 	})
@@ -207,7 +207,7 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
 	})
@@ -241,7 +241,7 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
 	})
@@ -275,7 +275,7 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &HTTPEventDispatcher{}
 	})
@@ -294,7 +294,7 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
 		qp.Q = NewInMemoryQueue(100)
 		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
 	})

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -47,7 +47,7 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewCustomEventProcessor(exeCtx, 10, 10, 100, nil, nil)
+	processor := NewEventProcessor(exeCtx, 10, 10, 100)
 
 	impression := BuildTestImpressionEvent()
 
@@ -78,15 +78,10 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(100)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -116,15 +111,10 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    2,
-		FlushInterval:   100,
-		Q:               NewInMemoryQueue(2),
-		EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(2)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 2, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(2)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -164,15 +154,10 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{ShouldFail:true, Events:NewInMemoryQueue(100)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -199,15 +184,10 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   30 * time.Second,
-		Q:               NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(100)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 30 * time.Second, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -227,15 +207,10 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(100)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -266,15 +241,10 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(100)},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -305,15 +275,10 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               NewChanQueue(100),
-		EventDispatcher: &HTTPEventDispatcher{},
-		wg:              exeCtx.GetWaitSync(),
-	}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &HTTPEventDispatcher{}
+	})
 
 	impression := BuildTestImpressionEvent()
 
@@ -329,9 +294,10 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := &QueueingEventProcessor{MaxQueueSize: 100, FlushInterval: 100, Q: NewChanQueue(100), EventDispatcher: &MockDispatcher{Events:NewInMemoryQueue(100)}, wg: exeCtx.GetWaitSync()}
-	processor.BatchSize = 10
-	processor.StartTicker(exeCtx.GetContext())
+	processor := NewEventProcessor(exeCtx, 10, 100, 100, func (qp *QueueingEventProcessor) {
+		qp.Q = NewInMemoryQueue(100)
+		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
+	})
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -78,10 +78,8 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100), ProcessorQueueSize(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(qp.MaxQueueSize)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorFlushInterval(100), ProcessorQueueSize(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -111,10 +109,8 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(2), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(2)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(2), ProcessorFlushInterval(100),
+		ProcessorQ( NewInMemoryQueue(2)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -154,10 +150,8 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -184,10 +178,8 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorQ(NewInMemoryQueue(100)),
+		ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -207,10 +199,8 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -241,10 +231,8 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -275,10 +263,8 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &HTTPEventDispatcher{}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&HTTPEventDispatcher{}))
 
 	impression := BuildTestImpressionEvent()
 
@@ -294,10 +280,8 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100), func (qp *QueueingEventProcessor) {
-		qp.Q = NewInMemoryQueue(100)
-		qp.EventDispatcher = &MockDispatcher{Events:NewInMemoryQueue(100)}
-	})
+	processor := NewEventProcessor(exeCtx, ProcessorQueueSize(100), ProcessorFlushInterval(100),
+		ProcessorQ(NewInMemoryQueue(100)), ProcessorDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()


### PR DESCRIPTION
…utionContext

This PR alters the NewEventProcessor so that you pass in EPOptionConfig for batchsize, flush interval, queue size, as well as queue or dispatcher.  This will be used in side door to create a NSQ based queue used by the event processor.  It will also allow for side door event processor that forwards to side door to be used as well.
