### PR TITLE
refac(context): Refactor to make execution context optional for components

### DIFF
--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -42,7 +42,7 @@ func stressTest() {
 	// Creates a default, canceleable context
 	decisionService := decision.NewCompositeService("sdk_key")
 
-	clientApp, err := optlyClient.Client(client.DecisionService(decisionService))
+	clientApp, err := optlyClient.Client(client.WithDecisionService(decisionService))
 	if err != nil {
 		log.Print(err)
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -62,9 +62,9 @@ func main() {
 	/************* Setting Polling Interval ********************/
 
 	optimizelyClient, _ = optimizelyFactory.Client(
-		client.PollingConfigManager(sdkKey, time.Second, nil),
-		client.CompositeDecisionService(sdkKey),
-		client.BatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
+		client.WithPollingConfigManager(sdkKey, time.Second, nil),
+		client.WithCompositeDecisionService(sdkKey),
+		client.WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 	optimizelyClient.Close()
 }

--- a/optimizely/client/client_test.go
+++ b/optimizely/client/client_test.go
@@ -24,34 +24,11 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/entities"
 	"github.com/optimizely/go-sdk/optimizely/event"
-	"github.com/optimizely/go-sdk/optimizely/notification"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
-
-type MockProjectConfigManager struct {
-	projectConfig optimizely.ProjectConfig
-	mock.Mock
-}
-
-func (p *MockProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
-	if p.projectConfig != nil {
-		return p.projectConfig, nil
-	}
-
-	args := p.Called()
-	return args.Get(0).(optimizely.ProjectConfig), args.Error(1)
-}
-
-func (p *MockProjectConfigManager) OnProjectConfigUpdate(callback func(notification.ProjectConfigUpdateNotification)) (int, error) {
-	return 0, nil
-}
-
-func (p *MockProjectConfigManager) RemoveOnProjectConfigUpdate(id int) error {
-	return nil
-}
 
 func ValidProjectConfigManager() *MockProjectConfigManager {
 	p := new(MockProjectConfigManager)

--- a/optimizely/client/factory_test.go
+++ b/optimizely/client/factory_test.go
@@ -61,7 +61,7 @@ func TestClientWithProjectConfigManagerInOptions(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
 	configManager := config.NewStaticProjectConfigManager(projectConfig)
 
-	optimizelyClient, err := factory.Client(ConfigManager(configManager))
+	optimizelyClient, err := factory.Client(WithConfigManager(configManager))
 	assert.NoError(t, err)
 	assert.NotNil(t, optimizelyClient.ConfigManager)
 	assert.NotNil(t, optimizelyClient.DecisionService)
@@ -80,7 +80,7 @@ func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 		EventDispatcher: &MockDispatcher{},
 	}
 
-	optimizelyClient, err := factory.Client(ConfigManager(configManager), DecisionService(decisionService), EventProcessor(processor))
+	optimizelyClient, err := factory.Client(WithConfigManager(configManager), WithDecisionService(decisionService), WithEventProcessor(processor))
 	assert.NoError(t, err)
 	assert.Equal(t, decisionService, optimizelyClient.DecisionService)
 	assert.Equal(t, processor, optimizelyClient.EventProcessor)

--- a/optimizely/client/factory_test.go
+++ b/optimizely/client/factory_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/optimizely/go-sdk/optimizely/config"
 	"github.com/optimizely/go-sdk/optimizely/config/datafileprojectconfig"
 	"github.com/optimizely/go-sdk/optimizely/event"
+	"github.com/optimizely/go-sdk/optimizely/utils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -84,4 +85,25 @@ func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, decisionService, optimizelyClient.DecisionService)
 	assert.Equal(t, processor, optimizelyClient.EventProcessor)
+}
+
+func TestClientWithCustomCtx(t *testing.T) {
+	factory := OptimizelyFactory{}
+	testExecutionCtx := utils.NewCancelableExecutionCtx()
+	mockConfigManager := new(MockProjectConfigManager)
+	client, err := factory.Client(
+		WithConfigManager(mockConfigManager),
+		WithExecutionContext(testExecutionCtx),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, client.executionCtx, testExecutionCtx)
+}
+
+func TestStaticClient(t *testing.T) {
+	factory := OptimizelyFactory{Datafile: []byte(`{"revision": "42"}`)}
+	optlyClient, err := factory.StaticClient()
+	assert.NoError(t, err)
+
+	parsedConfig, _ := optlyClient.ConfigManager.GetConfig()
+	assert.Equal(t, "42", parsedConfig.GetRevision())
 }

--- a/optimizely/client/fixtures_test.go
+++ b/optimizely/client/fixtures_test.go
@@ -18,6 +18,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/optimizely/go-sdk/optimizely"
 	"github.com/optimizely/go-sdk/optimizely/decision"
 	"github.com/optimizely/go-sdk/optimizely/entities"
@@ -128,7 +130,7 @@ func (m *PanickingDecisionService) RemoveOnDecision(id int) error {
 }
 
 // Helper methods for creating test entities
-func getTestExperiment(experimentKey string) entities.Experiment {
+func makeTestExperiment(experimentKey string) entities.Experiment {
 	return entities.Experiment{
 		Key: experimentKey,
 		Variations: map[string]entities.Variation{
@@ -136,4 +138,34 @@ func getTestExperiment(experimentKey string) entities.Experiment {
 			"v2": entities.Variation{Key: "v2"},
 		},
 	}
+}
+
+func makeTestVariation(variationKey string, featureEnabled bool) entities.Variation {
+	return entities.Variation{
+		ID:             fmt.Sprintf("test_variation_%s", variationKey),
+		Key:            variationKey,
+		FeatureEnabled: featureEnabled,
+	}
+}
+
+func makeTestExperimentWithVariations(experimentKey string, variations []entities.Variation) entities.Experiment {
+	variationsMap := make(map[string]entities.Variation)
+	for _, variation := range variations {
+		variationsMap[variation.ID] = variation
+	}
+	return entities.Experiment{
+		Key:        experimentKey,
+		ID:         fmt.Sprintf("test_experiment_%s", experimentKey),
+		Variations: variationsMap,
+	}
+}
+
+func makeTestFeatureWithExperiment(featureKey string, experiment entities.Experiment) entities.Feature {
+	testFeature := entities.Feature{
+		ID:                 fmt.Sprintf("test_feature_%s", featureKey),
+		Key:                featureKey,
+		FeatureExperiments: []entities.Experiment{experiment},
+	}
+
+	return testFeature
 }

--- a/optimizely/client/fixtures_test.go
+++ b/optimizely/client/fixtures_test.go
@@ -78,6 +78,28 @@ func (c *MockProjectConfig) GetBotFiltering() bool {
 	return false
 }
 
+type MockProjectConfigManager struct {
+	projectConfig optimizely.ProjectConfig
+	mock.Mock
+}
+
+func (p *MockProjectConfigManager) GetConfig() (optimizely.ProjectConfig, error) {
+	if p.projectConfig != nil {
+		return p.projectConfig, nil
+	}
+
+	args := p.Called()
+	return args.Get(0).(optimizely.ProjectConfig), args.Error(1)
+}
+
+func (p *MockProjectConfigManager) OnProjectConfigUpdate(callback func(notification.ProjectConfigUpdateNotification)) (int, error) {
+	return 0, nil
+}
+
+func (p *MockProjectConfigManager) RemoveOnProjectConfigUpdate(id int) error {
+	return nil
+}
+
 type MockDecisionService struct {
 	decision.Service
 	mock.Mock

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -48,7 +48,8 @@ func TestNewPollingProjectConfigManagerWithOptions(t *testing.T) {
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
+	configManager := NewPollingProjectConfigManager(sdkKey, Requester(mockRequester))
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -66,7 +67,8 @@ func TestNewPollingProjectConfigManagerWithNull(t *testing.T) {
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
+	configManager := NewPollingProjectConfigManager(sdkKey, Requester(mockRequester))
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	_, err := configManager.GetConfig()
@@ -83,7 +85,8 @@ func TestNewPollingProjectConfigManagerWithSimilarDatafileRevisions(t *testing.T
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
+	configManager := NewPollingProjectConfigManager(sdkKey, Requester(mockRequester))
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -108,7 +111,8 @@ func TestNewPollingProjectConfigManagerWithDifferentDatafileRevisions(t *testing
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
+	configManager := NewPollingProjectConfigManager(sdkKey, Requester(mockRequester))
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -132,7 +136,8 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 	sdkKey := "test_sdk_key"
 
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, Requester(mockRequester))
+	configManager := NewPollingProjectConfigManager(sdkKey, Requester(mockRequester))
+	configManager.Start(exeCtx)
 
 	var numberOfCalls = 0
 	callback := func(notification notification.ProjectConfigUpdateNotification) {

--- a/optimizely/config/polling_manager_test.go
+++ b/optimizely/config/polling_manager_test.go
@@ -172,7 +172,9 @@ func TestDefaultRequester(t *testing.T) {
 	sdkKey := "test_sdk_key"
 	DefaultRequester(sdkKey)
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, DefaultRequester(sdkKey))
+	configManager := NewPollingProjectConfigManager(sdkKey, DefaultRequester(sdkKey))
+	configManager.Start(exeCtx)
+
 	requester := configManager.requester
 	assert.NotNil(t, requester)
 	assert.Equal(t, requester.String(), "{url: https://cdn.optimizely.com/datafiles/test_sdk_key.json, timeout: 5s, retries: 1}")
@@ -183,7 +185,8 @@ func TestPollingInterval(t *testing.T) {
 	sdkKey := "test_sdk_key"
 	DefaultRequester(sdkKey)
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, PollingInterval(5*time.Second))
+	configManager := NewPollingProjectConfigManager(sdkKey, PollingInterval(5*time.Second))
+	configManager.Start(exeCtx)
 
 	assert.Equal(t, configManager.pollingInterval, 5*time.Second)
 }
@@ -193,7 +196,8 @@ func TestInitialDatafile(t *testing.T) {
 	sdkKey := "test_sdk_key"
 	DefaultRequester(sdkKey)
 	exeCtx := utils.NewCancelableExecutionCtx()
-	configManager := NewPollingProjectConfigManager(exeCtx, sdkKey, InitialDatafile([]byte("test")))
+	configManager := NewPollingProjectConfigManager(sdkKey, InitialDatafile([]byte("test")))
+	configManager.Start(exeCtx)
 
 	assert.Equal(t, configManager.initDatafile, []byte("test"))
 }

--- a/optimizely/entities/experiment.go
+++ b/optimizely/entities/experiment.go
@@ -31,7 +31,7 @@ type Experiment struct {
 	ID                    string
 	LayerID               string
 	Key                   string
-	Variations            map[string]Variation
+	Variations            map[string]Variation // keyed by variation ID
 	TrafficAllocation     []Range
 	GroupID               string
 	AudienceConditionTree *TreeNode

--- a/optimizely/event/factory_test.go
+++ b/optimizely/event/factory_test.go
@@ -121,7 +121,9 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), BatchSize(10), QueueSize(100), FlushInterval(100))
+	processor := NewEventProcessor(BatchSize(10), QueueSize(100), FlushInterval(100))
+
+	processor.Start(utils.NewCancelableExecutionCtx())
 
 	processor.ProcessEvent(impressionUserEvent)
 
@@ -136,7 +138,9 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(utils.NewCancelableExecutionCtx(), FlushInterval(100))
+	processor := NewEventProcessor(FlushInterval(100))
+
+	processor.Start(utils.NewCancelableExecutionCtx())
 
 	processor.ProcessEvent(conversionUserEvent)
 

--- a/optimizely/event/processor.go
+++ b/optimizely/event/processor.go
@@ -126,6 +126,7 @@ func (p *QueueingEventProcessor) Start(exeCtx utils.ExecutionCtx) {
 	}
 
 	p.startTicker(exeCtx)
+	pLogger.Debug("Batch event processor started")
 }
 
 // ProcessEvent processes the given impression event

--- a/optimizely/event/processor_test.go
+++ b/optimizely/event/processor_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+
 	"github.com/optimizely/go-sdk/optimizely/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,8 @@ import (
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, FlushInterval(100))
+	processor := NewEventProcessor(FlushInterval(100))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 
@@ -45,7 +47,8 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(10), FlushInterval(100))
+	processor := NewEventProcessor(QueueSize(10), FlushInterval(100))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 
@@ -62,7 +65,7 @@ func TestCustomEventProcessor_Create(t *testing.T) {
 
 type MockDispatcher struct {
 	ShouldFail bool
-	Events Queue
+	Events     Queue
 }
 
 func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
@@ -76,8 +79,9 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, FlushInterval(100), QueueSize(100),
+	processor := NewEventProcessor(FlushInterval(100), QueueSize(100),
 		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -107,8 +111,9 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(2), FlushInterval(100),
-		PQ( NewInMemoryQueue(2)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(QueueSize(2), FlushInterval(100),
+		PQ(NewInMemoryQueue(2)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -148,8 +153,9 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{ShouldFail: true, Events:NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
+		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{ShouldFail: true, Events: NewInMemoryQueue(100)}))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -176,8 +182,9 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), PQ(NewInMemoryQueue(100)),
+	processor := NewEventProcessor(QueueSize(100), PQ(NewInMemoryQueue(100)),
 		PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -197,8 +204,10 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
 		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -229,8 +238,10 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
 		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()
@@ -261,8 +272,10 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
 		PQ(NewInMemoryQueue(100)), PDispatcher(&HTTPEventDispatcher{}))
+
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 
@@ -278,8 +291,9 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(exeCtx, QueueSize(100), FlushInterval(100),
+	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
 		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
 	conversion := BuildTestConversionEvent()


### PR DESCRIPTION
# Summary
- Aims to simplify the construction of the top level components by removing the executionContext from the required path
- Renames some of the option functions to the new paradigm where they are prepended with `With`
- Important caveat to note is that now we have to explicitly call the `Start` methods of the `PollingConfigManager` and `QueueingEventProcessor`

# Test
- Unit