### PR TITLE
fix(decision): Logs produced by the various decision services.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -414,7 +414,7 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 		result := experimentDecision.Variation.Key
 		logger.Info(fmt.Sprintf(`User "%s" is bucketed into variation "%s" of experiment "%s".`, userContext.ID, result, experimentKey))
 	} else {
-		logger.Info(fmt.Sprintf(`User "%s" is not bucketed into any variation for experiment "%s".`, userContext.ID, experimentKey))
+		logger.Info(fmt.Sprintf(`User "%s" is not bucketed into any variation for experiment "%s": %s.`, userContext.ID, experimentKey, experimentDecision.Reason))
 	}
 
 	return decisionContext, experimentDecision, err

--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -18,7 +18,6 @@
 package decision
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -84,13 +83,11 @@ func NewCompositeExperimentService(options ...CESOptionFunc) *CompositeExperimen
 }
 
 // GetDecision returns a decision for the given experiment and user context
-func (s CompositeExperimentService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (ExperimentDecision, error) {
-
-	experimentDecision := ExperimentDecision{}
+func (s CompositeExperimentService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext) (decision ExperimentDecision, err error) {
 
 	// Run through the various decision services until we get a decision
 	for _, experimentService := range s.experimentServices {
-		decision, err := experimentService.GetDecision(decisionContext, userContext)
+		decision, err = experimentService.GetDecision(decisionContext, userContext)
 		if err != nil {
 			ceLogger.Debug(fmt.Sprintf("%v", err))
 		}
@@ -99,5 +96,5 @@ func (s CompositeExperimentService) GetDecision(decisionContext ExperimentDecisi
 		}
 	}
 
-	return experimentDecision, errors.New("no decision was made")
+	return decision, err
 }

--- a/pkg/decision/composite_experiment_service_test.go
+++ b/pkg/decision/composite_experiment_service_test.go
@@ -110,7 +110,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionNoDecisionsMade() {
 	}
 	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 
-	s.Error(err)
+	s.NoError(err)
 	s.Equal(expectedExperimentDecision2, decision)
 	s.mockExperimentService.AssertExpectations(s.T())
 	s.mockExperimentService2.AssertExpectations(s.T())

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -51,7 +51,7 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 			cfLogger.Debug(fmt.Sprintf("%v", err))
 		}
 
-		if featureDecision.Variation != nil && featureDecision.Variation.FeatureEnabled && err == nil {
+		if featureDecision.Variation != nil && err == nil {
 			return featureDecision, err
 		}
 	}

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -50,7 +50,8 @@ func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionCont
 		if err != nil {
 			cfLogger.Debug(fmt.Sprintf("%v", err))
 		}
-		if featureDecision.Variation != nil && err == nil {
+
+		if featureDecision.Variation != nil && featureDecision.Variation.FeatureEnabled && err == nil {
 			return featureDecision, err
 		}
 	}

--- a/pkg/decision/experiment_bucketer_service.go
+++ b/pkg/decision/experiment_bucketer_service.go
@@ -71,7 +71,9 @@ func (s ExperimentBucketerService) GetDecision(decisionContext ExperimentDecisio
 		bLogger.Debug(fmt.Sprintf(`Error computing bucketing ID for experiment "%s": "%s"`, experiment.Key, err.Error()))
 	}
 
-	bLogger.Debug(fmt.Sprintf(`Using bucketing ID: "%s"`, bucketingID))
+	if bucketingID != userContext.ID {
+		bLogger.Debug(fmt.Sprintf(`Using bucketing ID: "%s" for user "%s"`, bucketingID, userContext.ID))
+	}
 	// @TODO: handle error from bucketer
 	variation, reason, _ := s.bucketer.Bucket(bucketingID, *experiment, group)
 	experimentDecision.Reason = reason

--- a/pkg/decision/feature_experiment_service.go
+++ b/pkg/decision/feature_experiment_service.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
+
+var fesLogger = logging.GetLogger("FeatureExperimentService")
 
 // FeatureExperimentService helps evaluate feature test associated with the feature
 type FeatureExperimentService struct {
@@ -47,6 +50,13 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		}
 
 		experimentDecision, err := f.compositeExperimentService.GetDecision(experimentDecisionContext, userContext)
+		fesLogger.Debug(fmt.Sprintf(
+			`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
+			feature.Key,
+			userContext.ID,
+			experimentDecision.Reason,
+		))
+
 		// Variation not nil means we got a decision and should return it
 		if experimentDecision.Variation != nil {
 			featureDecision := FeatureDecision{
@@ -56,12 +66,6 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 				Source:     FeatureTest,
 			}
 
-			cfLogger.Debug(fmt.Sprintf(
-				`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
-				feature.Key,
-				userContext.ID,
-				featureDecision.Reason,
-			))
 			return featureDecision, err
 		}
 	}

--- a/pkg/decision/persisting_experiment_service.go
+++ b/pkg/decision/persisting_experiment_service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
-var pesLogger = logging.GetLogger("pkg/decision/persisting_experiment_service")
+var pesLogger = logging.GetLogger("PersistingExperimentService")
 
 // PersistingExperimentService attempts to retrieve a saved decision from the user profile service
 // for the user before having the ExperimentBucketerService compute it.

--- a/pkg/decision/reasons/reason.go
+++ b/pkg/decision/reasons/reason.go
@@ -25,6 +25,12 @@ const (
 	BucketedVariationNotFound Reason = "Bucketed variation not found"
 	// BucketedIntoVariation - the user is bucketed into a variation for the given experiment
 	BucketedIntoVariation Reason = "Bucketed into variation"
+	// BucketedIntoFeatureTest - the user is bucketed into a variation for the given feature test
+	BucketedIntoFeatureTest Reason = "Bucketed into feature test"
+	// BucketedIntoRollout - the user is bucketed into a variation for the given feature rollout
+	BucketedIntoRollout Reason = "Bucketed into feature rollout"
+	// FailedRolloutBucketing - the user is not bucketed into the feature rollout
+	FailedRolloutBucketing Reason = "Not bucketed into rollout"
 	// FailedRolloutTargeting - the user does not meet the rollout targeting rules
 	FailedRolloutTargeting Reason = "Does not meet rollout targeting rule"
 	// FailedAudienceTargeting - the user failed the audience targeting conditions

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -80,13 +80,16 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 	}
 
 	decision, _ := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext)
-	if decision.Reason == reasons.NotBucketedIntoVariation {
+	// translate the experiment reason into a more rollouts-appropriate reason
+	switch decision.Reason {
+	case reasons.NotBucketedIntoVariation:
 		featureDecision.Decision = Decision{Reason: reasons.FailedRolloutBucketing}
-	} else if decision.Reason == reasons.BucketedIntoVariation {
+	case reasons.BucketedIntoVariation:
 		featureDecision.Decision = Decision{Reason: reasons.BucketedIntoRollout}
-	} else {
+	default:
 		featureDecision.Decision = decision.Decision
 	}
+
 	featureDecision.Experiment = experiment
 	featureDecision.Variation = decision.Variation
 	rsLogger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -18,11 +18,16 @@
 package decision
 
 import (
+	"fmt"
+
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
+
+var rsLogger = logging.GetLogger("RolloutService")
 
 // RolloutService makes a feature decision for a given feature rollout
 type RolloutService struct {
@@ -69,13 +74,22 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		evalResult := r.audienceTreeEvaluator.Evaluate(experiment.AudienceConditionTree, condTreeParams)
 		if !evalResult {
 			featureDecision.Reason = reasons.FailedRolloutTargeting
+			rsLogger.Debug(fmt.Sprintf(`User "%s" failed targeting for feature rollout with key "%s".`, userContext.ID, feature.Key))
 			return featureDecision, nil
 		}
 	}
 
 	decision, _ := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext)
-	featureDecision.Decision = decision.Decision
+	if decision.Reason == reasons.NotBucketedIntoVariation {
+		featureDecision.Decision = Decision{Reason: reasons.FailedRolloutBucketing}
+	} else if decision.Reason == reasons.BucketedIntoVariation {
+		featureDecision.Decision = Decision{Reason: reasons.BucketedIntoRollout}
+	} else {
+		featureDecision.Decision = decision.Decision
+	}
 	featureDecision.Experiment = experiment
 	featureDecision.Variation = decision.Variation
+	rsLogger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))
+
 	return featureDecision, nil
 }


### PR DESCRIPTION
# Summary
- Fixes where and how we log various messages during the decision making process:
- 1. Gets rid of the `No decision made error` and instead returns the `decision` and `err` of the last decision maker
- 2. Logs debug messages in both feature experiment service as well as rollout service for clarity
- 3. Only logs (debug) bucketing ID if it is different from the user ID
- 4. Refactored the rollout_service_test to use suites

# Tests
- Unit