### PR TITLE
fix: support audience ids

### DIFF
--- a/pkg/config/datafileprojectconfig/entities/entities.go
+++ b/pkg/config/datafileprojectconfig/entities/entities.go
@@ -42,7 +42,7 @@ type Experiment struct {
 	TrafficAllocation  []trafficAllocation `json:"trafficAllocation"`
 	AudienceIds        []string            `json:"audienceIds"`
 	ForcedVariations   map[string]string   `json:"forcedVariations"`
-	AudienceConditions interface{}         `json:"audienceConditions"`
+	AudienceConditions []interface{}       `json:"audienceConditions"`
 }
 
 // FeatureFlag represents a FeatureFlag object from the Optimizely datafile

--- a/pkg/config/datafileprojectconfig/mappers/condition_trees.go
+++ b/pkg/config/datafileprojectconfig/mappers/condition_trees.go
@@ -108,9 +108,7 @@ func buildAudienceConditionTree(conditions interface{}) (conditionTree *entities
 	value := reflect.ValueOf(conditions)
 	visited := make(map[interface{}]bool)
 
-	conditionTree = &entities.TreeNode{
-		Operator: "or",
-	}
+	conditionTree = &entities.TreeNode{ Operator: "or" }
 	var populateConditions func(v reflect.Value, root *entities.TreeNode)
 	populateConditions = func(v reflect.Value, root *entities.TreeNode) {
 

--- a/pkg/config/datafileprojectconfig/mappers/condition_trees.go
+++ b/pkg/config/datafileprojectconfig/mappers/condition_trees.go
@@ -108,7 +108,9 @@ func buildAudienceConditionTree(conditions interface{}) (conditionTree *entities
 	value := reflect.ValueOf(conditions)
 	visited := make(map[interface{}]bool)
 
-	conditionTree = &entities.TreeNode{}
+	conditionTree = &entities.TreeNode{
+		Operator: "or",
+	}
 	var populateConditions func(v reflect.Value, root *entities.TreeNode)
 	populateConditions = func(v reflect.Value, root *entities.TreeNode) {
 

--- a/pkg/config/datafileprojectconfig/mappers/condition_trees_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/condition_trees_test.go
@@ -30,8 +30,9 @@ func TestBuildAudienceConditionTreeEmpty(t *testing.T) {
 	json.Unmarshal([]byte(conditionString), &conditions)
 	conditionTree, err := buildAudienceConditionTree(conditions)
 
-	assert.NotNil(t, err)
-	assert.Equal(t, (*entities.TreeNode)(nil), conditionTree)
+	expectedTree := &entities.TreeNode{Operator: "or"}
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTree, conditionTree)
 }
 
 func TestBuildAudienceConditionTreeSimpleAudienceCondition(t *testing.T) {

--- a/pkg/config/datafileprojectconfig/mappers/condition_trees_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/condition_trees_test.go
@@ -70,6 +70,22 @@ func TestBuildAudienceConditionTreeSimpleAudienceCondition(t *testing.T) {
 	assert.Equal(t, expectedConditionTree, conditionTree)
 }
 
+func TestBuildAudienceConditionTreeNoOperators(t *testing.T) {
+	conditions := []string{"123"}
+	expectedConditionTree := &entities.TreeNode{
+		Operator: "or",
+		Nodes: []*entities.TreeNode{
+			{
+				Item: "123",
+			},
+		},
+	}
+
+	conditionTree, err := buildAudienceConditionTree(conditions)
+	assert.Equal(t, expectedConditionTree, conditionTree)
+	assert.NoError(t, err)
+}
+
 func TestBuildConditionTreeUsingDatafileAudienceConditions(t *testing.T) {
 
 	audience := datafileConfig.Audience{

--- a/pkg/config/datafileprojectconfig/mappers/experiment.go
+++ b/pkg/config/datafileprojectconfig/mappers/experiment.go
@@ -60,7 +60,7 @@ func mapExperiment(rawExperiment datafileEntities.Experiment) entities.Experimen
 	var err error
 	if rawExperiment.AudienceConditions == nil && len(rawExperiment.AudienceIds) > 0 {
 		audienceConditionTree, err = buildAudienceConditionTree(rawExperiment.AudienceIds)
-	} else {
+	} else if len(rawExperiment.AudienceConditions) > 0 {
 		audienceConditionTree, err = buildAudienceConditionTree(rawExperiment.AudienceConditions)
 	}
 	if err != nil {

--- a/pkg/config/datafileprojectconfig/mappers/experiment.go
+++ b/pkg/config/datafileprojectconfig/mappers/experiment.go
@@ -56,7 +56,13 @@ func mapVariation(rawVariation datafileEntities.Variation) entities.Variation {
 
 // Maps the raw experiment entity from the datafile into an SDK Experiment entity
 func mapExperiment(rawExperiment datafileEntities.Experiment) entities.Experiment {
-	audienceConditionTree, err := buildAudienceConditionTree(rawExperiment.AudienceConditions)
+	var audienceConditionTree *entities.TreeNode
+	var err error
+	if rawExperiment.AudienceConditions == nil && len(rawExperiment.AudienceIds) > 0 {
+		audienceConditionTree, err = buildAudienceConditionTree(rawExperiment.AudienceIds)
+	} else {
+		audienceConditionTree, err = buildAudienceConditionTree(rawExperiment.AudienceConditions)
+	}
 	if err != nil {
 		// @TODO: handle error
 		func() {}() // cheat the linters

--- a/pkg/config/datafileprojectconfig/mappers/experiment_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/experiment_test.go
@@ -19,7 +19,7 @@ package mappers
 import (
 	"testing"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	datafileEntities "github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig/entities"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/stretchr/testify/assert"
@@ -112,4 +112,32 @@ func TestMapExperiments(t *testing.T) {
 
 	assert.Equal(t, expectedExperiments, experiments)
 	assert.Equal(t, expectedExperimentKeyMap, experimentKeyMap)
+}
+
+func TestMapExperimentsAudienceIdsOnly(t *testing.T) {
+	var rawExperiment datafileEntities.Experiment
+	rawExperiment.AudienceIds = []string{"11111", "11112"}
+	rawExperiment.Key = "test_experiment_1"
+	rawExperiment.ID = "22222"
+
+	expectedExperiment := entities.Experiment{
+		AudienceIds: rawExperiment.AudienceIds,
+		ID:          rawExperiment.ID,
+		Key:         rawExperiment.Key,
+		AudienceConditionTree: &entities.TreeNode{
+			Operator: "or",
+			Nodes: []*entities.TreeNode{
+				{
+					Operator: "",
+					Item:     "11111",
+				},
+				{
+					Operator: "",
+					Item:     "11112",
+				},
+			},
+		},
+	}
+	experiments, _ := MapExperiments([]datafileEntities.Experiment{rawExperiment})
+	assert.Equal(t, expectedExperiment.AudienceConditionTree, experiments[rawExperiment.ID].AudienceConditionTree)
 }

--- a/pkg/decision/evaluator/matchers/exact.go
+++ b/pkg/decision/evaluator/matchers/exact.go
@@ -34,7 +34,7 @@ func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	if stringValue, ok := m.Condition.Value.(string); ok {
 		attributeValue, err := user.GetStringAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return stringValue == attributeValue, nil
 	}
@@ -42,7 +42,7 @@ func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	if boolValue, ok := m.Condition.Value.(bool); ok {
 		attributeValue, err := user.GetBoolAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return boolValue == attributeValue, nil
 	}
@@ -50,7 +50,7 @@ func (m ExactMatcher) Match(user entities.UserContext) (bool, error) {
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
 		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return floatValue == attributeValue, nil
 	}

--- a/pkg/decision/evaluator/matchers/exact_test.go
+++ b/pkg/decision/evaluator/matchers/exact_test.go
@@ -54,7 +54,7 @@ func TestExactMatcherString(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"string_not_foo": "foo",
@@ -62,7 +62,7 @@ func TestExactMatcherString(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestExactMatcherBool(t *testing.T) {
@@ -95,7 +95,7 @@ func TestExactMatcherBool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"not_bool_true": true,
@@ -103,7 +103,7 @@ func TestExactMatcherBool(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestExactMatcherInt(t *testing.T) {
@@ -147,7 +147,7 @@ func TestExactMatcherInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"int_43": 42,
@@ -155,7 +155,7 @@ func TestExactMatcherInt(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestExactMatcherFloat(t *testing.T) {
@@ -188,7 +188,7 @@ func TestExactMatcherFloat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"float_4_3": 4.2,
@@ -196,5 +196,5 @@ func TestExactMatcherFloat(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/decision/evaluator/matchers/gt.go
+++ b/pkg/decision/evaluator/matchers/gt.go
@@ -35,7 +35,7 @@ func (m GtMatcher) Match(user entities.UserContext) (bool, error) {
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
 		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return floatValue < attributeValue, nil
 	}

--- a/pkg/decision/evaluator/matchers/gt_test.go
+++ b/pkg/decision/evaluator/matchers/gt_test.go
@@ -76,7 +76,7 @@ func TestGtMatcherInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"int_43": 42,
@@ -84,7 +84,7 @@ func TestGtMatcherInt(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGtMatcherFloat(t *testing.T) {
@@ -127,7 +127,7 @@ func TestGtMatcherFloat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"float_4_3": 4.2,
@@ -135,5 +135,5 @@ func TestGtMatcherFloat(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/decision/evaluator/matchers/lt.go
+++ b/pkg/decision/evaluator/matchers/lt.go
@@ -35,7 +35,7 @@ func (m LtMatcher) Match(user entities.UserContext) (bool, error) {
 	if floatValue, ok := utils.ToFloat(m.Condition.Value); ok {
 		attributeValue, err := user.GetFloatAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return floatValue > attributeValue, nil
 	}

--- a/pkg/decision/evaluator/matchers/lt_test.go
+++ b/pkg/decision/evaluator/matchers/lt_test.go
@@ -76,7 +76,7 @@ func TestLtMatcherInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"int_43": 42,
@@ -84,7 +84,7 @@ func TestLtMatcherInt(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestLtMatcherFloat(t *testing.T) {
@@ -127,7 +127,7 @@ func TestLtMatcherFloat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"float_4_3": 4.2,
@@ -135,5 +135,5 @@ func TestLtMatcherFloat(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/decision/evaluator/matchers/substring.go
+++ b/pkg/decision/evaluator/matchers/substring.go
@@ -35,7 +35,7 @@ func (m SubstringMatcher) Match(user entities.UserContext) (bool, error) {
 	if stringValue, ok := m.Condition.Value.(string); ok {
 		attributeValue, err := user.GetStringAttribute(m.Condition.Name)
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return strings.Contains(attributeValue, stringValue), nil
 	}

--- a/pkg/decision/evaluator/matchers/substring_test.go
+++ b/pkg/decision/evaluator/matchers/substring_test.go
@@ -55,7 +55,7 @@ func TestSubstringMatcher(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	// Test error case
+	// Test attribute not found
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{
 			"not_string_foo": "foo",
@@ -63,5 +63,5 @@ func TestSubstringMatcher(t *testing.T) {
 	}
 
 	_, err = matcher.Match(user)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
# Summary
- Fixes bug where `experiment.audienceIds` is not parsed into audience condition tree in the absence of `experiment.audienceConditions`
- Fixes bug where user attribute lookup returns error when attribute not found during condition matching, and thus results in the `not` condition being short-circuited to false