### PR TITLE
chore(docs): Clean up public doc strings on client, factory and top-level components.

### DIFF
--- a/optimizely.go
+++ b/optimizely.go
@@ -21,7 +21,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
-// Client returns an OptimizelyClient instantitated with the given key and options
+// Client returns an OptimizelyClient instantiated with the given key and options
 func Client(sdkKey string, options ...client.OptionFunc) (*client.OptimizelyClient, error) {
 	factory := &client.OptimizelyFactory{
 		SDKKey: sdkKey,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,7 +42,8 @@ type OptimizelyClient struct {
 	executionCtx utils.ExecutionCtx
 }
 
-// Activate returns the key of the variation the user is bucketed into and sends an impression event to the Optimizely log endpoint
+// Activate returns the key of the variation the user is bucketed into and queues up an impression event to be sent to
+// the Optimizely log endpoint for results processing.
 func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.UserContext) (result string, err error) {
 
 	defer func() {
@@ -77,7 +78,8 @@ func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.U
 	return result, err
 }
 
-// IsFeatureEnabled returns true if the feature is enabled for the given user
+// IsFeatureEnabled returns true if the feature is enabled for the given user. If the user is part of a feature test
+// then an impression event will be queued up to be sent to the Optimizely log endpoint for results processing.
 func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entities.UserContext) (result bool, err error) {
 
 	defer func() {
@@ -122,7 +124,8 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 	return result, err
 }
 
-// GetEnabledFeatures returns an array containing the keys of all features in the project that are enabled for the given user.
+// GetEnabledFeatures returns an array containing the keys of all features in the project that are enabled for the given
+// user. For features tests, impression events will be queued up to be sent to the Optimizely log endpoint for results processing.
 func (o *OptimizelyClient) GetEnabledFeatures(userContext entities.UserContext) (enabledFeatures []string, err error) {
 
 	defer func() {
@@ -156,7 +159,7 @@ func (o *OptimizelyClient) GetEnabledFeatures(userContext entities.UserContext) 
 	return enabledFeatures, err
 }
 
-// GetFeatureVariableBoolean returns boolean feature variable value
+// GetFeatureVariableBoolean returns the feature variable value of type bool associated with the given feature and variable keys.
 func (o *OptimizelyClient) GetFeatureVariableBoolean(featureKey, variableKey string, userContext entities.UserContext) (value bool, err error) {
 
 	val, valueType, err := o.GetFeatureVariable(featureKey, variableKey, userContext)
@@ -170,7 +173,7 @@ func (o *OptimizelyClient) GetFeatureVariableBoolean(featureKey, variableKey str
 	return convertedValue, err
 }
 
-// GetFeatureVariableDouble returns double feature variable value
+// GetFeatureVariableDouble returns the feature variable value of type double associated with the given feature and variable keys.
 func (o *OptimizelyClient) GetFeatureVariableDouble(featureKey, variableKey string, userContext entities.UserContext) (value float64, err error) {
 
 	val, valueType, err := o.GetFeatureVariable(featureKey, variableKey, userContext)
@@ -184,7 +187,7 @@ func (o *OptimizelyClient) GetFeatureVariableDouble(featureKey, variableKey stri
 	return convertedValue, err
 }
 
-// GetFeatureVariableInteger returns integer feature variable value
+// GetFeatureVariableInteger returns the feature variable value of type int associated with the given feature and variable keys.
 func (o *OptimizelyClient) GetFeatureVariableInteger(featureKey, variableKey string, userContext entities.UserContext) (value int, err error) {
 
 	val, valueType, err := o.GetFeatureVariable(featureKey, variableKey, userContext)
@@ -198,7 +201,7 @@ func (o *OptimizelyClient) GetFeatureVariableInteger(featureKey, variableKey str
 	return convertedValue, err
 }
 
-// GetFeatureVariableString returns string feature variable value
+// GetFeatureVariableString returns the feature variable value of type string associated with the given feature and variable keys.
 func (o *OptimizelyClient) GetFeatureVariableString(featureKey, variableKey string, userContext entities.UserContext) (value string, err error) {
 
 	value, valueType, err := o.GetFeatureVariable(featureKey, variableKey, userContext)
@@ -211,7 +214,7 @@ func (o *OptimizelyClient) GetFeatureVariableString(featureKey, variableKey stri
 	return value, err
 }
 
-// GetFeatureVariable returns feature as a string along with it's associated type
+// GetFeatureVariable returns feature variable as a string along with it's associated type.
 func (o *OptimizelyClient) GetFeatureVariable(featureKey, variableKey string, userContext entities.UserContext) (value string, valueType entities.VariableType, err error) {
 
 	featureDecisionContext, featureDecision, err := o.getFeatureDecision(featureKey, variableKey, userContext)
@@ -230,7 +233,7 @@ func (o *OptimizelyClient) GetFeatureVariable(featureKey, variableKey string, us
 	return variable.DefaultValue, variable.Type, err
 }
 
-// GetAllFeatureVariables returns all the variables for a given feature along with the enabled state
+// GetAllFeatureVariables returns all the variables for a given feature along with the enabled state.
 func (o *OptimizelyClient) GetAllFeatureVariables(featureKey string, userContext entities.UserContext) (enabled bool, variableMap map[string]string, err error) {
 
 	variableMap = make(map[string]string)
@@ -263,7 +266,7 @@ func (o *OptimizelyClient) GetAllFeatureVariables(featureKey string, userContext
 	return enabled, variableMap, err
 }
 
-// GetVariation returns the key of the variation the user is bucketed into
+// GetVariation returns the key of the variation the user is bucketed into. Does not generate impression events.
 func (o *OptimizelyClient) GetVariation(experimentKey string, userContext entities.UserContext) (result string, err error) {
 
 	defer func() {
@@ -294,7 +297,8 @@ func (o *OptimizelyClient) GetVariation(experimentKey string, userContext entiti
 	return result, err
 }
 
-// Track take and event key with event tags and if the event is part of the config, send to events backend.
+// Track generates a conversion event with the given event key if it exists and queues it up to be sent to the Optimizely
+// log endpoint for results processing.
 func (o *OptimizelyClient) Track(eventKey string, userContext entities.UserContext, eventTags map[string]interface{}) (err error) {
 
 	defer func() {
@@ -427,7 +431,7 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 	return decisionContext, experimentDecision, err
 }
 
-// GetProjectConfig returns the current ProjectConfig or nil if the instance is not valid
+// GetProjectConfig returns the current ProjectConfig or nil if the instance is not valid.
 func (o *OptimizelyClient) GetProjectConfig() (projectConfig pkg.ProjectConfig, err error) {
 
 	projectConfig, err = o.ConfigManager.GetConfig()
@@ -438,7 +442,7 @@ func (o *OptimizelyClient) GetProjectConfig() (projectConfig pkg.ProjectConfig, 
 	return projectConfig, nil
 }
 
-// Close closes the Optimizely instance and stops any ongoing tasks from its children components
+// Close closes the Optimizely instance and stops any ongoing tasks from its children components.
 func (o *OptimizelyClient) Close() {
 	o.executionCtx.TerminateAndWait()
 }

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -28,7 +28,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/utils"
 )
 
-// OptimizelyFactory is used to construct an instance of the OptimizelyClient
+// OptimizelyFactory is used to customize and construct an instance of the OptimizelyClient.
 type OptimizelyFactory struct {
 	SDKKey   string
 	Datafile []byte
@@ -41,10 +41,10 @@ type OptimizelyFactory struct {
 	overrideStore      decision.ExperimentOverrideStore
 }
 
-// OptionFunc is used to provide custom client configuration to the OptimizelyFactory
+// OptionFunc is used to provide custom client configuration to the OptimizelyFactory.
 type OptionFunc func(*OptimizelyFactory)
 
-// Client instantiates a new OptimizelyClient with the given options
+// Client instantiates a new OptimizelyClient with the given options.
 func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClient, error) {
 	// extract options
 	for _, opt := range clientOptions {
@@ -112,7 +112,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	return appClient, nil
 }
 
-// WithPollingConfigManager sets polling config manager on a client
+// WithPollingConfigManager sets polling config manager on a client.
 func WithPollingConfigManager(sdkKey string, pollingInterval time.Duration, initDataFile []byte) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.configManager = config.NewPollingProjectConfigManager(sdkKey, config.InitialDatafile(initDataFile),
@@ -120,7 +120,7 @@ func WithPollingConfigManager(sdkKey string, pollingInterval time.Duration, init
 	}
 }
 
-// WithPollingConfigManagerRequester sets polling config manager on a client
+// WithPollingConfigManagerRequester sets polling config manager on a client.
 func WithPollingConfigManagerRequester(requester utils.Requester, pollingInterval time.Duration, initDataFile []byte) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.configManager = config.NewPollingProjectConfigManager("", config.InitialDatafile(initDataFile),
@@ -128,42 +128,42 @@ func WithPollingConfigManagerRequester(requester utils.Requester, pollingInterva
 	}
 }
 
-// WithConfigManager sets polling config manager on a client
+// WithConfigManager sets polling config manager on a client.
 func WithConfigManager(configManager pkg.ProjectConfigManager) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.configManager = configManager
 	}
 }
 
-// WithCompositeDecisionService sets decision service on a client
+// WithCompositeDecisionService sets decision service on a client.
 func WithCompositeDecisionService(sdkKey string) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.decisionService = decision.NewCompositeService(sdkKey)
 	}
 }
 
-// WithDecisionService sets decision service on a client
+// WithDecisionService sets decision service on a client.
 func WithDecisionService(decisionService decision.Service) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.decisionService = decisionService
 	}
 }
 
-// WithUserProfileService sets the user profile service on the decision service
+// WithUserProfileService sets the user profile service on the decision service.
 func WithUserProfileService(userProfileService decision.UserProfileService) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.userProfileService = userProfileService
 	}
 }
 
-// WithExperimentOverrides sets the experiment override store on the decision service
+// WithExperimentOverrides sets the experiment override store on the decision service.
 func WithExperimentOverrides(overrideStore decision.ExperimentOverrideStore) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.overrideStore = overrideStore
 	}
 }
 
-// WithBatchEventProcessor sets event processor on a client
+// WithBatchEventProcessor sets event processor on a client.
 func WithBatchEventProcessor(batchSize, queueSize int, flushInterval time.Duration) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.eventProcessor = event.NewBatchEventProcessor(event.WithBatchSize(batchSize),
@@ -178,14 +178,14 @@ func WithEventProcessor(eventProcessor event.Processor) OptionFunc {
 	}
 }
 
-// WithExecutionContext allows user to pass in their own execution context to override the default one in the client
+// WithExecutionContext allows user to pass in their own execution context to override the default one in the client.
 func WithExecutionContext(executionContext utils.ExecutionCtx) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.executionCtx = executionContext
 	}
 }
 
-// StaticClient returns a client initialized with a static project config
+// StaticClient returns a client initialized with a static project config.
 func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 	var configManager pkg.ProjectConfigManager
 

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -60,7 +60,7 @@ type PollingProjectConfigManager struct {
 	projectConfig pkg.ProjectConfig
 }
 
-// OptionFunc is s used to provide custom configuration to the PollingProjectConfigManager.
+// OptionFunc is used to provide custom configuration to the PollingProjectConfigManager.
 type OptionFunc func(*PollingProjectConfigManager)
 
 // Requester is an optional function, sets a passed requester

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -45,7 +45,8 @@ const LastModified = "Last-Modified"
 
 var cmLogger = logging.GetLogger("PollingConfigManager")
 
-// PollingProjectConfigManager maintains a dynamic copy of the project config
+// PollingProjectConfigManager maintains a dynamic copy of the project config by continuously polling for the datafile
+// from the Optimizely CDN at a given (configurable) interval.
 type PollingProjectConfigManager struct {
 	requester          utils.Requester
 	pollingInterval    time.Duration
@@ -58,7 +59,7 @@ type PollingProjectConfigManager struct {
 	projectConfig pkg.ProjectConfig
 }
 
-// OptionFunc is a type to a proper func
+// OptionFunc is s used to provide custom configuration to the PollingProjectConfigManager.
 type OptionFunc func(*PollingProjectConfigManager)
 
 // DefaultRequester is an optional function, sets default requester based on a key.

--- a/pkg/decision/composite_service.go
+++ b/pkg/decision/composite_service.go
@@ -29,14 +29,14 @@ import (
 
 var csLogger = logging.GetLogger("CompositeDecisionService")
 
-// CompositeService is the entrypoint into the decision service. It provides out of the box decision making for Features and Experiments.
+// CompositeService is the entry-point into the decision service. It provides out of the box decision making for Features and Experiments.
 type CompositeService struct {
 	compositeExperimentService ExperimentService
 	compositeFeatureService    FeatureService
 	notificationCenter         notification.Center
 }
 
-// CSOptionFunc is used to pass config options into the CompositeService
+// CSOptionFunc is used to pass custom config options into the CompositeService.
 type CSOptionFunc func(*CompositeService)
 
 // WithCompositeExperimentService sets the composite experiment service on the CompositeService

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -129,11 +129,11 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	processor.ProcessEvent(impressionUserEvent)
 
-	assert.Equal(t, 1, processor.EventsCount())
+	assert.Equal(t, 1, processor.eventsCount())
 
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestCreateAndSendConversionEvent(t *testing.T) {
@@ -147,11 +147,11 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 
 	processor.ProcessEvent(conversionUserEvent)
 
-	assert.Equal(t, 1, processor.EventsCount())
+	assert.Equal(t, 1, processor.eventsCount())
 
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestCreateConversionEventRevenue(t *testing.T) {

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -55,13 +55,13 @@ func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 
 	processor.ProcessEvent(impression)
 
-	assert.Equal(t, 1, processor.EventsCount())
+	assert.Equal(t, 1, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestCustomEventProcessor_Create(t *testing.T) {
@@ -76,13 +76,13 @@ func TestCustomEventProcessor_Create(t *testing.T) {
 
 	processor.ProcessEvent(impression)
 
-	assert.Equal(t, 1, processor.EventsCount())
+	assert.Equal(t, 1, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
@@ -108,7 +108,7 @@ func TestDefaultEventProcessor_LogEventNotification(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
@@ -134,13 +134,13 @@ func TestDefaultEventProcessor_DefaultConfig(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	time.Sleep(31 * time.Second)
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -169,13 +169,13 @@ func TestDefaultEventProcessor_ProcessBatch(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	time.Sleep(1500 * time.Millisecond)
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -202,7 +202,7 @@ func TestDefaultEventProcessor_BatchSizeMet(t *testing.T) {
 	processor.ProcessEvent(impression)
 	processor.ProcessEvent(impression)
 
-	assert.Equal(t, 2, processor.EventsCount())
+	assert.Equal(t, 2, processor.eventsCount())
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -219,13 +219,13 @@ func TestDefaultEventProcessor_BatchSizeMet(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 2, processor.EventsCount())
+	assert.Equal(t, 2, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	if ok {
 		assert.Equal(t, 2, result.Events.Size())
@@ -259,12 +259,12 @@ func TestDefaultEventProcessor_QSizeExceeded(t *testing.T) {
 	processor.ProcessEvent(impression)
 	processor.ProcessEvent(impression)
 
-	assert.Equal(t, 2, processor.EventsCount())
+	assert.Equal(t, 2, processor.eventsCount())
 
 	processor.ProcessEvent(impression)
 	processor.ProcessEvent(impression)
 
-	assert.Equal(t, 2, processor.EventsCount())
+	assert.Equal(t, 2, processor.eventsCount())
 
 }
 
@@ -285,13 +285,13 @@ func TestDefaultEventProcessor_FailedDispatch(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -316,12 +316,12 @@ func TestBatchEventProcessor_FlushesOnClose(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	// Triggers the flush in the processor
 	exeCtx.TerminateAndWait()
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
@@ -342,13 +342,13 @@ func TestDefaultEventProcessor_ProcessBatchRevisionMismatch(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -378,13 +378,13 @@ func TestDefaultEventProcessor_ProcessBatchProjectMismatch(t *testing.T) {
 	processor.ProcessEvent(conversion)
 	processor.ProcessEvent(conversion)
 
-	assert.Equal(t, 4, processor.EventsCount())
+	assert.Equal(t, 4, processor.eventsCount())
 
 	exeCtx.TerminateAndWait()
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 
@@ -414,7 +414,7 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	exeCtx.TerminateAndWait()
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 }
 
 func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
@@ -437,7 +437,7 @@ func TestChanQueueEventProcessor_ProcessBatch(t *testing.T) {
 
 	assert.NotNil(t, processor.Ticker)
 
-	assert.Equal(t, 0, processor.EventsCount())
+	assert.Equal(t, 0, processor.eventsCount())
 
 	result, ok := (processor.EventDispatcher).(*MockDispatcher)
 

--- a/pkg/interface.go
+++ b/pkg/interface.go
@@ -22,7 +22,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/notification"
 )
 
-// ProjectConfig contains the parsed project entities
+// ProjectConfig represents the project's experiments and feature flags and contains methods for accessing the them.
 type ProjectConfig interface {
 	GetAccountID() string
 	GetAnonymizeIP() bool
@@ -41,7 +41,7 @@ type ProjectConfig interface {
 	GetRevision() string
 }
 
-// ProjectConfigManager manages the config
+// ProjectConfigManager maintains an instance of the ProjectConfig
 type ProjectConfigManager interface {
 	GetConfig() (ProjectConfig, error)
 	RemoveOnProjectConfigUpdate(id int) error


### PR DESCRIPTION
# Summary
- Clean up public doc strings on client, factory and top-level components.
- Makes private some of the methods on the `BatchEventProcessor` which do not need to be public.