### PR TITLE
refac(ep): Rename options and EP implementation.

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -45,9 +45,9 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	appClient := &OptimizelyClient{
 		executionCtx:    executionCtx,
 		DecisionService: decision.NewCompositeService(f.SDKKey),
-		EventProcessor: event.NewEventProcessor(event.BatchSize(event.DefaultBatchSize),
-			event.QueueSize(event.DefaultEventQueueSize), event.FlushInterval(event.DefaultEventFlushInterval),
-			event.SDKKey(f.SDKKey)),
+		EventProcessor: event.NewEventProcessor(event.WithBatchSize(event.DefaultBatchSize),
+			event.WithQueueSize(event.DefaultEventQueueSize), event.WithFlushInterval(event.DefaultEventFlushInterval),
+			event.WithSDKKey(f.SDKKey)),
 	}
 
 	for _, opt := range clientOptions {
@@ -68,8 +68,8 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 		pollingConfigManager.Start(appClient.executionCtx)
 	}
 
-	if queueingProcessor, ok := appClient.EventProcessor.(*event.QueueingEventProcessor); ok {
-		queueingProcessor.Start(appClient.executionCtx)
+	if batchProcessor, ok := appClient.EventProcessor.(*event.BatchEventProcessor); ok {
+		batchProcessor.Start(appClient.executionCtx)
 	}
 
 	return appClient, nil
@@ -115,8 +115,8 @@ func WithDecisionService(decisionService decision.Service) OptionFunc {
 // WithBatchEventProcessor sets event processor on a client
 func WithBatchEventProcessor(batchSize, queueSize int, flushInterval time.Duration) OptionFunc {
 	return func(f *OptimizelyClient) {
-		f.EventProcessor = event.NewEventProcessor(event.BatchSize(batchSize),
-			event.QueueSize(queueSize), event.FlushInterval(flushInterval))
+		f.EventProcessor = event.NewEventProcessor(event.WithBatchSize(batchSize),
+			event.WithQueueSize(queueSize), event.WithFlushInterval(flushInterval))
 	}
 }
 

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -45,7 +45,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	appClient := &OptimizelyClient{
 		executionCtx:    executionCtx,
 		DecisionService: decision.NewCompositeService(f.SDKKey),
-		EventProcessor: event.NewEventProcessor(event.WithBatchSize(event.DefaultBatchSize),
+		EventProcessor: event.NewBatchEventProcessor(event.WithBatchSize(event.DefaultBatchSize),
 			event.WithQueueSize(event.DefaultEventQueueSize), event.WithFlushInterval(event.DefaultEventFlushInterval),
 			event.WithSDKKey(f.SDKKey)),
 	}
@@ -115,7 +115,7 @@ func WithDecisionService(decisionService decision.Service) OptionFunc {
 // WithBatchEventProcessor sets event processor on a client
 func WithBatchEventProcessor(batchSize, queueSize int, flushInterval time.Duration) OptionFunc {
 	return func(f *OptimizelyClient) {
-		f.EventProcessor = event.NewEventProcessor(event.WithBatchSize(batchSize),
+		f.EventProcessor = event.NewBatchEventProcessor(event.WithBatchSize(batchSize),
 			event.WithQueueSize(queueSize), event.WithFlushInterval(flushInterval))
 	}
 }

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -107,7 +107,7 @@ func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
 	configManager := config.NewStaticProjectConfigManager(projectConfig)
 	decisionService := new(MockDecisionService)
-	processor := &event.QueueingEventProcessor{
+	processor := &event.BatchEventProcessor{
 		MaxQueueSize:    100,
 		FlushInterval:   100,
 		Q:               event.NewInMemoryQueue(100),

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -121,7 +121,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(WithBatchSize(10), WithQueueSize(100), WithFlushInterval(100))
+	processor := NewBatchEventProcessor(WithBatchSize(10), WithQueueSize(100), WithFlushInterval(100))
 
 	processor.Start(utils.NewCancelableExecutionCtx())
 
@@ -138,7 +138,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(WithFlushInterval(100))
+	processor := NewBatchEventProcessor(WithFlushInterval(100))
 
 	processor.Start(utils.NewCancelableExecutionCtx())
 

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -121,7 +121,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	impressionUserEvent := BuildTestImpressionEvent()
 
-	processor := NewEventProcessor(BatchSize(10), QueueSize(100), FlushInterval(100))
+	processor := NewEventProcessor(WithBatchSize(10), WithQueueSize(100), WithFlushInterval(100))
 
 	processor.Start(utils.NewCancelableExecutionCtx())
 
@@ -138,7 +138,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	conversionUserEvent := BuildTestConversionEvent()
 
-	processor := NewEventProcessor(FlushInterval(100))
+	processor := NewEventProcessor(WithFlushInterval(100))
 
 	processor.Start(utils.NewCancelableExecutionCtx())
 

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -103,8 +103,8 @@ func WithSDKKey(sdkKey string) BPOptionConfig {
 	}
 }
 
-// NewEventProcessor returns a new instance of BatchEventProcessor with queueSize and flushInterval
-func NewEventProcessor(options ...BPOptionConfig) *BatchEventProcessor {
+// NewBatchEventProcessor returns a new instance of BatchEventProcessor with queueSize and flushInterval
+func NewBatchEventProcessor(options ...BPOptionConfig) *BatchEventProcessor {
 	p := &BatchEventProcessor{}
 
 	for _, opt := range options {

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -57,39 +57,39 @@ const DefaultEventFlushInterval = 30 * time.Second
 
 var pLogger = logging.GetLogger("EventProcessor")
 
-// QPConfigOption is the QueuingProcessor options that give you the ability to add one more more options before the processor is initialized.
-type QPConfigOption func(qp *BatchEventProcessor)
+// BPOptionConfig is the BatchProcessor options that give you the ability to add one more more options before the processor is initialized.
+type BPOptionConfig func(qp *BatchEventProcessor)
 
 // WithBatchSize sets the batch size as a config option to be passed into the NewProcessor method
-func WithBatchSize(bsize int) QPConfigOption {
+func WithBatchSize(bsize int) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.BatchSize = bsize
 	}
 }
 
 // WithQueueSize sets the queue size as a config option to be passed into the NewProcessor method
-func WithQueueSize(qsize int) QPConfigOption {
+func WithQueueSize(qsize int) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.MaxQueueSize = qsize
 	}
 }
 
 // WithFlushInterval sets the flush interval as a config option to be passed into the NewProcessor method
-func WithFlushInterval(flushInterval time.Duration) QPConfigOption {
+func WithFlushInterval(flushInterval time.Duration) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.FlushInterval = flushInterval
 	}
 }
 
 // WithQueue sets the Processor Queue as a config option to be passed into the NewProcessor method
-func WithQueue(q Queue) QPConfigOption {
+func WithQueue(q Queue) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.Q = q
 	}
 }
 
 // WithEventDispatcher sets the Processor Dispatcher as a config option to be passed into the NewProcessor method
-func WithEventDispatcher(d Dispatcher) QPConfigOption {
+func WithEventDispatcher(d Dispatcher) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.EventDispatcher = d
 	}
@@ -97,14 +97,14 @@ func WithEventDispatcher(d Dispatcher) QPConfigOption {
 
 // WithSDKKey sets the SDKKey used to register for notifications.  This should be removed when the project
 // config supports sdk key.
-func WithSDKKey(sdkKey string) QPConfigOption {
+func WithSDKKey(sdkKey string) BPOptionConfig {
 	return func(qp *BatchEventProcessor) {
 		qp.sdkKey = sdkKey
 	}
 }
 
 // NewEventProcessor returns a new instance of BatchEventProcessor with queueSize and flushInterval
-func NewEventProcessor(options ...QPConfigOption) *BatchEventProcessor {
+func NewEventProcessor(options ...BPOptionConfig) *BatchEventProcessor {
 	p := &BatchEventProcessor{}
 
 	for _, opt := range options {

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(FlushInterval(100))
+	processor := NewEventProcessor(WithFlushInterval(100))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -47,7 +47,7 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(10), FlushInterval(100))
+	processor := NewEventProcessor(WithQueueSize(10), WithFlushInterval(100))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -79,9 +79,9 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(FlushInterval(100), QueueSize(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}),
-		SDKKey("fakeSDKKey"))
+	processor := NewEventProcessor(WithFlushInterval(100), WithQueueSize(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}),
+		WithSDKKey("fakeSDKKey"))
 
 	var logEvent LogEvent
 
@@ -113,8 +113,8 @@ func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(FlushInterval(100), QueueSize(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithFlushInterval(100), WithQueueSize(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -145,8 +145,8 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(2), FlushInterval(100),
-		PQ(NewInMemoryQueue(2)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(2), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(2)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -187,8 +187,8 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{ShouldFail: true, Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{ShouldFail: true, Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -216,8 +216,8 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), PQ(NewInMemoryQueue(100)),
-		PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(100), WithQueue(NewInMemoryQueue(100)),
+		WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -238,8 +238,8 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	processor.Start(exeCtx)
 
@@ -272,8 +272,8 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	processor.Start(exeCtx)
 
@@ -306,8 +306,8 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&HTTPEventDispatcher{}))
+	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&HTTPEventDispatcher{}))
 
 	processor.Start(exeCtx)
 
@@ -325,8 +325,8 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(QueueSize(100), FlushInterval(100),
-		PQ(NewInMemoryQueue(100)), PDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
+	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -43,7 +43,7 @@ func (f *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}), WithFlushInterval(100))
+	processor := NewBatchEventProcessor(WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}), WithFlushInterval(100))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -61,7 +61,7 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestCustomEventProcessor_Create(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}), WithQueueSize(10), WithFlushInterval(100))
+	processor := NewBatchEventProcessor(WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}), WithQueueSize(10), WithFlushInterval(100))
 	processor.Start(exeCtx)
 
 	impression := BuildTestImpressionEvent()
@@ -79,7 +79,7 @@ func TestCustomEventProcessor_Create(t *testing.T) {
 
 func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithFlushInterval(100), WithQueueSize(100),
+	processor := NewBatchEventProcessor(WithFlushInterval(100), WithQueueSize(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}),
 		WithSDKKey("fakeSDKKey"))
 
@@ -113,7 +113,7 @@ func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithFlushInterval(100), WithQueueSize(100),
+	processor := NewBatchEventProcessor(WithFlushInterval(100), WithQueueSize(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
@@ -145,7 +145,7 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 
 func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(2), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(2), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(2)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
@@ -187,7 +187,7 @@ func TestDefaultEventProcessor_QSizeMet(t *testing.T) {
 
 func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{ShouldFail: true, Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
@@ -216,7 +216,7 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 
 func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithQueue(NewInMemoryQueue(100)),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithQueue(NewInMemoryQueue(100)),
 		WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 
@@ -238,7 +238,7 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	processor.Start(exeCtx)
@@ -272,7 +272,7 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 
 func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	processor.Start(exeCtx)
@@ -306,7 +306,7 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&HTTPEventDispatcher{}))
 
 	processor.Start(exeCtx)
@@ -325,7 +325,7 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 	exeCtx := utils.NewCancelableExecutionCtx()
-	processor := NewEventProcessor(WithQueueSize(100), WithFlushInterval(100),
+	processor := NewBatchEventProcessor(WithQueueSize(100), WithFlushInterval(100),
 		WithQueue(NewInMemoryQueue(100)), WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 	processor.Start(exeCtx)
 

--- a/tests/integration/support/client_wrapper.go
+++ b/tests/integration/support/client_wrapper.go
@@ -38,7 +38,11 @@ func NewClientWrapper(datafileName string) ClientWrapper {
 		log.Fatal(err)
 	}
 
-	eventProcessor := event.NewEventProcessor(event.BatchSize(models.EventProcessorDefaultBatchSize), event.QueueSize(models.EventProcessorDefaultQueueSize), event.FlushInterval(models.EventProcessorDefaultFlushInterval))
+	eventProcessor := event.NewEventProcessor(
+		event.WithBatchSize(models.EventProcessorDefaultBatchSize),
+		event.WithQueueSize(models.EventProcessorDefaultQueueSize),
+		event.WithFlushInterval(models.EventProcessorDefaultFlushInterval),
+	)
 
 	optimizelyFactory := &client.OptimizelyFactory{
 		Datafile: datafile,

--- a/tests/integration/support/client_wrapper.go
+++ b/tests/integration/support/client_wrapper.go
@@ -38,7 +38,7 @@ func NewClientWrapper(datafileName string) ClientWrapper {
 		log.Fatal(err)
 	}
 
-	eventProcessor := event.NewEventProcessor(
+	eventProcessor := event.NewBatchEventProcessor(
 		event.WithBatchSize(models.EventProcessorDefaultBatchSize),
 		event.WithQueueSize(models.EventProcessorDefaultQueueSize),
 		event.WithFlushInterval(models.EventProcessorDefaultFlushInterval),


### PR DESCRIPTION
# Summary 
- Rename option func to be prepended with the word "With"
- Rename the QueueingEventProcessor to BatchEventProcessor to be more in line with our other SDKs and the dev docs