### PR TITLE
fix(ExperimentWhitelistService): Fix finding variation by key

### DIFF
--- a/pkg/decision/experiment_whitelist_service.go
+++ b/pkg/decision/experiment_whitelist_service.go
@@ -49,8 +49,8 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 
 	// TODO(Matt): Add a VariationsByKey map to the Experiment struct, and use it to look up Variation by key
 	for _, variation := range decisionContext.Experiment.Variations {
+		variation := variation
 		if variation.Key == variationKey {
-			variation := variation
 			decision.Reason = reasons.WhitelistVariationAssignmentFound
 			decision.Variation = &variation
 			return decision, nil

--- a/pkg/decision/experiment_whitelist_service.go
+++ b/pkg/decision/experiment_whitelist_service.go
@@ -47,13 +47,14 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 		return decision, nil
 	}
 
-	variation, ok := decisionContext.Experiment.Variations[variationKey]
-	if !ok {
-		decision.Reason = reasons.InvalidWhitelistVariationAssignment
-		return decision, nil
+	for _, variation := range decisionContext.Experiment.Variations {
+		if variation.Key == variationKey {
+			decision.Reason = reasons.WhitelistVariationAssignmentFound
+			decision.Variation = &variation
+			return decision, nil
+		}
 	}
 
-	decision.Reason = reasons.WhitelistVariationAssignmentFound
-	decision.Variation = &variation
+	decision.Reason = reasons.InvalidWhitelistVariationAssignment
 	return decision, nil
 }

--- a/pkg/decision/experiment_whitelist_service.go
+++ b/pkg/decision/experiment_whitelist_service.go
@@ -50,6 +50,7 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 	// TODO(Matt): Add a VariationsByKey map to the Experiment struct, and use it to look up Variation by key
 	for _, variation := range decisionContext.Experiment.Variations {
 		if variation.Key == variationKey {
+			variation := variation
 			decision.Reason = reasons.WhitelistVariationAssignmentFound
 			decision.Variation = &variation
 			return decision, nil

--- a/pkg/decision/experiment_whitelist_service.go
+++ b/pkg/decision/experiment_whitelist_service.go
@@ -47,6 +47,7 @@ func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisi
 		return decision, nil
 	}
 
+	// TODO(Matt): Add a VariationsByKey map to the Experiment struct, and use it to look up Variation by key
 	for _, variation := range decisionContext.Experiment.Variations {
 		if variation.Key == variationKey {
 			decision.Reason = reasons.WhitelistVariationAssignmentFound

--- a/pkg/decision/experiment_whitelist_service_test.go
+++ b/pkg/decision/experiment_whitelist_service_test.go
@@ -122,6 +122,23 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext(
 	s.Nil(decision.Variation)
 }
 
+// Test an experiment whose key differs from its id
+func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecisionForExpWithKey() {
+	testDecisionContext := ExperimentDecisionContext{
+		Experiment:    &testExpWhitelist2,
+		ProjectConfig: s.mockConfig,
+	}
+
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+}
+
 func TestExperimentWhitelistTestSuite(t *testing.T) {
 	suite.Run(t, new(ExperimentWhitelistServiceTestSuite))
 }

--- a/pkg/decision/experiment_whitelist_service_test.go
+++ b/pkg/decision/experiment_whitelist_service_test.go
@@ -122,23 +122,6 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext(
 	s.Nil(decision.Variation)
 }
 
-// Test an experiment whose key differs from its id
-func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecisionForExpWithKey() {
-	testDecisionContext := ExperimentDecisionContext{
-		Experiment:    &testExpWhitelist2,
-		ProjectConfig: s.mockConfig,
-	}
-
-	testUserContext := entities.UserContext{
-		ID: "test_user_1",
-	}
-
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext)
-
-	s.NoError(err)
-	s.NotNil(decision.Variation)
-}
-
 func TestExperimentWhitelistTestSuite(t *testing.T) {
 	suite.Run(t, new(ExperimentWhitelistServiceTestSuite))
 }

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -242,3 +242,21 @@ var testExpWhitelist = entities.Experiment{
 		"test_user_2": "2230",
 	},
 }
+
+// Experiment with a whitelist, and variation ids are not the same as keys
+const testExpWhitelistKey2 = "test_experiment_whitelist_2"
+
+var testExpWhitelistVar2230 = entities.Variation{ID: "2230", Key: "var_2230"}
+var testExpWhitelist2 = entities.Experiment{
+	ID:  "1117",
+	Key: testExpWhitelistKey2,
+	Variations: map[string]entities.Variation{
+		"2230": testExpWhitelistVar2230,
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2230", EndOfRange: 10000},
+	},
+	Whitelist: map[string]string{
+		"test_user_1": "var_2230",
+	},
+}

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -226,7 +226,7 @@ var testTargetedExp1116 = entities.Experiment{
 // Experiment with a whitelist
 const testExpWhitelistKey = "test_experiment_whitelist"
 
-var testExpWhitelistVar2229 = entities.Variation{ID: "2229", Key: "2229"}
+var testExpWhitelistVar2229 = entities.Variation{ID: "2229", Key: "var_2229"}
 var testExpWhitelist = entities.Experiment{
 	ID:  "1117",
 	Key: testExpWhitelistKey,
@@ -237,26 +237,8 @@ var testExpWhitelist = entities.Experiment{
 		entities.Range{EntityID: "2229", EndOfRange: 10000},
 	},
 	Whitelist: map[string]string{
-		"test_user_1": "2229",
-		// Note: this is an invalid entry, there is no variation 2230 in this experiment
-		"test_user_2": "2230",
-	},
-}
-
-// Experiment with a whitelist, and variation ids are not the same as keys
-const testExpWhitelistKey2 = "test_experiment_whitelist_2"
-
-var testExpWhitelistVar2230 = entities.Variation{ID: "2230", Key: "var_2230"}
-var testExpWhitelist2 = entities.Experiment{
-	ID:  "1117",
-	Key: testExpWhitelistKey2,
-	Variations: map[string]entities.Variation{
-		"2230": testExpWhitelistVar2230,
-	},
-	TrafficAllocation: []entities.Range{
-		entities.Range{EntityID: "2230", EndOfRange: 10000},
-	},
-	Whitelist: map[string]string{
-		"test_user_1": "var_2230",
+		"test_user_1": "var_2229",
+		// Note: this is an invalid entry, there is no variation with key "var_2230" in this experiment
+		"test_user_2": "var_2230",
 	},
 }


### PR DESCRIPTION
Previously, `GetDecision` of `ExperimentWhitelistService` was incorrectly using variation key to look up variations in the `Variations` map of an `Experiment` struct, in which keys are variation IDs, not variation keys. 

With this fix, we iterate over variations to find the one with the desired key. To avoid needing to search all variations, we can add a map keyed by variation key as a follow up.