### PR TITLE
fix: Add a public function to create a MapExperimentOverridesStore instance

### DIFF
--- a/pkg/decision/experiment_override_service.go
+++ b/pkg/decision/experiment_override_service.go
@@ -46,6 +46,13 @@ type MapExperimentOverridesStore struct {
 	mutex        sync.RWMutex
 }
 
+// NewMapExperimentOverridesStore returns a new MapExperimentOverridesStore
+func NewMapExperimentOverridesStore() *MapExperimentOverridesStore {
+	return &MapExperimentOverridesStore{
+		overridesMap: make(map[ExperimentOverrideKey]string),
+	}
+}
+
 // GetVariation returns the override variation key associated with the given user+experiment key
 func (m *MapExperimentOverridesStore) GetVariation(overrideKey ExperimentOverrideKey) (string, bool) {
 	m.mutex.RLock()

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -35,9 +35,7 @@ type ExperimentOverrideServiceTestSuite struct {
 
 func (s *ExperimentOverrideServiceTestSuite) SetupTest() {
 	s.mockConfig = new(mockProjectConfig)
-	s.overrides = &MapExperimentOverridesStore{
-		overridesMap: make(map[ExperimentOverrideKey]string),
-	}
+	s.overrides = NewMapExperimentOverridesStore()
 	s.overrideService = NewExperimentOverrideService(s.overrides)
 }
 


### PR DESCRIPTION
This adds a new function `NewMapExperimentOverridesStore`, so that `MapExperimentOverridesStore` can be used outside the `decision` package. Unit tests are updated to exercise `NewMapExperimentOverridesStore`.