### PR TITLE
fix: Invalid datafile JSON should return an error

### DIFF
--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -141,7 +141,7 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 
 	if err != nil {
 		cmLogger.Warning("failed to create project config")
-		closeMutex(err)
+		closeMutex(errors.New("unable to parse datafile"))
 		return
 	}
 


### PR DESCRIPTION
Now it returns this:
```
[Optimizely]2019/12/03 10:42:23 [Error][DatafileProjectConfig] Error parsing datafile.: readObjectStart: expect { or n, but found D, error found in #1 byte of ...|DATAFILE_JS|..., bigger context ...|DATAFILE_JSON_STRING_HERE|...
[Optimizely]2019/12/03 10:42:23 [Warning][PollingConfigManager] failed to create project config
[Optimizely]2019/12/03 10:42:23 [Error][Client] received an error while computing experiment decision: unable to parse datafile
```