### PR TITLE
feat(registry): Added service registry for retrieving instances of notif center

### DIFF
--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/client"
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/entities"
-	"github.com/optimizely/go-sdk/optimizely/notification"
 
 	"github.com/pkg/profile"
 )
@@ -41,8 +40,7 @@ func stressTest() {
 	}
 
 	// Creates a default, canceleable context
-	notificationCenter := notification.NewNotificationCenter()
-	decisionService := decision.NewCompositeService(notificationCenter)
+	decisionService := decision.NewCompositeService("sdk_key")
 
 	clientApp, err := optlyClient.Client(client.DecisionService(decisionService))
 	if err != nil {

--- a/examples/main.go
+++ b/examples/main.go
@@ -11,11 +11,10 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/entities"
 	"github.com/optimizely/go-sdk/optimizely/event"
 	"github.com/optimizely/go-sdk/optimizely/logging"
-	"github.com/optimizely/go-sdk/optimizely/notification"
 )
 
 func main() {
-
+	sdkKey := "4SLpaJA1r1pgE6T2CoMs9q"
 	logging.SetLogLevel(logging.LogLevelDebug)
 	user := entities.UserContext{
 		ID: "mike ng",
@@ -25,7 +24,7 @@ func main() {
 		},
 	}
 	optimizelyFactory := &client.OptimizelyFactory{
-		SDKKey: "4SLpaJA1r1pgE6T2CoMs9q",
+		SDKKey: sdkKey,
 	}
 
 	/************* StaticClient ********************/
@@ -46,7 +45,7 @@ func main() {
 	/************* Client ********************/
 
 	optimizelyFactory = &client.OptimizelyFactory{
-		SDKKey: "4SLpaJA1r1pgE6T2CoMs9q",
+		SDKKey: sdkKey,
 	}
 
 	optimizelyClient, err = optimizelyFactory.Client()
@@ -62,11 +61,9 @@ func main() {
 
 	/************* Setting Polling Interval ********************/
 
-	notificationCenter := notification.NewNotificationCenter()
-
 	optimizelyClient, _ = optimizelyFactory.Client(
-		client.PollingConfigManager("4SLpaJA1r1pgE6T2CoMs9q", time.Second, nil, notificationCenter),
-		client.CompositeDecisionService(notificationCenter),
+		client.PollingConfigManager(sdkKey, time.Second, nil),
+		client.CompositeDecisionService(sdkKey),
 		client.BatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 	optimizelyClient.Close()

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.12
 require (
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.7
+	github.com/pkg/profile v1.3.0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/twmb/murmur3 v1.0.0
 )
-
 
 // Work around issue wtih git.apache.org/thrift.git
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/profile v1.3.0 h1:OQIvuDgm00gWVWGTf4m4mCt6W1/0YqU7Ntg0mySWgaI=
+github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/optimizely/client/factory.go
+++ b/optimizely/client/factory.go
@@ -25,7 +25,6 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/config"
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/event"
-	"github.com/optimizely/go-sdk/optimizely/notification"
 	"github.com/optimizely/go-sdk/optimizely/utils"
 )
 
@@ -42,11 +41,10 @@ type OptionFunc func(*OptimizelyClient, utils.ExecutionCtx)
 func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClient, error) {
 
 	executionCtx := utils.NewCancelableExecutionCtx()
-	notificationCenter := notification.NewNotificationCenter()
 
 	appClient := &OptimizelyClient{
 		executionCtx:    executionCtx,
-		decisionService: decision.NewCompositeService(notificationCenter),
+		decisionService: decision.NewCompositeService(f.SDKKey),
 		eventProcessor:  event.NewEventProcessor(executionCtx, event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	}
 
@@ -61,17 +59,17 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	if appClient.configManager == nil { // if it was not passed then assign here
 
 		appClient.configManager = config.NewPollingProjectConfigManager(executionCtx, f.SDKKey,
-			config.InitialDatafile(f.Datafile), config.PollingInterval(config.DefaultPollingInterval), config.NotificationCenter(notificationCenter))
+			config.InitialDatafile(f.Datafile), config.PollingInterval(config.DefaultPollingInterval))
 	}
 
 	return appClient, nil
 }
 
 // PollingConfigManager sets polling config manager on a client
-func PollingConfigManager(sdkKey string, pollingInterval time.Duration, initDataFile []byte, notificationCenter notification.Center) OptionFunc {
+func PollingConfigManager(sdkKey string, pollingInterval time.Duration, initDataFile []byte) OptionFunc {
 	return func(f *OptimizelyClient, executionCtx utils.ExecutionCtx) {
 		f.configManager = config.NewPollingProjectConfigManager(f.executionCtx, sdkKey, config.InitialDatafile(initDataFile),
-			config.PollingInterval(pollingInterval), config.NotificationCenter(notificationCenter))
+			config.PollingInterval(pollingInterval))
 	}
 }
 
@@ -83,9 +81,9 @@ func ConfigManager(configManager optimizely.ProjectConfigManager) OptionFunc {
 }
 
 // CompositeDecisionService sets decision service on a client
-func CompositeDecisionService(notificationCenter notification.Center) OptionFunc {
+func CompositeDecisionService(sdkKey string) OptionFunc {
 	return func(f *OptimizelyClient, executionCtx utils.ExecutionCtx) {
-		f.decisionService = decision.NewCompositeService(notificationCenter)
+		f.decisionService = decision.NewCompositeService(sdkKey)
 	}
 }
 
@@ -133,11 +131,9 @@ func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 		configManager = staticConfigManager
 	}
 
-	notificationCenter := notification.NewNotificationCenter()
-
 	optlyClient, e := f.Client(
 		ConfigManager(configManager),
-		CompositeDecisionService(notificationCenter),
+		CompositeDecisionService(f.SDKKey),
 		BatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 	return optlyClient, e

--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/config/datafileprojectconfig"
 	"github.com/optimizely/go-sdk/optimizely/logging"
 	"github.com/optimizely/go-sdk/optimizely/notification"
+	"github.com/optimizely/go-sdk/optimizely/registry"
 	"github.com/optimizely/go-sdk/optimizely/utils"
 )
 
@@ -75,13 +76,6 @@ func Requester(requester utils.Requester) OptionFunc {
 func PollingInterval(interval time.Duration) OptionFunc {
 	return func(p *PollingProjectConfigManager) {
 		p.pollingInterval = interval
-	}
-}
-
-// NotificationCenter is an optional function, sets a passed notification
-func NotificationCenter(notificationCenter notification.Center) OptionFunc {
-	return func(p *PollingProjectConfigManager) {
-		p.notificationCenter = notificationCenter
 	}
 }
 
@@ -152,7 +146,12 @@ func (cm *PollingProjectConfigManager) start() {
 func NewPollingProjectConfigManager(exeCtx utils.ExecutionCtx, sdkKey string, pollingMangerOptions ...OptionFunc) *PollingProjectConfigManager {
 	url := fmt.Sprintf(DatafileURLTemplate, sdkKey)
 
-	pollingProjectConfigManager := PollingProjectConfigManager{exeCtx: exeCtx, pollingInterval: DefaultPollingInterval, requester: utils.NewHTTPRequester(url)}
+	pollingProjectConfigManager := PollingProjectConfigManager{
+		exeCtx:             exeCtx,
+		notificationCenter: registry.GetNotificationCenter(sdkKey),
+		pollingInterval:    DefaultPollingInterval,
+		requester:          utils.NewHTTPRequester(url),
+	}
 
 	for _, opt := range pollingMangerOptions {
 		opt(&pollingProjectConfigManager)

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -132,7 +132,7 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester), NotificationCenter(notification.NewNotificationCenter()))
+	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
 
 	var numberOfCalls = 0
 	callback := func(notification notification.ProjectConfigUpdateNotification) {

--- a/optimizely/decision/composite_service.go
+++ b/optimizely/decision/composite_service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/entities"
 	"github.com/optimizely/go-sdk/optimizely/logging"
 	"github.com/optimizely/go-sdk/optimizely/notification"
+	"github.com/optimizely/go-sdk/optimizely/registry"
 )
 
 var csLogger = logging.GetLogger("CompositeDecisionService")
@@ -35,14 +36,14 @@ type CompositeService struct {
 }
 
 // NewCompositeService returns a new instance of the CompositeService with the defaults
-func NewCompositeService(notificationCenter notification.Center) *CompositeService {
+func NewCompositeService(sdkKey string) *CompositeService {
 	// @TODO: add factory method with option funcs to accept custom feature and experiment services
 	compositeFeatureDecisionService := NewCompositeFeatureService()
 	compositeExperimentService := NewCompositeExperimentService()
 	return &CompositeService{
 		compositeExperimentService: compositeExperimentService,
 		compositeFeatureService:    compositeFeatureDecisionService,
-		notificationCenter:         notificationCenter,
+		notificationCenter:         registry.GetNotificationCenter(sdkKey),
 	}
 }
 

--- a/optimizely/decision/composite_service_test.go
+++ b/optimizely/decision/composite_service_test.go
@@ -92,7 +92,7 @@ func (s *CompositeServiceTestSuite) TestDecisionListeners() {
 
 func (s *CompositeServiceTestSuite) TestNewCompositeService() {
 	notificationCenter := notification.NewNotificationCenter()
-	compositeService := NewCompositeService(notificationCenter)
+	compositeService := NewCompositeService("sdk_key")
 	s.Equal(notificationCenter, compositeService.notificationCenter)
 	s.IsType(&CompositeExperimentService{}, compositeService.compositeExperimentService)
 	s.IsType(&CompositeFeatureService{}, compositeService.compositeFeatureService)

--- a/optimizely/registry/service.go
+++ b/optimizely/registry/service.go
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package registry
+
+import (
+	"github.com/optimizely/go-sdk/optimizely/notification"
+)
+
+var notificationCenterCache = make(map[string]notification.Center)
+
+// GetNotificationCenter returns the notification center instance associated with the given SDK Key or creates a new one if not found
+func GetNotificationCenter(sdkKey string) notification.Center {
+	var notificationCenter notification.Center
+	var ok bool
+	if notificationCenter, ok = notificationCenterCache[sdkKey]; !ok {
+		notificationCenter = notification.NewNotificationCenter()
+		notificationCenterCache[sdkKey] = notificationCenter
+	}
+
+	return notificationCenter
+}

--- a/optimizely/registry/service.go
+++ b/optimizely/registry/service.go
@@ -14,6 +14,7 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
+// Package registry is the global access point for retrieving instances of services by SDK Key //
 package registry
 
 import (

--- a/optimizely/registry/service_test.go
+++ b/optimizely/registry/service_test.go
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ServiceRegistryTestSuite struct {
+	suite.Suite
+}
+
+func (s *ServiceRegistryTestSuite) TestGetNotificationCenter() {
+	// empty state, make sure we get a new notification center
+	sdkKey := "sdk_key_1"
+	notificationCenter := GetNotificationCenter(sdkKey)
+	s.NotNil(notificationCenter)
+
+	notificationCenter2 := GetNotificationCenter(sdkKey)
+	s.Equal(notificationCenter, notificationCenter2)
+}
+
+func TestServiceRegistryTestSuite(t *testing.T) {
+	suite.Run(t, new(ServiceRegistryTestSuite))
+}


### PR DESCRIPTION
# Summary
- Refactors how we construct top-level components with the notification center
- This simplifies the initialization code for PollingConfigManager and DecisionService because now they don't need to know about the internal notification center

# Tests
- Unit tests (missing) for the service registry