### PR TITLE
RFC: Experiment overrides

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/client"
+	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
 	"github.com/optimizely/go-sdk/pkg/logging"
@@ -67,4 +68,24 @@ func main() {
 		client.WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 	optimizelyClient.Close()
+
+	/************* Setting experiment overrides (a.k.a. "forced variations") ********************/
+	overrideKey := decision.OverrideKey{
+		Experiment: "aaaa",
+		User:       "Matt",
+	}
+	overrides := map[decision.OverrideKey]string{
+		overrideKey: "variation_1",
+	}
+	compositeService := decision.NewCompositeService(
+		sdkKey,
+		decision.WithExperimentOverrides(overrides),
+	)
+	optimizelyClient, _ = optimizelyFactory.Client(
+		client.WithDecisionService(compositeService),
+	)
+	// Optimizely client now has "variation_1" forced for user "Matt" in experiment "aaaa"
+	// The forced variation will work regardless of whether "aaaa" is an A/B test or a Feature Test.
+	fmt.Printf("Is feature enabled? %v\n", enabled)
+
 }

--- a/pkg/decision/composite_service.go
+++ b/pkg/decision/composite_service.go
@@ -38,10 +38,12 @@ type CompositeService struct {
 // CSOptionFunc allows customization of the CompositeService returned from NewCompositeService
 type CSOptionFunc func(*CompositeService)
 
-// WithCompositeExperimentService sets a custom compositeExperimentService
-func WithCompositeExperimentService(compositeExperimentService *CompositeExperimentService) CSOptionFunc {
+// WithExperimentOverrides applies the argument experiment overrides to a composite service
+func WithExperimentOverrides(experimentOverrides map[OverrideKey]string) CSOptionFunc {
 	return func(service *CompositeService) {
-		service.compositeExperimentService = compositeExperimentService
+		service.compositeExperimentService = NewCompositeExperimentService(
+			WithOverrides(experimentOverrides),
+		)
 	}
 }
 

--- a/pkg/decision/experiment_override_service.go
+++ b/pkg/decision/experiment_override_service.go
@@ -1,0 +1,68 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"errors"
+
+	"github.com/optimizely/go-sdk/pkg/decision/reasons"
+	"github.com/optimizely/go-sdk/pkg/entities"
+)
+
+// OverrideKey is the type of keys in the Overrides map of ExperimentOverrideService
+type OverrideKey struct {
+	experiment, user string
+}
+
+// ExperimentOverrideService makes a decision using a given map of (experiment key, user id) to variation keys
+// Implements the ExperimentService interface
+type ExperimentOverrideService struct {
+	Overrides map[OverrideKey]string
+}
+
+// NewExperimentOverrideService returns a pointer to an initialized ExperimentOverrideService
+func NewExperimentOverrideService(overrides map[OverrideKey]string) *ExperimentOverrideService {
+	return &ExperimentOverrideService{
+		Overrides: overrides,
+	}
+}
+
+// GetDecision returns a decision with a variation when a variation assignment is found in the configured overrides for the given user and experiment
+func (s ExperimentOverrideService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (ExperimentDecision, error) {
+	decision := ExperimentDecision{}
+
+	if decisionContext.Experiment == nil {
+		return decision, errors.New("decisionContext Experiment is nil")
+	}
+
+	variationKey, ok := s.Overrides[OverrideKey{experiment: decisionContext.Experiment.Key, user: userContext.ID}]
+	if !ok {
+		decision.Reason = reasons.NoOverrideVariationForUser
+		return decision, nil
+	}
+
+	variation, ok := decisionContext.Experiment.Variations[variationKey]
+	if !ok {
+		decision.Reason = reasons.InvalidOverrideVariationForUser
+		return decision, nil
+	}
+
+	decision.Variation = &variation
+	decision.Reason = reasons.OverrideVariationFound
+	return decision, nil
+}

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -47,7 +47,7 @@ func (s *ExperimentOverrideServiceTestSuite) TestOverridesIncludeVariation() {
 		ID: "test_user_1",
 	}
 
-	s.overrides[OverrideKey{experiment: testExp1111.Key, user: testUserContext.ID}] = testExp1111Var2222.Key
+	s.overrides[OverrideKey{Experiment: testExp1111.Key, User: testUserContext.ID}] = testExp1111Var2222.Key
 
 	decision, err := s.overrideService.GetDecision(testDecisionContext, testUserContext)
 

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"testing"
+
+	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExperimentOverrideServiceTestSuite struct {
+	suite.Suite
+	mockConfig      *mockProjectConfig
+	overrides       map[OverrideKey]string
+	overrideService *ExperimentOverrideService
+}
+
+func (s *ExperimentOverrideServiceTestSuite) SetupTest() {
+	s.mockConfig = new(mockProjectConfig)
+	s.overrides = make(map[OverrideKey]string)
+	s.overrideService = NewExperimentOverrideService(s.overrides)
+}
+
+func (s *ExperimentOverrideServiceTestSuite) TestOverridesIncludeVariation() {
+	testDecisionContext := ExperimentDecisionContext{
+		Experiment:    &testExp1111,
+		ProjectConfig: s.mockConfig,
+	}
+
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	s.overrides[OverrideKey{experiment: testExp1111.Key, user: testUserContext.ID}] = testExp1111Var2222.Key
+
+	decision, err := s.overrideService.GetDecision(testDecisionContext, testUserContext)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+}
+
+func TestExperimentOverridesTestSuite(t *testing.T) {
+	suite.Run(t, new(ExperimentOverrideServiceTestSuite))
+}

--- a/pkg/decision/reasons/reason.go
+++ b/pkg/decision/reasons/reason.go
@@ -44,9 +44,9 @@ const (
 	// WhitelistVariationAssignmentFound - a valid variation assignment was found for the given user and experiment
 	WhitelistVariationAssignmentFound Reason = "Whitelist variation assignment found"
 	// NoOverrideVariationForUser - No override variation was found for the given user and experiment
-	NoOverrideVariationForUser Reason = "No override variation for user"
+	NoOverrideVariationForUser Reason = "No override variation assignment"
 	// InvalidOverrideVariationForUser - An override variation was found for the given user and experiment, but no variation with that key exists in the given experiment
-	InvalidOverrideVariationForUser Reason = "No override variation for user"
+	InvalidOverrideVariationForUser Reason = "Invalid override variation assignment"
 	// OverrideVariationFound - A valid override variation was found for the given user and experiment
-	OverrideVariationFound Reason = "Override variation found"
+	OverrideVariationFound Reason = "Override variation assignment found"
 )

--- a/pkg/decision/reasons/reason.go
+++ b/pkg/decision/reasons/reason.go
@@ -43,4 +43,10 @@ const (
 	InvalidWhitelistVariationAssignment Reason = "Invalid whitelist variation assignment"
 	// WhitelistVariationAssignmentFound - a valid variation assignment was found for the given user and experiment
 	WhitelistVariationAssignmentFound Reason = "Whitelist variation assignment found"
+	// NoOverrideVariationForUser - No override variation was found for the given user and experiment
+	NoOverrideVariationForUser Reason = "No override variation for user"
+	// InvalidOverrideVariationForUser - An override variation was found for the given user and experiment, but no variation with that key exists in the given experiment
+	InvalidOverrideVariationForUser Reason = "No override variation for user"
+	// OverrideVariationFound - A valid override variation was found for the given user and experiment
+	OverrideVariationFound Reason = "Override variation found"
 )


### PR DESCRIPTION
This WIP PR introduces "experiment overrides" as a way of satisfying the same requirements that are covered by "forced variation" methods in older SDKs.

The approach is to allow the SDK consumer to maintain their own map, which specifies the desired set of forced variations. They can add or remove entries from this map at will. The SDK provides an option function to be used with `NewCompositeService` that accepts the overrides map, and can be used to create a decision service which will honor the overrides in the map any time an experiment decision is made.

Comments requested on the following:

- There are no affordances for concurrency. Should there be? Do we say that the client is not thread safe, and push all responsibility to the user?
- As option functions proliferate, we might introduce implicit ordering or state requirements that ruin their composability, and I see no testing in place to prevent this. Should we have a standard framework or test strategy to prevent problems?
- When using option functions to overwrite certain struct fields, we potentially waste work creating values for fields, only for them to be overwritten by the option func. This could turn into a performance problem. Is the best general approach to create a zero-valued struct first, then apply options, and then finally fill in remaining fields? How do we tell in general what fields remain uninitialized after applying options?