### PR TITLE
feat: Add ExperimentWhitelistService

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         - $GOPATH/bin/golangci-lint run --out-format=tab --tests=false optimizely/...
     - stage: 'Integration Tests'
       merge_mode: replace
-      env: SDK=go
+      env: SDK=go SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
       cache: false
       language: minimal
       install: skip
@@ -29,7 +29,7 @@ jobs:
       after_success: travis_terminate 0
     - &test
       stage: 'Unit test'
-      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64      
+      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
       script:
         - go test -v -race ./... -coverprofile=profile.cov
     - <<: *test
@@ -48,7 +48,7 @@ jobs:
     - <<: *test
       stage: 'Unit test'
       env: GIMME_GO_VERSION=1.12.x
-      before_script:      
+      before_script:
         - go get github.com/mattn/goveralls
       after_success:
         - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ jobs:
       before_script:
         - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
       script:
-        - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
+        # TODO: Remove sohail/gosdkonly branch specification here, after
+        # we can run FSC tests on master: https://optimizely.atlassian.net/browse/OASIS-5425
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh sohail/gosdkonly
       after_success: travis_terminate 0
     - &test
       stage: 'Unit test'

--- a/optimizely/config/datafileprojectconfig/mappers/experiment.go
+++ b/optimizely/config/datafileprojectconfig/mappers/experiment.go
@@ -63,13 +63,13 @@ func mapExperiment(rawExperiment datafileEntities.Experiment) entities.Experimen
 	}
 
 	experiment := entities.Experiment{
-		AudienceIds:             rawExperiment.AudienceIds,
-		ID:                      rawExperiment.ID,
-		Key:                     rawExperiment.Key,
-		Variations:              make(map[string]entities.Variation),
-		TrafficAllocation:       make([]entities.Range, len(rawExperiment.TrafficAllocation)),
-		AudienceConditionTree:   audienceConditionTree,
-		UserIDToVariationKeyMap: rawExperiment.ForcedVariations,
+		AudienceIds:           rawExperiment.AudienceIds,
+		ID:                    rawExperiment.ID,
+		Key:                   rawExperiment.Key,
+		Variations:            make(map[string]entities.Variation),
+		TrafficAllocation:     make([]entities.Range, len(rawExperiment.TrafficAllocation)),
+		AudienceConditionTree: audienceConditionTree,
+		Whitelist:             rawExperiment.ForcedVariations,
 	}
 
 	for _, variation := range rawExperiment.Variations {

--- a/optimizely/config/datafileprojectconfig/mappers/experiment.go
+++ b/optimizely/config/datafileprojectconfig/mappers/experiment.go
@@ -63,12 +63,13 @@ func mapExperiment(rawExperiment datafileEntities.Experiment) entities.Experimen
 	}
 
 	experiment := entities.Experiment{
-		AudienceIds:           rawExperiment.AudienceIds,
-		ID:                    rawExperiment.ID,
-		Key:                   rawExperiment.Key,
-		Variations:            make(map[string]entities.Variation),
-		TrafficAllocation:     make([]entities.Range, len(rawExperiment.TrafficAllocation)),
-		AudienceConditionTree: audienceConditionTree,
+		AudienceIds:             rawExperiment.AudienceIds,
+		ID:                      rawExperiment.ID,
+		Key:                     rawExperiment.Key,
+		Variations:              make(map[string]entities.Variation),
+		TrafficAllocation:       make([]entities.Range, len(rawExperiment.TrafficAllocation)),
+		AudienceConditionTree:   audienceConditionTree,
+		UserIDToVariationKeyMap: rawExperiment.ForcedVariations,
 	}
 
 	for _, variation := range rawExperiment.Variations {

--- a/optimizely/decision/composite_experiment_service.go
+++ b/optimizely/decision/composite_experiment_service.go
@@ -29,10 +29,12 @@ type CompositeExperimentService struct {
 // NewCompositeExperimentService creates a new instance of the CompositeExperimentService
 func NewCompositeExperimentService() *CompositeExperimentService {
 	// These decision services are applied in order:
-	// 1. Bucketing
-	// @TODO(mng): Prepend forced variation and whitelisting services
+	// 1. Whitelist
+	// 2. Bucketing
+	// @TODO(mng): Prepend forced variation
 	return &CompositeExperimentService{
 		experimentServices: []ExperimentService{
+			NewExperimentWhitelistService(),
 			NewExperimentBucketerService(),
 		},
 	}

--- a/optimizely/decision/composite_experiment_service_test.go
+++ b/optimizely/decision/composite_experiment_service_test.go
@@ -115,6 +115,14 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionNoDecisionsMade() {
 	s.mockExperimentService2.AssertExpectations(s.T())
 }
 
+func (s *CompositeExperimentTestSuite) TestNewCompositeExperimentService() {
+	// Assert that the service is instantiated with the correct child services in the right order
+	compositeExperimentService := NewCompositeExperimentService()
+	s.Equal(2, len(compositeExperimentService.experimentServices))
+	s.IsType(&ExperimentWhitelistService{}, compositeExperimentService.experimentServices[0])
+	s.IsType(&ExperimentBucketerService{}, compositeExperimentService.experimentServices[1])
+}
+
 func TestCompositeExperimentTestSuite(t *testing.T) {
 	suite.Run(t, new(CompositeExperimentTestSuite))
 }

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ExperimentWhitelistService makes a decision using a whitelist (a set of experiment + variation assignments for a set of users)
-// whitelist should be a map of user ID, to a map of Experiment key to Variation key
+// whitelist should be a map of experiment key, to a map of user ID to Variation key
 type ExperimentWhitelistService struct {
 	whitelist map[string]map[string]string
 }
@@ -38,7 +38,7 @@ func NewExperimentWhitelistService(whitelist map[string]map[string]string) *Expe
 	}
 }
 
-// GetDecision returns a decision with a variation when an entry is found for a given user ID and experiment key
+// GetDecision returns a decision with a variation when an entry is found for a given experiment key and user ID
 func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (decision ExperimentDecision, err error) {
 	if decisionContext.Experiment == nil {
 		return decision, errors.New("decisionContext Experiment is nil")
@@ -49,13 +49,13 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 		return decision, fmt.Errorf("error looking up experiment in decision context: %v", err)
 	}
 
-	userEntry, ok := s.whitelist[userContext.ID]
+	experimentEntry, ok := s.whitelist[decisionContext.Experiment.Key]
 	if !ok {
 		decision.Reason = reasons.NoWhitelistVariationAssignment
 		return decision, nil
 	}
 
-	variationKey, ok := userEntry[decisionContext.Experiment.Key]
+	variationKey, ok := experimentEntry[userContext.ID]
 	if !ok {
 		decision.Reason = reasons.NoWhitelistVariationAssignment
 		return decision, nil

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -19,7 +19,6 @@ package decision
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
 	"github.com/optimizely/go-sdk/optimizely/entities"
@@ -41,25 +40,19 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 		return decision, errors.New("decisionContext Experiment is nil")
 	}
 
-	experiment, err := decisionContext.ProjectConfig.GetExperimentByKey(decisionContext.Experiment.Key)
-	if err != nil {
-		return decision, fmt.Errorf("error looking up experiment in decision context: %v", err)
-	}
-
-	variationKey, ok := experiment.UserIDToVariationKeyMap[userContext.ID]
+	variationKey, ok := decisionContext.Experiment.UserIDToVariationKeyMap[userContext.ID]
 	if !ok {
 		decision.Reason = reasons.NoWhitelistVariationAssignment
-		return decision, err
+		return decision, nil
 	}
 
-	variation, ok := experiment.Variations[variationKey]
+	variation, ok := decisionContext.Experiment.Variations[variationKey]
 	if !ok {
 		decision.Reason = reasons.InvalidWhitelistVariationAssignment
-		return decision, err
+		return decision, nil
 	}
 
 	decision.Reason = reasons.WhitelistVariationAssignmentFound
 	decision.Variation = &variation
-	return decision, err
-
+	return decision, nil
 }

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -47,7 +47,7 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 
 	experiment, err := decisionContext.ProjectConfig.GetExperimentByKey(decisionContext.Experiment.Key)
 	if err != nil {
-		return decision, fmt.Errorf("error looking up experiment in decision context: %w", err)
+		return decision, fmt.Errorf("error looking up experiment in decision context: %v", err)
 	}
 
 	userEntry, ok := s.whitelist[userContext.ID]

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -47,7 +47,7 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 
 	experiment, err := decisionContext.ProjectConfig.GetExperimentByKey(decisionContext.Experiment.Key)
 	if err != nil {
-		return decision, fmt.Errorf("Error looking up experiment in decision context: %w", err)
+		return decision, fmt.Errorf("error looking up experiment in decision context: %w", err)
 	}
 
 	userEntry, ok := s.whitelist[userContext.ID]

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -40,7 +40,7 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 		return decision, errors.New("decisionContext Experiment is nil")
 	}
 
-	variationKey, ok := decisionContext.Experiment.UserIDToVariationKeyMap[userContext.ID]
+	variationKey, ok := decisionContext.Experiment.Whitelist[userContext.ID]
 	if !ok {
 		decision.Reason = reasons.NoWhitelistVariationAssignment
 		return decision, nil

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+)
+
+// ExperimentWhitelistService makes a decision using a whitelist (a set of experiment + variation assignments for a set of users)
+// whitelist should be a map of user ID, to a map of Experiment key to Variation key
+type ExperimentWhitelistService struct {
+	whitelist map[string]map[string]string
+}
+
+// NewExperimentWhitelistService returns a new instance of ExperimentWhitelistService
+func NewExperimentWhitelistService(whitelist map[string]map[string]string) *ExperimentWhitelistService {
+	return &ExperimentWhitelistService{
+		whitelist: whitelist,
+	}
+}
+
+// GetDecision returns a decision with a variation when an entry is found for a given user ID and experiment key
+func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (decision ExperimentDecision, err error) {
+	if decisionContext.Experiment == nil {
+		return decision, errors.New("decisionContext Experiment is nil")
+	}
+
+	experiment, err := decisionContext.ProjectConfig.GetExperimentByKey(decisionContext.Experiment.Key)
+	if err != nil {
+		return decision, fmt.Errorf("Error looking up experiment in decision context: %w", err)
+	}
+
+	userEntry, ok := s.whitelist[userContext.ID]
+	if !ok {
+		decision.Reason = reasons.NoWhitelistVariationAssignment
+		return decision, nil
+	}
+
+	variationKey, ok := userEntry[decisionContext.Experiment.Key]
+	if !ok {
+		decision.Reason = reasons.NoWhitelistVariationAssignment
+		return decision, nil
+	}
+
+	variation, ok := experiment.Variations[variationKey]
+	if !ok {
+		decision.Reason = reasons.InvalidWhitelistVariationAssignment
+		return decision, nil
+	}
+
+	decision.Reason = reasons.WhitelistVariationAssignmentFound
+	decision.Variation = &variation
+	return decision, nil
+}

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
-
 	"github.com/optimizely/go-sdk/optimizely/entities"
 )
 

--- a/optimizely/decision/experiment_whitelist_service.go
+++ b/optimizely/decision/experiment_whitelist_service.go
@@ -25,6 +25,7 @@ import (
 )
 
 // ExperimentWhitelistService makes a decision using an experiment's whitelist (a map of user id to variation keys)
+// Implements the ExperimentService interface
 type ExperimentWhitelistService struct{}
 
 // NewExperimentWhitelistService returns a new instance of ExperimentWhitelistService

--- a/optimizely/decision/experiment_whitelist_service_test.go
+++ b/optimizely/decision/experiment_whitelist_service_test.go
@@ -18,7 +18,6 @@
 package decision
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/optimizely/go-sdk/optimizely/decision/reasons"
@@ -38,8 +37,6 @@ func (s *ExperimentWhitelistServiceTestSuite) SetupTest() {
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
-	s.mockConfig.On("GetExperimentByKey", "test_experiment_whitelist").Return(testExpWhitelist, nil)
-
 	testDecisionContext := ExperimentDecisionContext{
 		Experiment:    &testExpWhitelist,
 		ProjectConfig: s.mockConfig,
@@ -56,16 +53,14 @@ func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) TestNoUserEntryInWhitelist() {
-	s.mockConfig.On("GetExperimentByKey", "test_experiment_whitelist").Return(testExp1111, nil)
-
 	testDecisionContext := ExperimentDecisionContext{
 		Experiment:    &testExpWhitelist,
 		ProjectConfig: s.mockConfig,
 	}
 
-	// user context has test_user_1, but there's only a whitelist entry for test_user_2
+	// user context has test_user_3, but there's only a whitelist entry for test_user_1 and test_user_2
 	testUserContext := entities.UserContext{
-		ID: "test_user_1",
+		ID: "test_user_3",
 	}
 
 	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext)
@@ -76,8 +71,6 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoUserEntryInWhitelist() {
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) TestEmptyWhitelist() {
-	s.mockConfig.On("GetExperimentByKey", "test_experiment_1111").Return(testExp1111, nil)
-
 	testDecisionContext := ExperimentDecisionContext{
 		// testExp1111 has no whitelist
 		Experiment:    &testExp1111,
@@ -96,8 +89,6 @@ func (s *ExperimentWhitelistServiceTestSuite) TestEmptyWhitelist() {
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) TestInvalidVariationInUserEntry() {
-	s.mockConfig.On("GetExperimentByKey", "test_experiment_whitelist").Return(testExpWhitelist, nil)
-
 	testDecisionContext := ExperimentDecisionContext{
 		Experiment:    &testExpWhitelist,
 		ProjectConfig: s.mockConfig,
@@ -126,26 +117,6 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext(
 	}
 
 	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext)
-
-	s.Error(err)
-	s.Nil(decision.Variation)
-}
-
-func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInProjectConfig() {
-	whitelistService := NewExperimentWhitelistService()
-
-	s.mockConfig.On("GetExperimentByKey", "test_experiment_whitelist").Return(entities.Experiment{}, errors.New("Experiment not found"))
-
-	testDecisionContext := ExperimentDecisionContext{
-		Experiment:    &testExpWhitelist,
-		ProjectConfig: s.mockConfig,
-	}
-
-	testUserContext := entities.UserContext{
-		ID: "test_user_1",
-	}
-
-	decision, err := whitelistService.GetDecision(testDecisionContext, testUserContext)
 
 	s.Error(err)
 	s.Nil(decision.Variation)

--- a/optimizely/decision/experiment_whitelist_service_test.go
+++ b/optimizely/decision/experiment_whitelist_service_test.go
@@ -37,8 +37,8 @@ func (s *ExperimentWhitelistServiceTestSuite) SetupTest() {
 
 func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
 	whitelist := map[string]map[string]string{
-		"test_user_1": {
-			"test_experiment_1111": "2222",
+		"test_experiment_1111": {
+			"test_user_1": "2222",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)
@@ -62,8 +62,8 @@ func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
 
 func (s *ExperimentWhitelistServiceTestSuite) TestNoUserEntryInWhitelist() {
 	whitelist := map[string]map[string]string{
-		"test_user_2": {
-			"test_experiment_1111": "2222",
+		"test_experiment_1111": {
+			"test_user_2": "2222",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)
@@ -89,8 +89,8 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoUserEntryInWhitelist() {
 
 func (s *ExperimentWhitelistServiceTestSuite) TestNoVariationInUserEntry() {
 	whitelist := map[string]map[string]string{
-		"test_user_1": {
-			"test_experiment_1113": "2223",
+		"test_experiment_1113": {
+			"test_user_1": "2223",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)
@@ -116,9 +116,9 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoVariationInUserEntry() {
 
 func (s *ExperimentWhitelistServiceTestSuite) TestInvalidVariationInUserEntry() {
 	whitelist := map[string]map[string]string{
-		"test_user_1": {
-			// Whitelist has assigned 222222222 for test_experiment_1111, but no such variation exists
-			"test_experiment_1111": "222222222",
+		"test_experiment_1111": {
+			// Whitelist has assigned 222222222 for this user, but no such variation exists
+			"test_user_1": "222222222",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)
@@ -165,8 +165,8 @@ func (s *ExperimentWhitelistServiceTestSuite) TestEmptyWhitelist() {
 
 func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext() {
 	whitelist := map[string]map[string]string{
-		"test_user_1": {
-			"test_experiment_1111": "2222",
+		"test_experiment_1111": {
+			"test_user_1": "2222",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)
@@ -190,8 +190,8 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext(
 
 func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInProjectConfig() {
 	whitelist := map[string]map[string]string{
-		"test_user_1": {
-			"test_experiment_1111": "2222",
+		"test_experiment_1111": {
+			"test_user_1": "2222",
 		},
 	}
 	whitelistService := NewExperimentWhitelistService(whitelist)

--- a/optimizely/decision/experiment_whitelist_service_test.go
+++ b/optimizely/decision/experiment_whitelist_service_test.go
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"testing"
+
+	"github.com/optimizely/go-sdk/optimizely/entities"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExperimentWhitelistServiceTestSuite struct {
+	suite.Suite
+	mockConfig *mockProjectConfig
+}
+
+func (s *ExperimentWhitelistServiceTestSuite) SetupTest() {
+	s.mockConfig = new(mockProjectConfig)
+}
+
+func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
+	whitelist := map[string]map[string]string{
+		"test_user_1": {
+			"test_experiment_1111": "2222",
+		},
+	}
+	whitelistService := NewExperimentWhitelistService(whitelist)
+
+	mockExp := entities.Experiment{
+		Key: "test_experiment_1111",
+		Variations: map[string]entities.Variation{
+			"2222": entities.Variation{
+				Key: "2222",
+			},
+		},
+	}
+	s.mockConfig.On("GetExperimentByKey", mock.Anything).Return(mockExp, nil)
+
+	testDecisionContext := ExperimentDecisionContext{
+		Experiment:    &testExp1111,
+		ProjectConfig: s.mockConfig,
+	}
+
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	decision, err := whitelistService.GetDecision(testDecisionContext, testUserContext)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Exactly("2222", decision.Variation.Key)
+}
+
+func TestExperimentWhitelistTestSuite(t *testing.T) {
+	suite.Run(t, new(ExperimentWhitelistServiceTestSuite))
+}

--- a/optimizely/decision/helpers_test.go
+++ b/optimizely/decision/helpers_test.go
@@ -236,7 +236,7 @@ var testExpWhitelist = entities.Experiment{
 	TrafficAllocation: []entities.Range{
 		entities.Range{EntityID: "2229", EndOfRange: 10000},
 	},
-	UserIDToVariationKeyMap: map[string]string{
+	Whitelist: map[string]string{
 		"test_user_1": "2229",
 		// Note: this is an invalid entry, there is no variation 2230 in this experiment
 		"test_user_2": "2230",

--- a/optimizely/decision/helpers_test.go
+++ b/optimizely/decision/helpers_test.go
@@ -213,12 +213,32 @@ const testTargetedExp1116Key = "test_targeted_experiment_1116"
 var testTargetedExp1116Var2228 = entities.Variation{ID: "2228", Key: "2228"}
 var testTargetedExp1116 = entities.Experiment{
 	AudienceConditionTree: &entities.TreeNode{Operator: "or", Item: "7771"},
-	ID:  "1116",
-	Key: testTargetedExp1116Key,
+	ID:                    "1116",
+	Key:                   testTargetedExp1116Key,
 	Variations: map[string]entities.Variation{
 		"2228": testTargetedExp1116Var2228,
 	},
 	TrafficAllocation: []entities.Range{
 		entities.Range{EntityID: "2228", EndOfRange: 10000},
+	},
+}
+
+// Experiment with a whitelist
+const testExpWhitelistKey = "test_experiment_whitelist"
+
+var testExpWhitelistVar2229 = entities.Variation{ID: "2229", Key: "2229"}
+var testExpWhitelist = entities.Experiment{
+	ID:  "1117",
+	Key: testExpWhitelistKey,
+	Variations: map[string]entities.Variation{
+		"2229": testExpWhitelistVar2229,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2229", EndOfRange: 10000},
+	},
+	UserIDToVariationKeyMap: map[string]string{
+		"test_user_1": "2229",
+		// Note: this is an invalid entry, there is no variation 2230 in this experiment
+		"test_user_2": "2230",
 	},
 }

--- a/optimizely/decision/reasons/reason.go
+++ b/optimizely/decision/reasons/reason.go
@@ -37,7 +37,7 @@ const (
 	NotBucketedIntoVariation Reason = "Not bucketed into a variation"
 	// NotInGroup - the user is not bucketed into the mutex group
 	NotInGroup Reason = "Not bucketed into any experiment in mutex group"
-	// NoWhitelistVariationAssignment - there is no variation assignment for the given experiment in the whitelist entry for the given user
+	// NoWhitelistVariationAssignment - there is no variation assignment for the given user and experiment
 	NoWhitelistVariationAssignment Reason = "No whitelist variation assignment"
 	// InvalidWhitelistVariationAssignment - A variation assignment was found for the given user and experiment, but no variation with that key exists in the given experiment
 	InvalidWhitelistVariationAssignment Reason = "Invalid whitelist variation assignment"

--- a/optimizely/decision/reasons/reason.go
+++ b/optimizely/decision/reasons/reason.go
@@ -37,4 +37,10 @@ const (
 	NotBucketedIntoVariation Reason = "Not bucketed into a variation"
 	// NotInGroup - the user is not bucketed into the mutex group
 	NotInGroup Reason = "Not bucketed into any experiment in mutex group"
+	// NoWhitelistVariationAssignment - there is no variation assignment for the given experiment in the whitelist entry for the given user
+	NoWhitelistVariationAssignment Reason = "No whitelist variation assignment"
+	// InvalidWhitelistVariationAssignment - A variation assignment was found for the given user and experiment, but no variation with that key exists in the given experiment
+	InvalidWhitelistVariationAssignment Reason = "Invalid whitelist variation assignment"
+	// WhitelistVariationAssignmentFound - a valid variation assignment was found for the given user and experiment
+	WhitelistVariationAssignmentFound Reason = "Whitelist variation assignment found"
 )

--- a/optimizely/entities/experiment.go
+++ b/optimizely/entities/experiment.go
@@ -27,15 +27,15 @@ type Variation struct {
 
 // Experiment represents an experiment
 type Experiment struct {
-	AudienceIds             []string
-	ID                      string
-	LayerID                 string
-	Key                     string
-	Variations              map[string]Variation
-	TrafficAllocation       []Range
-	GroupID                 string
-	AudienceConditionTree   *TreeNode
-	UserIDToVariationKeyMap map[string]string
+	AudienceIds           []string
+	ID                    string
+	LayerID               string
+	Key                   string
+	Variations            map[string]Variation
+	TrafficAllocation     []Range
+	GroupID               string
+	AudienceConditionTree *TreeNode
+	Whitelist             map[string]string
 }
 
 // Range represents bucketing range that the specify entityID falls into

--- a/optimizely/entities/experiment.go
+++ b/optimizely/entities/experiment.go
@@ -27,14 +27,15 @@ type Variation struct {
 
 // Experiment represents an experiment
 type Experiment struct {
-	AudienceIds           []string
-	ID                    string
-	LayerID               string
-	Key                   string
-	Variations            map[string]Variation
-	TrafficAllocation     []Range
-	GroupID               string
-	AudienceConditionTree *TreeNode
+	AudienceIds             []string
+	ID                      string
+	LayerID                 string
+	Key                     string
+	Variations              map[string]Variation
+	TrafficAllocation       []Range
+	GroupID                 string
+	AudienceConditionTree   *TreeNode
+	UserIDToVariationKeyMap map[string]string
 }
 
 // Range represents bucketing range that the specify entityID falls into


### PR DESCRIPTION
## Summary

Add `ExperimentWhitelistService`, which returns decisions based on the contents of `forcedVariations` in experiments in the datafile. `NewCompositeExperimentService` creates an `ExperimentWhitelistService` as its first child service, taking precedence over normal bucketing.

To support `ExperimentWhitelistService`, I added a `Whitelist` field to the `Experiment` entity. The value comes directly from `forcedVariations` of the datafile experiment. I named it `Whitelist` to match the term we use to talk about this kind of override, even though it's not named that in the datafile.

## Test plan
Added unit tests