### PR TITLE
Revert signature changes to PollingProjectConfigManager.

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -103,7 +103,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 
 	// Initialize the default services with the execution context
 	if pollingConfigManager, ok := appClient.ConfigManager.(*config.PollingProjectConfigManager); ok {
-		pollingConfigManager.Start(f.SDKKey, appClient.executionCtx)
+		pollingConfigManager.Start(appClient.executionCtx)
 	}
 
 	if batchProcessor, ok := appClient.EventProcessor.(*event.BatchEventProcessor); ok {

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -50,12 +50,13 @@ var cmLogger = logging.GetLogger("PollingConfigManager")
 // PollingProjectConfigManager maintains a dynamic copy of the project config by continuously polling for the datafile
 // from the Optimizely CDN at a given (configurable) interval.
 type PollingProjectConfigManager struct {
-	requester           utils.Requester
-	pollingInterval     time.Duration
-	notificationCenter  notification.Center
+	datafileURLTemplate string
 	initDatafile        []byte
 	lastModified        string
-	datafileURLTemplate string
+	notificationCenter  notification.Center
+	pollingInterval     time.Duration
+	requester           utils.Requester
+	sdkKey              string
 
 	configLock    sync.RWMutex
 	err           error
@@ -94,7 +95,7 @@ func WithInitialDatafile(datafile []byte) OptionFunc {
 }
 
 // SyncConfig gets current datafile and updates projectConfig
-func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte) {
+func (cm *PollingProjectConfigManager) SyncConfig(datafile []byte) {
 	var e error
 	var code int
 	var respHeaders http.Header
@@ -104,7 +105,7 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 		cm.configLock.Unlock()
 	}
 
-	url := fmt.Sprintf(cm.datafileURLTemplate, sdkKey)
+	url := fmt.Sprintf(cm.datafileURLTemplate, cm.sdkKey)
 	if len(datafile) == 0 {
 		if cm.lastModified != "" {
 			lastModifiedHeader := utils.Header{Name: ModifiedSince, Value: cm.lastModified}
@@ -170,14 +171,14 @@ func (cm *PollingProjectConfigManager) SyncConfig(sdkKey string, datafile []byte
 }
 
 // Start starts the polling
-func (cm *PollingProjectConfigManager) Start(sdkKey string, exeCtx utils.ExecutionCtx) {
+func (cm *PollingProjectConfigManager) Start(exeCtx utils.ExecutionCtx) {
 	go func() {
 		cmLogger.Debug("Polling Config Manager Initiated")
 		t := time.NewTicker(cm.pollingInterval)
 		for {
 			select {
 			case <-t.C:
-				cm.SyncConfig(sdkKey, []byte{})
+				cm.SyncConfig([]byte{})
 			case <-exeCtx.GetContext().Done():
 				cmLogger.Debug("Polling Config Manager Stopped")
 				return
@@ -194,6 +195,7 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 		pollingInterval:     DefaultPollingInterval,
 		requester:           utils.NewHTTPRequester(),
 		datafileURLTemplate: DatafileURLTemplate,
+		sdkKey:              sdkKey,
 	}
 
 	for _, opt := range pollingMangerOptions {
@@ -201,7 +203,7 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 	}
 
 	initDatafile := pollingProjectConfigManager.initDatafile
-	pollingProjectConfigManager.SyncConfig(sdkKey, initDatafile) // initial poll
+	pollingProjectConfigManager.SyncConfig(initDatafile) // initial poll
 	return &pollingProjectConfigManager
 }
 

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -51,7 +51,7 @@ func TestNewPollingProjectConfigManagerWithOptions(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -72,7 +72,7 @@ func TestNewPollingProjectConfigManagerWithNull(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	_, err := configManager.GetConfig()
@@ -90,7 +90,7 @@ func TestNewPollingProjectConfigManagerWithSimilarDatafileRevisions(t *testing.T
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -98,7 +98,7 @@ func TestNewPollingProjectConfigManagerWithSimilarDatafileRevisions(t *testing.T
 	assert.NotNil(t, actual)
 	assert.Equal(t, projectConfig1, actual)
 
-	configManager.SyncConfig(sdkKey, mockDatafile2)
+	configManager.SyncConfig(mockDatafile2)
 	actual, err = configManager.GetConfig()
 	assert.Equal(t, projectConfig1, actual)
 }
@@ -118,7 +118,7 @@ func TestNewPollingProjectConfigManagerWithLastModifiedDates(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 
 	// Fetch valid config
 	actual, err := configManager.GetConfig()
@@ -127,7 +127,7 @@ func TestNewPollingProjectConfigManagerWithLastModifiedDates(t *testing.T) {
 	assert.Equal(t, projectConfig1, actual)
 
 	// Sync and check no changes were made to the previous config because of 304 error code
-	configManager.SyncConfig(sdkKey, []byte{})
+	configManager.SyncConfig([]byte{})
 	actual, err = configManager.GetConfig()
 	assert.Nil(t, err)
 	assert.NotNil(t, actual)
@@ -148,7 +148,7 @@ func TestNewPollingProjectConfigManagerWithDifferentDatafileRevisions(t *testing
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig()
@@ -156,7 +156,7 @@ func TestNewPollingProjectConfigManagerWithDifferentDatafileRevisions(t *testing
 	assert.NotNil(t, actual)
 	assert.Equal(t, projectConfig1, actual)
 
-	configManager.SyncConfig(sdkKey, mockDatafile2)
+	configManager.SyncConfig(mockDatafile2)
 	actual, err = configManager.GetConfig()
 	assert.Equal(t, projectConfig2, actual)
 }
@@ -175,7 +175,7 @@ func TestNewPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 	mockRequester.AssertExpectations(t)
 
 	actual, err := configManager.GetConfig() // polling for bad file
@@ -183,12 +183,12 @@ func TestNewPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 	assert.Nil(t, actual)
 	assert.Nil(t, projectConfig1)
 
-	configManager.SyncConfig(sdkKey, mockDatafile2) // polling for good file
+	configManager.SyncConfig(mockDatafile2) // polling for good file
 	actual, err = configManager.GetConfig()
 	assert.Nil(t, err)
 	assert.Equal(t, projectConfig2, actual)
 
-	configManager.SyncConfig(sdkKey, mockDatafile1) // polling for bad file, error not null but good project
+	configManager.SyncConfig(mockDatafile1) // polling for bad file, error not null but good project
 	actual, err = configManager.GetConfig()
 	assert.Nil(t, err)
 	assert.Equal(t, projectConfig2, actual)
@@ -206,7 +206,7 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithRequester(mockRequester))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 
 	var numberOfCalls = 0
 	callback := func(notification notification.ProjectConfigUpdateNotification) {
@@ -219,7 +219,7 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, actual)
 
-	configManager.SyncConfig(sdkKey, mockDatafile2)
+	configManager.SyncConfig(mockDatafile2)
 	actual, err = configManager.GetConfig()
 	assert.Nil(t, err)
 	assert.NotNil(t, actual)
@@ -240,7 +240,7 @@ func TestPollingInterval(t *testing.T) {
 
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithPollingInterval(5*time.Second))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 
 	assert.Equal(t, configManager.pollingInterval, 5*time.Second)
 }
@@ -250,7 +250,7 @@ func TestInitialDatafile(t *testing.T) {
 	sdkKey := "test_sdk_key"
 	exeCtx := utils.NewCancelableExecutionCtx()
 	configManager := NewPollingProjectConfigManager(sdkKey, WithInitialDatafile([]byte("test")))
-	configManager.Start(sdkKey, exeCtx)
+	configManager.Start(exeCtx)
 
 	assert.Equal(t, configManager.initDatafile, []byte("test"))
 }


### PR DESCRIPTION
## Summary
* Reverts signature changes for `PollingProjectConfigManager`
* Store `sdkKey` on the `PollingProjectConfigManager`

A recent PR https://github.com/optimizely/go-sdk/pull/195 broke backwards compatibility and added potential internal discrepancies of the current SDK. This change ensures that the SDK key used to initialize the Config Manager is used consistently throughout its lifecycle.