### PR TITLE
fix: correct error returned when SDK key is invalid

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -400,7 +400,6 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 
 	projectConfig, e := o.GetProjectConfig()
 	if e != nil {
-		logger.Error("Error calling getExperimentDecision", e)
 		return decisionContext, experimentDecision, e
 	}
 

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -114,7 +114,7 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 		}
 
 		if e != nil {
-			msg := "unable to get fresh datafile"
+			msg := "unable to fetch fresh datafile"
 			cmLogger.Warning(msg)
 			cm.configLock.Lock()
 			closeMutex(errors.New(fmt.Sprintf("%s, reason (http status code): %s", msg, e.Error())))

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -29,6 +29,8 @@ import (
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/registry"
 	"github.com/optimizely/go-sdk/pkg/utils"
+
+	"github.com/pkg/errors"
 )
 
 // DefaultPollingInterval sets default interval for polling manager
@@ -112,9 +114,10 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 		}
 
 		if e != nil {
-			cmLogger.Error(fmt.Sprintf("request returned with http code=%d", code), e)
+			msg := "unable to get fresh datafile"
+			cmLogger.Warning(msg)
 			cm.configLock.Lock()
-			closeMutex(e)
+			closeMutex(errors.New(fmt.Sprintf("%s, reason (http status code): %s", msg, e.Error())))
 			return
 		}
 
@@ -137,7 +140,7 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 	cm.configLock.Lock()
 
 	if err != nil {
-		cmLogger.Error("failed to create project config", err)
+		cmLogger.Warning("failed to create project config")
 		closeMutex(err)
 		return
 	}


### PR DESCRIPTION
Now it displays:
```
[Optimizely]2019/12/02 16:59:23 [Warning][Requester] error status code=403
[Optimizely]2019/12/02 16:59:23 [Warning][PollingConfigManager] unable to get fresh datafile
[Optimizely]2019/12/02 16:59:23 [Error][Client] received an error while computing experiment decision: unable to get fresh datafile, reason (http status code): 403 Forbidden
```
