### PR TITLE
(fix): Fixed GetDecision for CompositeFeatureService and key for VisitorAttribute.

### DIFF
--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -44,19 +44,16 @@ func NewCompositeFeatureService(compositeExperimentService ExperimentService) *C
 
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
-	lastElementIndex := len(f.featureServices) - 1
-	for index, featureDecisionService := range f.featureServices {
-		featureDecision, err := featureDecisionService.GetDecision(decisionContext, userContext)
+	var featureDecision = FeatureDecision{}
+	var err = errors.New("")
+	for _, featureDecisionService := range f.featureServices {
+		featureDecision, err = featureDecisionService.GetDecision(decisionContext, userContext)
 		if err != nil {
 			cfLogger.Debug(fmt.Sprintf("%v", err))
 		}
 		if featureDecision.Variation != nil && err == nil {
 			return featureDecision, err
 		}
-		if index == lastElementIndex {
-			return featureDecision, err
-		}
 	}
-
-	return FeatureDecision{}, errors.New("no decision was made")
+	return featureDecision, err
 }

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -44,10 +44,7 @@ func NewCompositeFeatureService(compositeExperimentService ExperimentService) *C
 
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
-	lastElementIndex := 0
-	if len(f.featureServices) > 0 {
-		lastElementIndex = len(f.featureServices) - 1
-	}
+	lastElementIndex := len(f.featureServices) - 1
 	for index, featureDecisionService := range f.featureServices {
 		featureDecision, err := featureDecisionService.GetDecision(decisionContext, userContext)
 		if err != nil {

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -18,7 +18,6 @@
 package decision
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -45,7 +44,7 @@ func NewCompositeFeatureService(compositeExperimentService ExperimentService) *C
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
 	var featureDecision = FeatureDecision{}
-	var err = errors.New("")
+	var err error
 	for _, featureDecisionService := range f.featureServices {
 		featureDecision, err = featureDecisionService.GetDecision(decisionContext, userContext)
 		if err != nil {

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -54,5 +54,6 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		}
 	}
 
-	return FeatureDecision{}, errors.New("no decision was made")
+	featureDecision, _ := f.featureServices[len(f.featureServices)-1].GetDecision(decisionContext, userContext)
+	return featureDecision, errors.New("no decision was made")
 }

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -44,7 +44,7 @@ func NewCompositeFeatureService(compositeExperimentService ExperimentService) *C
 
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
-	for _, featureDecisionService := range f.featureServices {
+	for index, featureDecisionService := range f.featureServices {
 		featureDecision, err := featureDecisionService.GetDecision(decisionContext, userContext)
 		if err != nil {
 			cfLogger.Debug(fmt.Sprintf("%v", err))
@@ -52,8 +52,10 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		if featureDecision.Variation != nil && err == nil {
 			return featureDecision, err
 		}
+		if index == len(f.featureServices)-1 {
+			return featureDecision, err
+		}
 	}
 
-	featureDecision, _ := f.featureServices[len(f.featureServices)-1].GetDecision(decisionContext, userContext)
-	return featureDecision, errors.New("no decision was made")
+	return FeatureDecision{}, errors.New("no decision was made")
 }

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -44,6 +44,10 @@ func NewCompositeFeatureService(compositeExperimentService ExperimentService) *C
 
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error) {
+	lastElementIndex := 0
+	if len(f.featureServices) > 0 {
+		lastElementIndex = len(f.featureServices) - 1
+	}
 	for index, featureDecisionService := range f.featureServices {
 		featureDecision, err := featureDecisionService.GetDecision(decisionContext, userContext)
 		if err != nil {
@@ -52,7 +56,7 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		if featureDecision.Variation != nil && err == nil {
 			return featureDecision, err
 		}
-		if index == len(f.featureServices)-1 {
+		if index == lastElementIndex {
 			return featureDecision, err
 		}
 	}

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -128,6 +128,33 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsError() {
 	s.mockFeatureService2.AssertExpectations(s.T())
 }
 
+func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWithError() {
+	// test that GetDecision returns the last decision with error "no decision was made" if all decision services return error
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	expectedDecision := FeatureDecision{
+		Variation: &testExp1113Var2223,
+	}
+	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext).Return(expectedDecision, errors.New("Error making decision"))
+
+	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext).Return(expectedDecision, errors.New("Error making decision"))
+
+	compositeFeatureService := &CompositeFeatureService{
+		featureServices: []FeatureService{
+			s.mockFeatureService,
+			s.mockFeatureService2,
+		},
+	}
+	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
+	s.Equal(expectedDecision, decision)
+	s.Error(err)
+	s.Equal(err.Error(), "no decision was made")
+	s.mockFeatureService.AssertExpectations(s.T())
+	s.mockFeatureService2.AssertExpectations(s.T())
+}
+
 func (s *CompositeFeatureServiceTestSuite) TestNewCompositeFeatureService() {
 	// Assert that the service is instantiated with the correct child services in the right order
 	compositeExperimentService := NewCompositeExperimentService()

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -129,7 +129,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsError() {
 }
 
 func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWithError() {
-	// test that GetDecision returns the last decision with error "no decision was made" if all decision services return error
+	// test that GetDecision returns the last decision with error if all decision services return error
 	testUserContext := entities.UserContext{
 		ID: "test_user_1",
 	}
@@ -139,7 +139,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 	}
 	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext).Return(expectedDecision, errors.New("Error making decision"))
 
-	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext).Return(expectedDecision, errors.New("Error making decision"))
+	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext).Return(expectedDecision, errors.New("test error"))
 
 	compositeFeatureService := &CompositeFeatureService{
 		featureServices: []FeatureService{
@@ -150,7 +150,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)
 	s.Error(err)
-	s.Equal(err.Error(), "no decision was made")
+	s.Equal(err.Error(), "test error")
 	s.mockFeatureService.AssertExpectations(s.T())
 	s.mockFeatureService2.AssertExpectations(s.T())
 }

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -240,7 +240,7 @@ func getEventAttributes(projectConfig pkg.ProjectConfig, attributes map[string]i
 			efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
 			continue
 		}
-		visitorAttribute.Key = attribute.Key
+		visitorAttribute.Key = key
 		visitorAttribute.Value = value
 		visitorAttribute.AttributeType = attributeType
 


### PR DESCRIPTION
### Summary
- Fixed `GetDecision` method for CompositeFeatureService, it now returns the last decision made in case every decision-service returned an error.
- Fixed assignment of `Key` property for visitor attribute struct.