### PR TITLE
refac(test): Move some client tests into test suite.

### DIFF
--- a/optimizely/client/fixtures_test.go
+++ b/optimizely/client/fixtures_test.go
@@ -18,6 +18,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/optimizely/go-sdk/optimizely"
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/entities"
@@ -128,7 +130,7 @@ func (m *PanickingDecisionService) RemoveOnDecision(id int) error {
 }
 
 // Helper methods for creating test entities
-func getTestExperiment(experimentKey string) entities.Experiment {
+func makeTestExperiment(experimentKey string) entities.Experiment {
 	return entities.Experiment{
 		Key: experimentKey,
 		Variations: map[string]entities.Variation{
@@ -136,4 +138,34 @@ func getTestExperiment(experimentKey string) entities.Experiment {
 			"v2": entities.Variation{Key: "v2"},
 		},
 	}
+}
+
+func makeTestVariation(variationKey string, featureEnabled bool) entities.Variation {
+	return entities.Variation{
+		ID:             fmt.Sprintf("test_variation_%s", variationKey),
+		Key:            variationKey,
+		FeatureEnabled: featureEnabled,
+	}
+}
+
+func makeTestExperimentWithVariations(experimentKey string, variations []entities.Variation) entities.Experiment {
+	variationsMap := make(map[string]entities.Variation)
+	for _, variation := range variations {
+		variationsMap[variation.ID] = variation
+	}
+	return entities.Experiment{
+		Key:        experimentKey,
+		ID:         fmt.Sprintf("test_experiment_%s", experimentKey),
+		Variations: variationsMap,
+	}
+}
+
+func makeTestFeatureWithExperiment(featureKey string, experiment entities.Experiment) entities.Feature {
+	testFeature := entities.Feature{
+		ID:                 fmt.Sprintf("test_feature_%s", featureKey),
+		Key:                featureKey,
+		FeatureExperiments: []entities.Experiment{experiment},
+	}
+
+	return testFeature
 }

--- a/optimizely/entities/experiment.go
+++ b/optimizely/entities/experiment.go
@@ -31,7 +31,7 @@ type Experiment struct {
 	ID                    string
 	LayerID               string
 	Key                   string
-	Variations            map[string]Variation
+	Variations            map[string]Variation // keyed by variation ID
 	TrafficAllocation     []Range
 	GroupID               string
 	AudienceConditionTree *TreeNode


### PR DESCRIPTION
# Summary
- Moves tests into a suite with reused setup steps to avoid code duplication
- Introduces helper test functions for creating entities