### PR TITLE
fix: return right after datafile getter returns an error (don't parse garbage)

### DIFF
--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -94,6 +94,8 @@ func (cm *PollingProjectConfigManager) SyncConfig(datafile []byte) {
 
 		if e != nil {
 			cmLogger.Error(fmt.Sprintf("request returned with http code=%d", code), e)
+			cm.err = e
+			return
 		}
 	}
 

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -41,6 +41,7 @@ func NewStaticProjectConfigManagerFromURL(sdkKey string) (*StaticProjectConfigMa
 	datafile, code, e := requester.Get()
 	if e != nil {
 		cmLogger.Error(fmt.Sprintf("request returned with http code=%d", code), e)
+		return nil, e
 	}
 
 	return NewStaticProjectConfigManagerFromPayload(datafile)


### PR DESCRIPTION
related to https://optimizely.atlassian.net/browse/OASIS-5597