### PR TITLE
feat(notif): Add notification handlers from factory methods.

### DIFF
--- a/optimizely/config/polling_manager.go
+++ b/optimizely/config/polling_manager.go
@@ -86,6 +86,14 @@ func InitialDatafile(datafile []byte) OptionFunc {
 	}
 }
 
+// WithProjectConfigUpdateCallback is an optional function that adds a callback for project config updates
+// @TODO: refactor all other OptionFunc to be prefixed with "With"
+func WithProjectConfigUpdateCallback(callback func(notification.ProjectConfigUpdateNotification)) OptionFunc {
+	return func(p *PollingProjectConfigManager) {
+		p.OnProjectConfigUpdate(callback)
+	}
+}
+
 // SyncConfig gets current datafile and updates projectConfig
 func (cm *PollingProjectConfigManager) SyncConfig(datafile []byte) {
 	var e error

--- a/optimizely/decision/composite_service_test.go
+++ b/optimizely/decision/composite_service_test.go
@@ -19,6 +19,7 @@ package decision
 import (
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/optimizely/go-sdk/optimizely/entities"
@@ -115,6 +116,25 @@ func (s *CompositeServiceExperimentTestSuite) SetupTest() {
 	s.testUserContext = entities.UserContext{
 		ID: "test_user",
 	}
+}
+
+func (s *CompositeServiceExperimentTestSuite) TestConstructorWithOptions() {
+	listener := new(mockListener)
+	listener.On("callback", mock.AnythingOfType("notification.DecisionNotification"))
+
+	expectedExperimentDecision := ExperimentDecision{
+		Variation: &testExp1111Var2222,
+	}
+	s.mockExperimentService.On("GetDecision", s.decisionContext, s.testUserContext).Return(expectedExperimentDecision, nil)
+
+	decisionService := NewCompositeService("test_sdk_key", WithExperimentService(s.mockExperimentService), WithDecisionCallback(listener.callback))
+	experimentDecision, err := decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext)
+
+	// Test assertions
+	s.Equal(expectedExperimentDecision, experimentDecision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+	listener.AssertExpectations(s.T())
 }
 
 func (s *CompositeServiceExperimentTestSuite) TestGetExperimentDecision() {

--- a/optimizely/decision/helpers_test.go
+++ b/optimizely/decision/helpers_test.go
@@ -22,9 +22,11 @@
 package decision
 
 import (
+	"github.com/stretchr/testify/mock"
+
 	"github.com/optimizely/go-sdk/optimizely"
 	"github.com/optimizely/go-sdk/optimizely/entities"
-	"github.com/stretchr/testify/mock"
+	"github.com/optimizely/go-sdk/optimizely/notification"
 )
 
 // Mock implementation of ProjectConfig
@@ -78,6 +80,14 @@ type MockAudienceTreeEvaluator struct {
 func (m *MockAudienceTreeEvaluator) Evaluate(node *entities.TreeNode, condTreeParams *entities.TreeParameters) bool {
 	args := m.Called(node, condTreeParams)
 	return args.Bool(0)
+}
+
+type mockListener struct {
+	mock.Mock
+}
+
+func (m *mockListener) callback(payload notification.DecisionNotification) {
+	m.Called(payload)
 }
 
 // Single variation experiment
@@ -213,8 +223,8 @@ const testTargetedExp1116Key = "test_targeted_experiment_1116"
 var testTargetedExp1116Var2228 = entities.Variation{ID: "2228", Key: "2228"}
 var testTargetedExp1116 = entities.Experiment{
 	AudienceConditionTree: &entities.TreeNode{Operator: "or", Item: "7771"},
-	ID:  "1116",
-	Key: testTargetedExp1116Key,
+	ID:                    "1116",
+	Key:                   testTargetedExp1116Key,
 	Variations: map[string]entities.Variation{
 		"2228": testTargetedExp1116Var2228,
 	},


### PR DESCRIPTION
# Summary
- Introduce option func for adding notification callbacks in the DecisionService and ConfigManager
- Introduces a new option func paradigm where the func name is prepended with `With` to avoid naming collisions as well as making it more apparent that they are option func methods.

# Tests
- Unit