### PR TITLE
feat(activate): Add Activate and GetVariation APIs.

### DIFF
--- a/optimizely/client/client.go
+++ b/optimizely/client/client.go
@@ -410,24 +410,23 @@ func (o *OptimizelyClient) Track(eventKey string, userContext entities.UserConte
 		}
 	}()
 
-	projectConfig, err := o.GetProjectConfig()
-	if err != nil {
-		logger.Error("Optimizely SDK tracking error", err)
-		return err
+	projectConfig, e := o.GetProjectConfig()
+	if e != nil {
+		logger.Error("Optimizely SDK tracking error", e)
+		return e
 	}
 
-	configEvent, err := projectConfig.GetEventByKey(eventKey)
+	configEvent, e := projectConfig.GetEventByKey(eventKey)
 
-	if err == nil {
-		userEvent := event.CreateConversionUserEvent(projectConfig, configEvent, userContext, eventTags)
-		o.eventProcessor.ProcessEvent(userEvent)
-	} else {
+	if e != nil {
 		errorMessage := fmt.Sprintf(`optimizely SDK track: error getting event with key "%s"`, eventKey)
-		logger.Error(errorMessage, err)
-		return err
+		logger.Error(errorMessage, e)
+		return e
 	}
 
-	return err
+	userEvent := event.CreateConversionUserEvent(projectConfig, configEvent, userContext, eventTags)
+	o.eventProcessor.ProcessEvent(userEvent)
+	return nil
 }
 
 func (o *OptimizelyClient) getFeatureDecision(featureKey string, userContext entities.UserContext) (decisionContext decision.FeatureDecisionContext, featureDecision decision.FeatureDecision, err error) {
@@ -470,7 +469,6 @@ func (o *OptimizelyClient) getFeatureDecision(featureKey string, userContext ent
 
 	featureDecision, err = o.decisionService.GetFeatureDecision(decisionContext, userContext)
 	if err != nil {
-		err = nil
 		logger.Warning("error making a decision")
 		return decisionContext, featureDecision, err
 	}
@@ -502,7 +500,6 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 
 	experimentDecision, err = o.decisionService.GetExperimentDecision(decisionContext, userContext)
 	if err != nil {
-		err = nil
 		logger.Warning(fmt.Sprintf(`error making a decision for experiment "%s"`, experimentKey))
 		return decisionContext, experimentDecision, err
 	}

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -1655,9 +1655,9 @@ func (s *ClientTestSuiteAB) TestActivate() {
 	s.mockEventProcessor.On("ProcessEvent", mock.AnythingOfType("event.UserEvent"))
 
 	testClient := OptimizelyClient{
-		configManager:   s.mockConfigManager,
-		decisionService: s.mockDecisionService,
-		eventProcessor:  s.mockEventProcessor,
+		ConfigManager:   s.mockConfigManager,
+		DecisionService: s.mockDecisionService,
+		EventProcessor:  s.mockEventProcessor,
 	}
 
 	variationKey, err := testClient.Activate("test_exp_1", testUserContext)
@@ -1672,8 +1672,8 @@ func (s *ClientTestSuiteAB) TestActivatePanics() {
 	// ensure that we recover if the SDK panics while getting variation
 	testUserContext := entities.UserContext{}
 	testClient := OptimizelyClient{
-		configManager:   new(PanickingConfigManager),
-		decisionService: s.mockDecisionService,
+		ConfigManager:   new(PanickingConfigManager),
+		DecisionService: s.mockDecisionService,
 	}
 
 	variationKey, err := testClient.Activate("test_exp_1", testUserContext)
@@ -1698,8 +1698,8 @@ func (s *ClientTestSuiteAB) TestGetVariation() {
 	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext).Return(expectedExperimentDecision, nil)
 
 	testClient := OptimizelyClient{
-		configManager:   s.mockConfigManager,
-		decisionService: s.mockDecisionService,
+		ConfigManager:   s.mockConfigManager,
+		DecisionService: s.mockDecisionService,
 	}
 
 	variationKey, err := testClient.GetVariation("test_exp_1", testUserContext)
@@ -1714,8 +1714,8 @@ func (s *ClientTestSuiteAB) TestGetVariationPanics() {
 	// ensure that we recover if the SDK panics while getting variation
 	testUserContext := entities.UserContext{}
 	testClient := OptimizelyClient{
-		configManager:   new(PanickingConfigManager),
-		decisionService: s.mockDecisionService,
+		ConfigManager:   new(PanickingConfigManager),
+		DecisionService: s.mockDecisionService,
 	}
 
 	variationKey, err := testClient.GetVariation("test_exp_1", testUserContext)

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -1529,7 +1529,7 @@ func TestGetFeatureDecisionErrFeatureDecision(t *testing.T) {
 	}
 
 	_, _, err := client.getFeatureDecision(testFeatureKey, testUserContext)
-	assert.Nil(t, err)
+	assert.Error(t, err)
 }
 
 func TestGetAllFeatureVariables(t *testing.T) {
@@ -1657,6 +1657,19 @@ func (s *ClientTestSuiteAB) TestActivate() {
 	s.mockConfig.AssertExpectations(s.T())
 	s.mockDecisionService.AssertExpectations(s.T())
 	s.mockEventProcessor.AssertExpectations(s.T())
+}
+
+func (s *ClientTestSuiteAB) TestActivatePanics() {
+	// ensure that we recover if the SDK panics while getting variation
+	testUserContext := entities.UserContext{}
+	testClient := OptimizelyClient{
+		configManager:   new(PanickingConfigManager),
+		decisionService: s.mockDecisionService,
+	}
+
+	variationKey, err := testClient.Activate("test_exp_1", testUserContext)
+	s.Equal("", variationKey)
+	s.EqualError(err, "I'm panicking")
 }
 
 func (s *ClientTestSuiteAB) TestGetVariation() {

--- a/optimizely/client/fixtures_test.go
+++ b/optimizely/client/fixtures_test.go
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package client //
+package client
+
+import (
+	"github.com/optimizely/go-sdk/optimizely"
+	"github.com/optimizely/go-sdk/optimizely/decision"
+	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/optimizely/go-sdk/optimizely/event"
+	"github.com/optimizely/go-sdk/optimizely/notification"
+	"github.com/stretchr/testify/mock"
+)
+
+/**
+ * This file provides mocks and other test fixtures to facilitate our test scenarios
+ */
+
+type MockProjectConfig struct {
+	optimizely.ProjectConfig
+	mock.Mock
+}
+
+func (c *MockProjectConfig) GetEventByKey(string) (entities.Event, error) {
+	args := c.Called()
+	return args.Get(0).(entities.Event), args.Error(1)
+}
+
+func (c *MockProjectConfig) GetExperimentByKey(experimentKey string) (entities.Experiment, error) {
+	args := c.Called(experimentKey)
+	return args.Get(0).(entities.Experiment), args.Error(1)
+}
+
+func (c *MockProjectConfig) GetFeatureByKey(featureKey string) (entities.Feature, error) {
+	args := c.Called(featureKey)
+	return args.Get(0).(entities.Feature), args.Error(1)
+}
+
+func (c *MockProjectConfig) GetFeatureList() []entities.Feature {
+	args := c.Called()
+	return args.Get(0).([]entities.Feature)
+}
+
+func (c *MockProjectConfig) GetVariableByKey(featureKey string, variableKey string) (entities.Variable, error) {
+	args := c.Called(featureKey, variableKey)
+	return args.Get(0).(entities.Variable), args.Error(1)
+}
+
+func (c *MockProjectConfig) GetProjectID() string {
+	return "15389410617"
+}
+func (c *MockProjectConfig) GetRevision() string {
+	return "7"
+}
+func (c *MockProjectConfig) GetAccountID() string {
+	return "8362480420"
+}
+func (c *MockProjectConfig) GetAnonymizeIP() bool {
+	return true
+}
+func (c *MockProjectConfig) GetBotFiltering() bool {
+	return false
+}
+
+type MockDecisionService struct {
+	decision.Service
+	mock.Mock
+}
+
+func (m *MockDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext) (decision.FeatureDecision, error) {
+	args := m.Called(decisionContext, userContext)
+	return args.Get(0).(decision.FeatureDecision), args.Error(1)
+}
+
+func (m *MockDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext) (decision.ExperimentDecision, error) {
+	args := m.Called(decisionContext, userContext)
+	return args.Get(0).(decision.ExperimentDecision), args.Error(1)
+}
+
+type MockEventProcessor struct {
+	event.Processor
+	mock.Mock
+}
+
+func (m *MockEventProcessor) ProcessEvent(userEvent event.UserEvent) {
+	m.Called(userEvent)
+}
+
+type PanickingConfigManager struct {
+}
+
+func (m *PanickingConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
+	panic("I'm panicking")
+}
+
+type PanickingDecisionService struct {
+}
+
+func (m *PanickingDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext) (decision.FeatureDecision, error) {
+	panic("I'm panicking")
+}
+
+func (m *PanickingDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext) (decision.ExperimentDecision, error) {
+	panic("I'm panicking")
+}
+
+func (m *PanickingDecisionService) OnDecision(callback func(notification.DecisionNotification)) (int, error) {
+	panic("I'm panicking")
+}
+
+func (m *PanickingDecisionService) RemoveOnDecision(id int) error {
+	panic("I'm panicking")
+}
+
+// Helper methods for creating test entities
+func getTestExperiment(experimentKey string) entities.Experiment {
+	return entities.Experiment{
+		Key: experimentKey,
+		Variations: map[string]entities.Variation{
+			"v1": entities.Variation{Key: "v1"},
+			"v2": entities.Variation{Key: "v2"},
+		},
+	}
+}

--- a/optimizely/client/fixtures_test.go
+++ b/optimizely/client/fixtures_test.go
@@ -101,6 +101,7 @@ func (m *MockEventProcessor) ProcessEvent(userEvent event.UserEvent) {
 }
 
 type PanickingConfigManager struct {
+	optimizely.ProjectConfigManager
 }
 
 func (m *PanickingConfigManager) GetConfig() (optimizely.ProjectConfig, error) {

--- a/optimizely/decision/composite_feature_service.go
+++ b/optimizely/decision/composite_feature_service.go
@@ -32,10 +32,10 @@ type CompositeFeatureService struct {
 }
 
 // NewCompositeFeatureService returns a new instance of the CompositeFeatureService
-func NewCompositeFeatureService() *CompositeFeatureService {
+func NewCompositeFeatureService(compositeExperimentService ExperimentService) *CompositeFeatureService {
 	return &CompositeFeatureService{
 		featureServices: []FeatureService{
-			NewFeatureExperimentService(),
+			NewFeatureExperimentService(compositeExperimentService),
 			NewRolloutService(),
 		},
 	}

--- a/optimizely/decision/composite_feature_service_test.go
+++ b/optimizely/decision/composite_feature_service_test.go
@@ -100,9 +100,10 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionFallthrough() {
 
 func (s *CompositeFeatureServiceTestSuite) TestNewCompositeFeatureService() {
 	// Assert that the service is instantiated with the correct child services in the right order
-	compositeFeatureService := NewCompositeFeatureService()
+	compositeExperimentService := NewCompositeExperimentService()
+	compositeFeatureService := NewCompositeFeatureService(compositeExperimentService)
 	s.Equal(2, len(compositeFeatureService.featureServices))
-	s.IsType(&FeatureExperimentService{}, compositeFeatureService.featureServices[0])
+	s.IsType(&FeatureExperimentService{compositeExperimentService: compositeExperimentService}, compositeFeatureService.featureServices[0])
 	s.IsType(&RolloutService{}, compositeFeatureService.featureServices[1])
 }
 

--- a/optimizely/decision/composite_service.go
+++ b/optimizely/decision/composite_service.go
@@ -80,7 +80,9 @@ func (s CompositeService) GetFeatureDecision(featureDecisionContext FeatureDecis
 
 // GetExperimentDecision returns a decision for the given experiment key
 func (s CompositeService) GetExperimentDecision(experimentDecisionContext ExperimentDecisionContext, userContext entities.UserContext) (experimentDecision ExperimentDecision, err error) {
-	experimentDecision, err = s.compositeExperimentService.GetDecision(experimentDecisionContext, userContext)
+	if experimentDecision, err = s.compositeExperimentService.GetDecision(experimentDecisionContext, userContext); err != nil {
+		return experimentDecision, err
+	}
 
 	if s.notificationCenter != nil && experimentDecision.Variation != nil {
 		decisionInfo := map[string]interface{}{

--- a/optimizely/decision/feature_experiment_service.go
+++ b/optimizely/decision/feature_experiment_service.go
@@ -29,9 +29,9 @@ type FeatureExperimentService struct {
 }
 
 // NewFeatureExperimentService returns a new instance of the FeatureExperimentService
-func NewFeatureExperimentService() *FeatureExperimentService {
+func NewFeatureExperimentService(compositeExperimentService ExperimentService) *FeatureExperimentService {
 	return &FeatureExperimentService{
-		compositeExperimentService: NewCompositeExperimentService(),
+		compositeExperimentService: compositeExperimentService,
 	}
 }
 

--- a/optimizely/decision/feature_experiment_service_test.go
+++ b/optimizely/decision/feature_experiment_service_test.go
@@ -108,8 +108,9 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 }
 
 func (s *FeatureExperimentServiceTestSuite) TestNewFeatureExperimentService() {
-	featureExperimentService := NewFeatureExperimentService()
-	s.IsType(&CompositeExperimentService{}, featureExperimentService.compositeExperimentService)
+	compositeExperimentService := &CompositeExperimentService{}
+	featureExperimentService := NewFeatureExperimentService(compositeExperimentService)
+	s.IsType(compositeExperimentService, featureExperimentService.compositeExperimentService)
 }
 
 func TestFeatureExperimentServiceTestSuite(t *testing.T) {

--- a/optimizely/decision/interface.go
+++ b/optimizely/decision/interface.go
@@ -25,6 +25,7 @@ import (
 // Service interface is used to make a decision for a given feature or experiment
 type Service interface {
 	GetFeatureDecision(FeatureDecisionContext, entities.UserContext) (FeatureDecision, error)
+	GetExperimentDecision(ExperimentDecisionContext, entities.UserContext) (ExperimentDecision, error)
 	OnDecision(func(notification.DecisionNotification)) (int, error)
 	RemoveOnDecision(id int) error
 }

--- a/optimizely/notification/entities.go
+++ b/optimizely/notification/entities.go
@@ -30,6 +30,9 @@ const (
 	Decision Type = "decision"
 	// ProjectConfigUpdate notification type
 	ProjectConfigUpdate Type = "project_config_update"
+
+	// ABTest is used when the decision is returned as part of evaluating an ab test
+	ABTest DecisionNotificationType = "ab-test"
 	// Feature is used when the decision is returned as part of evaluating a feature
 	Feature DecisionNotificationType = "feature"
 )


### PR DESCRIPTION
# Summary
- Add `Activate` API for A/B tests
- Add `GetVariation` API for A/B tests
- Introduced test suites and test fixtures for client package testing
- Adds Decision notifications for both

# Tests
- Unit

Address #59 