### PR TITLE
feat: Method for removing forced variations

### DIFF
--- a/pkg/decision/experiment_override_service.go
+++ b/pkg/decision/experiment_override_service.go
@@ -68,6 +68,14 @@ func (m *MapExperimentOverridesStore) SetVariation(overrideKey ExperimentOverrid
 	m.mutex.Unlock()
 }
 
+// RemoveVariation removes the override variation key associated with the argument user+experiment key.
+// If there is no override variation key set, this method has no effect.
+func (m *MapExperimentOverridesStore) RemoveVariation(overrideKey ExperimentOverrideKey) {
+	m.mutex.Lock()
+	delete(m.overridesMap, overrideKey)
+	m.mutex.Unlock()
+}
+
 // ExperimentOverrideService makes a decision using an ExperimentOverridesStore
 // Implements the ExperimentService interface
 type ExperimentOverrideService struct {

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -187,6 +187,22 @@ func (s *ExperimentOverrideServiceTestSuite) TestMapExperimentOverridesStoreConc
 	s.Exactly(testExp1111Var2222.Key, user3Decision.Variation.Key)
 }
 
+func (s *ExperimentOverrideServiceTestSuite) TestRemovePreviouslySetVariation() {
+	testDecisionContext := ExperimentDecisionContext{
+		Experiment:    &testExp1111,
+		ProjectConfig: s.mockConfig,
+	}
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+	overrideKey := ExperimentOverrideKey{ExperimentKey: testExp1111.Key, UserID: "test_user_1"}
+	s.overrides.SetVariation(overrideKey, testExp1111Var2222.Key)
+	s.overrides.RemoveVariation(overrideKey)
+	decision, err := s.overrideService.GetDecision(testDecisionContext, testUserContext)
+	s.NoError(err)
+	s.Nil(decision.Variation)
+}
+
 func TestExperimentOverridesTestSuite(t *testing.T) {
 	suite.Run(t, new(ExperimentOverrideServiceTestSuite))
 }


### PR DESCRIPTION
This adds a `RemoveVariation` method of `MapExperimentOverridesStore`, which can be used to delete a previously set variation.