### PR TITLE
feat(decision): User profile service

### DIFF
--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -34,16 +34,14 @@ type CompositeExperimentService struct {
 
 // NewCompositeExperimentService creates a new instance of the CompositeExperimentService
 func NewCompositeExperimentService() *CompositeExperimentService {
-	persistingExperimentService := NewPersistingExperimentService(NewExperimentBucketerService())
-
 	// These decision services are applied in order:
 	// 1. Whitelist
-	// 2. Bucketing (wrapped with user profile service)
+	// 2. Bucketing
 	// @TODO(mng): Prepend forced variation
 	return &CompositeExperimentService{
 		experimentServices: []ExperimentService{
 			NewExperimentWhitelistService(),
-			persistingExperimentService,
+			NewExperimentBucketerService(),
 		},
 	}
 }

--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -34,14 +34,16 @@ type CompositeExperimentService struct {
 
 // NewCompositeExperimentService creates a new instance of the CompositeExperimentService
 func NewCompositeExperimentService() *CompositeExperimentService {
+	persistingExperimentService := NewPersistingExperimentService(NewExperimentBucketerService())
+
 	// These decision services are applied in order:
 	// 1. Whitelist
-	// 2. Bucketing
+	// 2. Bucketing (wrapped with user profile service)
 	// @TODO(mng): Prepend forced variation
 	return &CompositeExperimentService{
 		experimentServices: []ExperimentService{
 			NewExperimentWhitelistService(),
-			NewExperimentBucketerService(),
+			persistingExperimentService,
 		},
 	}
 }

--- a/pkg/decision/entities.go
+++ b/pkg/decision/entities.go
@@ -67,6 +67,15 @@ type ExperimentDecision struct {
 // UserDecisionKey is used to access the saved decisions in a user profile
 type UserDecisionKey struct {
 	ExperimentID string
+	Field        string
+}
+
+// NewUserDecisionKey returns a new UserDecisionKey with the given experiment ID
+func NewUserDecisionKey(experimentID string) UserDecisionKey {
+	return UserDecisionKey{
+		ExperimentID: experimentID,
+		Field:        "variation_id",
+	}
 }
 
 // UserProfile represents a saved user profile

--- a/pkg/decision/entities.go
+++ b/pkg/decision/entities.go
@@ -63,3 +63,14 @@ type ExperimentDecision struct {
 	Decision
 	Variation *entities.Variation
 }
+
+// UserDecisionKey is used to access the saved decisions in a user profile
+type UserDecisionKey struct {
+	ExperimentID string
+}
+
+// UserProfile represents a saved user profile
+type UserProfile struct {
+	ID                  string
+	ExperimentBucketMap map[UserDecisionKey]string
+}

--- a/pkg/decision/interface.go
+++ b/pkg/decision/interface.go
@@ -42,6 +42,6 @@ type FeatureService interface {
 
 // UserProfileService is used to save and retrieve past bucketing decisions for users
 type UserProfileService interface {
-	Lookup(string) (UserProfile, error)
-	Save(UserProfile) error
+	Lookup(string) UserProfile
+	Save(UserProfile)
 }

--- a/pkg/decision/interface.go
+++ b/pkg/decision/interface.go
@@ -39,3 +39,9 @@ type ExperimentService interface {
 type FeatureService interface {
 	GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext) (FeatureDecision, error)
 }
+
+// UserProfileService is used to save and retrieve past bucketing decisions for users
+type UserProfileService interface {
+	Lookup(string) (UserProfile, error)
+	Save(UserProfile) error
+}

--- a/pkg/decision/persisting_experiment_service.go
+++ b/pkg/decision/persisting_experiment_service.go
@@ -1,0 +1,119 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"fmt"
+
+	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+)
+
+var pesLogger = logging.GetLogger("pkg/decision/persisting_experiment_service")
+
+// PersistingExperimentService attempts to retrieve a saved decision from the user profile service
+// for the user before having the ExperimentBucketerService compute it.
+// If computed, the decision is saved back to the user profile service if provided.
+type PersistingExperimentService struct {
+	experimentBucketedService ExperimentService
+	userProfileService        UserProfileService
+}
+
+// PESOptionFunc is used to extend the PersistingExperimentService with additional options
+type PESOptionFunc func(*PersistingExperimentService)
+
+// WithUserProfileService sets the user profile service on the persistingExperimentService instance
+func WithUserProfileService(userProfileService UserProfileService) PESOptionFunc {
+	return func(f *PersistingExperimentService) {
+		f.userProfileService = userProfileService
+	}
+}
+
+// NewPersistingExperimentService returns a new instance of the PersistingExperimentService
+func NewPersistingExperimentService(experimentBucketerService ExperimentService, options ...PESOptionFunc) *PersistingExperimentService {
+	persistingExperimentService := &PersistingExperimentService{
+		experimentBucketedService: experimentBucketerService,
+	}
+
+	for _, opt := range options {
+		opt(persistingExperimentService)
+	}
+
+	return persistingExperimentService
+}
+
+// GetDecision returns the decision with the variation the user is bucketed into
+func (p PersistingExperimentService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (ExperimentDecision, error) {
+	var experimentDecision ExperimentDecision
+	var err error
+	var userProfile UserProfile
+	// check to see if there is a saved decision for the user
+	if p.userProfileService != nil {
+		experimentDecision, userProfile = p.getSavedDecision(decisionContext, userContext)
+		if experimentDecision.Variation != nil {
+			return experimentDecision, nil
+		}
+	}
+
+	experimentDecision, err = p.experimentBucketedService.GetDecision(decisionContext, userContext)
+	if experimentDecision.Variation != nil && p.userProfileService != nil {
+		// save decision if a user profile service is provided
+		p.saveDecision(userProfile, decisionContext.Experiment, experimentDecision)
+	}
+
+	return experimentDecision, err
+}
+
+func (p PersistingExperimentService) getSavedDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (ExperimentDecision, UserProfile) {
+	experimentDecision := ExperimentDecision{}
+
+	if p.userProfileService == nil {
+		return experimentDecision, UserProfile{}
+	}
+
+	userProfile, err := p.userProfileService.Lookup(userContext.ID)
+	if err != nil {
+		errMessage := fmt.Sprintf(`Error looking up user from user profile service: %s`, err)
+		bLogger.Warning(errMessage)
+		return experimentDecision, UserProfile{}
+	}
+
+	// look up experiment decision from user profile
+	decisionKey := UserDecisionKey{ExperimentID: decisionContext.Experiment.ID}
+	if savedVariationID, ok := userProfile.ExperimentBucketMap[decisionKey]; ok {
+		if variation, ok := decisionContext.Experiment.Variations[savedVariationID]; ok {
+			experimentDecision.Variation = &variation
+			bLogger.Debug(fmt.Sprintf(`User "%s" was previously bucketed into variation "%s" of experiment "%s".`, userContext.ID, variation.Key, decisionContext.Experiment.Key))
+		} else {
+			bLogger.Warning(fmt.Sprintf(`User "%s" was previously bucketed into variation with ID "%s" for experiment "%s", but no matching variation was found.`, userContext.ID, savedVariationID, decisionContext.Experiment.Key))
+		}
+	}
+
+	return experimentDecision, userProfile
+}
+
+func (p PersistingExperimentService) saveDecision(userProfile UserProfile, experiment *entities.Experiment, decision ExperimentDecision) {
+	if p.userProfileService != nil {
+		decisionKey := UserDecisionKey{ExperimentID: experiment.ID}
+		userProfile.ExperimentBucketMap[decisionKey] = decision.Variation.ID
+		err := p.userProfileService.Save(userProfile)
+		if err != nil {
+			bLogger.Error(`Unable to save decision to user profile service`, err)
+		}
+	}
+}

--- a/pkg/decision/persisting_experiment_service.go
+++ b/pkg/decision/persisting_experiment_service.go
@@ -71,7 +71,7 @@ func (p PersistingExperimentService) getSavedDecision(decisionContext Experiment
 	userProfile, err := p.userProfileService.Lookup(userContext.ID)
 	if err != nil {
 		errMessage := fmt.Sprintf(`Error looking up user from user profile service: %s`, err)
-		bLogger.Warning(errMessage)
+		pesLogger.Warning(errMessage)
 		return experimentDecision, UserProfile{ID: userContext.ID}
 	}
 
@@ -80,9 +80,9 @@ func (p PersistingExperimentService) getSavedDecision(decisionContext Experiment
 	if savedVariationID, ok := userProfile.ExperimentBucketMap[decisionKey]; ok {
 		if variation, ok := decisionContext.Experiment.Variations[savedVariationID]; ok {
 			experimentDecision.Variation = &variation
-			bLogger.Debug(fmt.Sprintf(`User "%s" was previously bucketed into variation "%s" of experiment "%s".`, userContext.ID, variation.Key, decisionContext.Experiment.Key))
+			pesLogger.Debug(fmt.Sprintf(`User "%s" was previously bucketed into variation "%s" of experiment "%s".`, userContext.ID, variation.Key, decisionContext.Experiment.Key))
 		} else {
-			bLogger.Warning(fmt.Sprintf(`User "%s" was previously bucketed into variation with ID "%s" for experiment "%s", but no matching variation was found.`, userContext.ID, savedVariationID, decisionContext.Experiment.Key))
+			pesLogger.Warning(fmt.Sprintf(`User "%s" was previously bucketed into variation with ID "%s" for experiment "%s", but no matching variation was found.`, userContext.ID, savedVariationID, decisionContext.Experiment.Key))
 		}
 	}
 
@@ -98,7 +98,7 @@ func (p PersistingExperimentService) saveDecision(userProfile UserProfile, exper
 		userProfile.ExperimentBucketMap[decisionKey] = decision.Variation.ID
 		err := p.userProfileService.Save(userProfile)
 		if err != nil {
-			bLogger.Error(`Unable to save decision to user profile service`, err)
+			pesLogger.Error(`Unable to save decision to user profile service`, err)
 		}
 	}
 }

--- a/pkg/decision/persisting_experiment_service_test.go
+++ b/pkg/decision/persisting_experiment_service_test.go
@@ -1,0 +1,177 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package decision //
+package decision
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type MockUserProfileService struct {
+	UserProfileService
+	mock.Mock
+}
+
+func (m *MockUserProfileService) Lookup(userID string) (UserProfile, error) {
+	args := m.Called(userID)
+	return args.Get(0).(UserProfile), args.Error(1)
+}
+
+func (m *MockUserProfileService) Save(userProfile UserProfile) error {
+	args := m.Called(userProfile)
+	return args.Error(0)
+}
+
+var testUserContext entities.UserContext = entities.UserContext{
+	ID: "test_user_1",
+}
+
+type PersistingExperimentServiceTestSuite struct {
+	suite.Suite
+	mockProjectConfig      *mockProjectConfig
+	mockExperimentService  *MockExperimentDecisionService
+	mockUserProfileService *MockUserProfileService
+	testComputedDecision   ExperimentDecision
+	testDecisionContext    ExperimentDecisionContext
+}
+
+func (s *PersistingExperimentServiceTestSuite) SetupTest() {
+	s.mockProjectConfig = new(mockProjectConfig)
+	s.mockExperimentService = new(MockExperimentDecisionService)
+	s.mockUserProfileService = new(MockUserProfileService)
+	s.testDecisionContext = ExperimentDecisionContext{
+		Experiment:    &testExp1113,
+		ProjectConfig: s.mockProjectConfig,
+	}
+
+	computedVariation := testExp1113.Variations["2223"]
+	s.testComputedDecision = ExperimentDecision{
+		Variation: &computedVariation,
+	}
+	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext).Return(s.testComputedDecision, nil)
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestNilUserProfileService() {
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, nil)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	s.Equal(s.testComputedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestSavedVariationFound() {
+	decisionKey := UserDecisionKey{ExperimentID: s.testDecisionContext.Experiment.ID}
+	savedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: testExp1113Var2224.ID},
+	}
+	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(savedUserProfile, nil)
+	s.mockUserProfileService.On("Save", mock.Anything)
+
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	savedDecision := ExperimentDecision{
+		Variation: &testExp1113Var2224,
+	}
+	s.Equal(savedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertNotCalled(s.T(), "GetDecision", s.testDecisionContext, testUserContext)
+	s.mockUserProfileService.AssertNotCalled(s.T(), "Save", mock.Anything)
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestNoSavedVariation() {
+	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(UserProfile{ID: testUserContext.ID}, nil) // empty user profile
+	decisionKey := UserDecisionKey{ExperimentID: s.testDecisionContext.Experiment.ID}
+	updatedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
+	}
+
+	s.mockUserProfileService.On("Save", updatedUserProfile).Return(nil)
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	s.Equal(s.testComputedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+	s.mockUserProfileService.AssertExpectations(s.T())
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestSavedVariationNoLongerValid() {
+	decisionKey := UserDecisionKey{ExperimentID: s.testDecisionContext.Experiment.ID}
+	savedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: "forgotten_variation"},
+	}
+	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(savedUserProfile, nil) // empty user profile
+
+	updatedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
+	}
+	s.mockUserProfileService.On("Save", updatedUserProfile).Return(nil)
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	s.Equal(s.testComputedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+	s.mockUserProfileService.AssertExpectations(s.T())
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestErrorGettingSavedVariation() {
+	userProfileErr := errors.New("could not retrieve user profile")
+	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(UserProfile{ID: testUserContext.ID}, userProfileErr) // empty user profile
+
+	decisionKey := UserDecisionKey{ExperimentID: s.testDecisionContext.Experiment.ID}
+	updatedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
+	}
+
+	s.mockUserProfileService.On("Save", updatedUserProfile).Return(nil)
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	s.Equal(s.testComputedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+	s.mockUserProfileService.AssertExpectations(s.T())
+}
+
+func (s *PersistingExperimentServiceTestSuite) TestErrorSavingVariation() {
+	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(UserProfile{ID: testUserContext.ID}, nil) // empty user profile
+	decisionKey := UserDecisionKey{ExperimentID: s.testDecisionContext.Experiment.ID}
+	updatedUserProfile := UserProfile{
+		ID:                  testUserContext.ID,
+		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
+	}
+
+	s.mockUserProfileService.On("Save", updatedUserProfile).Return(errors.New("could not save"))
+	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
+	s.Equal(s.testComputedDecision, decision)
+	s.NoError(err)
+	s.mockExperimentService.AssertExpectations(s.T())
+	s.mockUserProfileService.AssertExpectations(s.T())
+}
+
+func TestPersistingExperimentServiceTestSuite(t *testing.T) {
+	suite.Run(t, new(PersistingExperimentServiceTestSuite))
+}


### PR DESCRIPTION
# Summary
- Introduces UserProfileService interface
- Introduces a PersistingExperimentService class that wraps over the ExperimentBucketerService and performs UPS lookup and save
- Integration into the `CompositeExperimentService` will be done in a follow-up PR