### PR TITLE
fix(linter): Fixed golangci-lint implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ jobs:
   include:
     - stage: 'Lint'
       install:
-        - go get github.com/golangci/golangci-lint/cmd/golangci-lint
+        - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.19.0
       script:
-        - golangci-lint run --out-format=tab --tests=false optimizely/...
+        - $GOPATH/bin/golangci-lint run --out-format=tab --tests=false optimizely/...
     - stage: 'Integration Tests'
       merge_mode: replace
       env: SDK=go
@@ -34,4 +34,3 @@ jobs:
       script:
         - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
       after_success: travis_terminate 0
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,4 @@ jobs:
       script:
         - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
       after_success: travis_terminate 0
+      

--- a/optimizely/notification/manager.go
+++ b/optimizely/notification/manager.go
@@ -18,8 +18,13 @@
 package notification
 
 import (
+	"fmt"
 	"sync/atomic"
+
+	"github.com/optimizely/go-sdk/optimizely/logging"
 )
+
+var managerLogger = logging.GetLogger("NotificationManager")
 
 // Manager is a generic interface for managing notifications of a particular type
 type Manager interface {
@@ -51,7 +56,12 @@ func (am *AtomicManager) Add(newHandler func(interface{})) (int, error) {
 // Remove removes handler with the given id
 func (am *AtomicManager) Remove(id int) {
 	handlerID := uint32(id)
-	delete(am.handlers, handlerID)
+	if _, ok := am.handlers[handlerID]; ok {
+		delete(am.handlers, handlerID)
+		return
+	}
+	managerLogger.Debug(fmt.Sprintf("Handler for id:%d not found", id))
+
 }
 
 // Send sends the notification to the registered handlers

--- a/optimizely/notification/manager.go
+++ b/optimizely/notification/manager.go
@@ -51,9 +51,7 @@ func (am *AtomicManager) Add(newHandler func(interface{})) (int, error) {
 // Remove removes handler with the given id
 func (am *AtomicManager) Remove(id int) {
 	handlerID := uint32(id)
-	if _, ok := am.handlers[handlerID]; ok {
-		delete(am.handlers, handlerID)
-	}
+	delete(am.handlers, handlerID)
 }
 
 // Send sends the notification to the registered handlers

--- a/optimizely/notification/manager_test.go
+++ b/optimizely/notification/manager_test.go
@@ -46,4 +46,7 @@ func TestAtomicManager(t *testing.T) {
 	atomicManager.Remove(result2)
 	atomicManager.Send(payload)
 	mockReceiver.AssertNumberOfCalls(t, "handleBetter", 2)
+
+	// Sanity check by calling remove with a incorrect handler id
+	atomicManager.Remove(55)
 }


### PR DESCRIPTION
1. Fixed implementation of golangci-lint as suggested in the documentation. The previously implemented way was only suggested for local installation and was flaky.
2. Made a minor fix as per linter recommendation.