### PR TITLE
feat: Add observability metrics for event queue

### DIFF
--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -51,6 +51,10 @@ func (f *MockDispatcher) DispatchEvent(event event.LogEvent) (bool, error) {
 	return true, nil
 }
 
+func (f *MockDispatcher) GetMetrics() event.Metrics {
+	return nil
+}
+
 func TestFactoryClientReturnsDefaultClient(t *testing.T) {
 	factory := OptimizelyFactory{}
 

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -45,6 +45,7 @@ type HTTPEventDispatcher struct {
 	requester *utils.HTTPRequester
 }
 
+// GetMetrics is the metric accessor
 func (ed *HTTPEventDispatcher) GetMetrics() Metrics {
 	return nil
 }
@@ -89,6 +90,7 @@ func (ed *QueueEventDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 	return true, nil
 }
 
+// GetMetrics is the metric accessor
 func (ed *QueueEventDispatcher) GetMetrics() Metrics {
 	return ed.metrics
 }

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -92,7 +92,13 @@ func (ed *QueueEventDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 
 // GetMetrics is the metric accessor
 func (ed *QueueEventDispatcher) GetMetrics() Metrics {
+	ed.eventFlushLock.Lock()
+
+	defer func() {
+		ed.eventFlushLock.Unlock()
+	}()
 	return ed.metrics
+
 }
 
 // flush the events
@@ -161,7 +167,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 
 // NewQueueEventDispatcher creates a Dispatcher that queues in memory and then sends via go routine.
 func NewQueueEventDispatcher(ctx context.Context) Dispatcher {
-	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: NewDefaultMetrics()}
+	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: &DefaultMetrics{}}
 
 	go func() {
 		<-ctx.Done()

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -161,7 +161,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 
 // NewQueueEventDispatcher creates a Dispatcher that queues in memory and then sends via go routine.
 func NewQueueEventDispatcher(ctx context.Context) Dispatcher {
-	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: &DefaultMetrics{}}
+	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: NewDefaultMetrics()}
 
 	go func() {
 		<-ctx.Done()

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -37,11 +37,16 @@ var dispatcherLogger = logging.GetLogger("EventDispatcher")
 // Dispatcher dispatches events
 type Dispatcher interface {
 	DispatchEvent(event LogEvent) (bool, error)
+	GetMetrics() Metrics
 }
 
 // HTTPEventDispatcher is the HTTP implementation of the Dispatcher interface
 type HTTPEventDispatcher struct {
 	requester *utils.HTTPRequester
+}
+
+func (ed *HTTPEventDispatcher) GetMetrics() Metrics {
+	return nil
 }
 
 // DispatchEvent dispatches event with callback
@@ -71,6 +76,8 @@ type QueueEventDispatcher struct {
 	eventQueue     Queue
 	eventFlushLock sync.Mutex
 	Dispatcher     Dispatcher
+
+	metrics Metrics
 }
 
 // DispatchEvent queues event with callback and calls flush in a go routine.
@@ -80,6 +87,10 @@ func (ed *QueueEventDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 		ed.flushEvents()
 	}()
 	return true, nil
+}
+
+func (ed *QueueEventDispatcher) GetMetrics() Metrics {
+	return ed.metrics
 }
 
 // flush the events
@@ -93,9 +104,11 @@ func (ed *QueueEventDispatcher) flushEvents() {
 
 	retryCount := 0
 
+	ed.metrics.SetQueueSize(ed.eventQueue.Size())
 	for ed.eventQueue.Size() > 0 {
 		if retryCount > maxRetries {
 			dispatcherLogger.Error(fmt.Sprintf("event failed to send %d times. It will retry on next event sent", maxRetries), nil)
+			ed.metrics.IncrFailFlushCount()
 			break
 		}
 
@@ -109,6 +122,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 			// remove it
 			dispatcherLogger.Error("invalid type passed to event Dispatcher", nil)
 			ed.eventQueue.Remove(1)
+			ed.metrics.IncrFailFlushCount()
 			continue
 		}
 
@@ -119,6 +133,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 				dispatcherLogger.Debug(fmt.Sprintf("Dispatched log event %+v", event))
 				ed.eventQueue.Remove(1)
 				retryCount = 0
+				ed.metrics.IncrSuccessFlushCount()
 			} else {
 				dispatcherLogger.Warning("dispatch event failed")
 				// we failed.  Sleep some seconds and try again.
@@ -126,6 +141,8 @@ func (ed *QueueEventDispatcher) flushEvents() {
 				// increase retryCount.  We exit if we have retried x times.
 				// we will retry again next event that is added.
 				retryCount++
+				ed.metrics.IncrRetryFlushCount()
+
 			}
 		} else {
 			dispatcherLogger.Error("Error dispatching ", err)
@@ -134,13 +151,15 @@ func (ed *QueueEventDispatcher) flushEvents() {
 			// increase retryCount.  We exit if we have retried x times.
 			// we will retry again next event that is added.
 			retryCount++
+			ed.metrics.IncrRetryFlushCount()
 		}
 	}
+	ed.metrics.SetQueueSize(ed.eventQueue.Size())
 }
 
 // NewQueueEventDispatcher creates a Dispatcher that queues in memory and then sends via go routine.
 func NewQueueEventDispatcher(ctx context.Context) Dispatcher {
-	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}}
+	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: &DefaultMetrics{}}
 
 	go func() {
 		<-ctx.Done()

--- a/pkg/event/dispatcher_metrics.go
+++ b/pkg/event/dispatcher_metrics.go
@@ -17,6 +17,7 @@
 // Package event //
 package event
 
+// Metrics is the interface for event processor
 type Metrics interface {
 	SetQueueSize(queueSize int)
 	IncrSuccessFlushCount()
@@ -24,6 +25,7 @@ type Metrics interface {
 	IncrRetryFlushCount()
 }
 
+// DefaultMetrics stores the actual metrics
 type DefaultMetrics struct {
 	QueueSize         int
 	SuccessFlushCount int64
@@ -36,16 +38,22 @@ func NewDefaultMetrics() *DefaultMetrics {
 	return &DefaultMetrics{}
 }
 
+// SetQueueSize sets the queue size
 func (m *DefaultMetrics) SetQueueSize(queueSize int) {
 	m.QueueSize = queueSize
 }
 
+// IncrSuccessFlushCount increments counter for successful flush
 func (m *DefaultMetrics) IncrSuccessFlushCount() {
 	m.SuccessFlushCount++
 }
+
+// IncrFailFlushCount increments counter for failed flush
 func (m *DefaultMetrics) IncrFailFlushCount() {
 	m.FailFlushCount++
 }
+
+// IncrRetryFlushCount increments counter for retried flush
 func (m *DefaultMetrics) IncrRetryFlushCount() {
 	m.RetryFlushCount++
 }

--- a/pkg/event/dispatcher_metrics.go
+++ b/pkg/event/dispatcher_metrics.go
@@ -17,8 +17,6 @@
 // Package event //
 package event
 
-import "sync"
-
 // Metrics is the interface for event processor
 type Metrics interface {
 	SetQueueSize(queueSize int)
@@ -33,34 +31,24 @@ type DefaultMetrics struct {
 	SuccessFlushCount int64
 	FailFlushCount    int64
 	RetryFlushCount   int64
-
-	metricLock sync.RWMutex
 }
 
 // SetQueueSize sets the queue size
 func (m *DefaultMetrics) SetQueueSize(queueSize int) {
-	m.metricLock.Lock()
-	defer m.metricLock.Unlock()
 	m.QueueSize = queueSize
 }
 
 // IncrSuccessFlushCount increments counter for successful flush
 func (m *DefaultMetrics) IncrSuccessFlushCount() {
-	m.metricLock.Lock()
-	defer m.metricLock.Unlock()
 	m.SuccessFlushCount++
 }
 
 // IncrFailFlushCount increments counter for failed flush
 func (m *DefaultMetrics) IncrFailFlushCount() {
-	m.metricLock.Lock()
-	defer m.metricLock.Unlock()
 	m.FailFlushCount++
 }
 
 // IncrRetryFlushCount increments counter for retried flush
 func (m *DefaultMetrics) IncrRetryFlushCount() {
-	m.metricLock.Lock()
-	defer m.metricLock.Unlock()
 	m.RetryFlushCount++
 }

--- a/pkg/event/dispatcher_metrics.go
+++ b/pkg/event/dispatcher_metrics.go
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package event //
+package event
+
+type Metrics interface {
+	SetQueueSize(queueSize int)
+	IncrSuccessFlushCount()
+	IncrFailFlushCount()
+	IncrRetryFlushCount()
+}
+
+type DefaultMetrics struct {
+	QueueSize         int
+	SuccessFlushCount int64
+	FailFlushCount    int64
+	RetryFlushCount   int64
+}
+
+// NewDefaultMetrics initialized metrics
+func NewDefaultMetrics() *DefaultMetrics {
+	return &DefaultMetrics{}
+}
+
+func (m *DefaultMetrics) SetQueueSize(queueSize int) {
+	m.QueueSize = queueSize
+}
+
+func (m *DefaultMetrics) IncrSuccessFlushCount() {
+	m.SuccessFlushCount++
+}
+func (m *DefaultMetrics) IncrFailFlushCount() {
+	m.FailFlushCount++
+}
+func (m *DefaultMetrics) IncrRetryFlushCount() {
+	m.RetryFlushCount++
+}

--- a/pkg/event/dispatcher_metrics.go
+++ b/pkg/event/dispatcher_metrics.go
@@ -52,3 +52,11 @@ func (m *DefaultMetrics) IncrFailFlushCount() {
 func (m *DefaultMetrics) IncrRetryFlushCount() {
 	m.RetryFlushCount++
 }
+
+// Add a metric collection to existing metrics
+func (m *DefaultMetrics) Add(v *DefaultMetrics) {
+	m.QueueSize += v.QueueSize
+	m.FailFlushCount += v.FailFlushCount
+	m.SuccessFlushCount += v.SuccessFlushCount
+	m.RetryFlushCount += v.RetryFlushCount
+}

--- a/pkg/event/dispatcher_metrics.go
+++ b/pkg/event/dispatcher_metrics.go
@@ -17,6 +17,8 @@
 // Package event //
 package event
 
+import "sync"
+
 // Metrics is the interface for event processor
 type Metrics interface {
 	SetQueueSize(queueSize int)
@@ -31,29 +33,34 @@ type DefaultMetrics struct {
 	SuccessFlushCount int64
 	FailFlushCount    int64
 	RetryFlushCount   int64
-}
 
-// NewDefaultMetrics initialized metrics
-func NewDefaultMetrics() *DefaultMetrics {
-	return &DefaultMetrics{}
+	metricLock sync.RWMutex
 }
 
 // SetQueueSize sets the queue size
 func (m *DefaultMetrics) SetQueueSize(queueSize int) {
+	m.metricLock.Lock()
+	defer m.metricLock.Unlock()
 	m.QueueSize = queueSize
 }
 
 // IncrSuccessFlushCount increments counter for successful flush
 func (m *DefaultMetrics) IncrSuccessFlushCount() {
+	m.metricLock.Lock()
+	defer m.metricLock.Unlock()
 	m.SuccessFlushCount++
 }
 
 // IncrFailFlushCount increments counter for failed flush
 func (m *DefaultMetrics) IncrFailFlushCount() {
+	m.metricLock.Lock()
+	defer m.metricLock.Unlock()
 	m.FailFlushCount++
 }
 
 // IncrRetryFlushCount increments counter for retried flush
 func (m *DefaultMetrics) IncrRetryFlushCount() {
+	m.metricLock.Lock()
+	defer m.metricLock.Unlock()
 	m.RetryFlushCount++
 }

--- a/pkg/event/dispatcher_metrics_test.go
+++ b/pkg/event/dispatcher_metrics_test.go
@@ -76,3 +76,20 @@ func TestIncrRetryFlushCount(t *testing.T) {
 	assert.Equal(t, int64(1), metric.RetryFlushCount)
 
 }
+
+func TestAdd(t *testing.T) {
+
+	metric := &DefaultMetrics{}
+	metric.IncrRetryFlushCount()
+	metric.IncrSuccessFlushCount()
+	metric.IncrSuccessFlushCount()
+	metric.IncrFailFlushCount()
+	metric.SetQueueSize(24)
+
+	metric.Add(metric)
+	assert.Equal(t, 48, metric.QueueSize)
+	assert.Equal(t, int64(4), metric.SuccessFlushCount)
+	assert.Equal(t, int64(2), metric.FailFlushCount)
+	assert.Equal(t, int64(2), metric.RetryFlushCount)
+
+}

--- a/pkg/event/dispatcher_metrics_test.go
+++ b/pkg/event/dispatcher_metrics_test.go
@@ -1,0 +1,78 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package event //
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultMetrics(t *testing.T) {
+
+	metric := NewDefaultMetrics()
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.Equal(t, int64(0), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
+
+}
+
+func TestSetQueueSize(t *testing.T) {
+
+	metric := NewDefaultMetrics()
+	metric.SetQueueSize(24)
+	assert.Equal(t, 24, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.Equal(t, int64(0), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
+
+}
+
+func TestIncrSuccessFlushCount(t *testing.T) {
+
+	metric := NewDefaultMetrics()
+	metric.IncrSuccessFlushCount()
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(1), metric.SuccessFlushCount)
+	assert.Equal(t, int64(0), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
+
+}
+
+func TestIncrFailFlushCount(t *testing.T) {
+
+	metric := NewDefaultMetrics()
+	metric.IncrFailFlushCount()
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.Equal(t, int64(1), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
+
+}
+
+func TestIncrRetryFlushCount(t *testing.T) {
+
+	metric := NewDefaultMetrics()
+	metric.IncrRetryFlushCount()
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.Equal(t, int64(0), metric.FailFlushCount)
+	assert.Equal(t, int64(1), metric.RetryFlushCount)
+
+}

--- a/pkg/event/dispatcher_metrics_test.go
+++ b/pkg/event/dispatcher_metrics_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestNewDefaultMetrics(t *testing.T) {
 
-	metric := NewDefaultMetrics()
+	metric := DefaultMetrics{}
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
 	assert.Equal(t, int64(0), metric.FailFlushCount)
@@ -35,7 +35,7 @@ func TestNewDefaultMetrics(t *testing.T) {
 
 func TestSetQueueSize(t *testing.T) {
 
-	metric := NewDefaultMetrics()
+	metric := DefaultMetrics{}
 	metric.SetQueueSize(24)
 	assert.Equal(t, 24, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
@@ -46,7 +46,7 @@ func TestSetQueueSize(t *testing.T) {
 
 func TestIncrSuccessFlushCount(t *testing.T) {
 
-	metric := NewDefaultMetrics()
+	metric := DefaultMetrics{}
 	metric.IncrSuccessFlushCount()
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(1), metric.SuccessFlushCount)
@@ -57,7 +57,7 @@ func TestIncrSuccessFlushCount(t *testing.T) {
 
 func TestIncrFailFlushCount(t *testing.T) {
 
-	metric := NewDefaultMetrics()
+	metric := DefaultMetrics{}
 	metric.IncrFailFlushCount()
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
@@ -68,7 +68,7 @@ func TestIncrFailFlushCount(t *testing.T) {
 
 func TestIncrRetryFlushCount(t *testing.T) {
 
-	metric := NewDefaultMetrics()
+	metric := DefaultMetrics{}
 	metric.IncrRetryFlushCount()
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -57,7 +57,7 @@ func TestQueueEventDispatcher_DispatchEvent(t *testing.T) {
 	// check the queue
 	assert.Equal(t, 0, qd.eventQueue.Size())
 
-	metric := qd.GetMetrics().(*DefaultMetrics)
+	metric := *qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(1), metric.SuccessFlushCount)
 	assert.Equal(t, int64(0), metric.FailFlushCount)
@@ -86,7 +86,7 @@ func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 0, qd.eventQueue.Size())
 
-	metric := qd.GetMetrics().(*DefaultMetrics)
+	metric := *qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
 	assert.Equal(t, int64(1), metric.FailFlushCount)
@@ -123,7 +123,7 @@ func TestQueueEventDispatcher_FailDispath(t *testing.T) {
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 1, qd.eventQueue.Size())
 
-	metric := qd.GetMetrics().(*DefaultMetrics)
+	metric := *qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 1, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
 	assert.True(t, metric.RetryFlushCount > 1)

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -57,12 +57,17 @@ func TestQueueEventDispatcher_DispatchEvent(t *testing.T) {
 	// check the queue
 	assert.Equal(t, 0, qd.eventQueue.Size())
 
+	metric := qd.GetMetrics().(*DefaultMetrics)
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(1), metric.SuccessFlushCount)
+	assert.Equal(t, int64(0), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
+
 }
 
 func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 	ctx := context.TODO()
 	q := NewQueueEventDispatcher(ctx)
-
 
 	config := TestConfig{}
 
@@ -80,6 +85,12 @@ func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 0, qd.eventQueue.Size())
+
+	metric := qd.GetMetrics().(*DefaultMetrics)
+	assert.Equal(t, 0, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.Equal(t, int64(1), metric.FailFlushCount)
+	assert.Equal(t, int64(0), metric.RetryFlushCount)
 
 }
 
@@ -112,5 +123,9 @@ func TestQueueEventDispatcher_FailDispath(t *testing.T) {
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 1, qd.eventQueue.Size())
 
-}
+	metric := qd.GetMetrics().(*DefaultMetrics)
+	assert.Equal(t, 1, metric.QueueSize)
+	assert.Equal(t, int64(0), metric.SuccessFlushCount)
+	assert.True(t, metric.RetryFlushCount > 1)
 
+}

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -119,6 +119,7 @@ func TestQueueEventDispatcher_FailDispath(t *testing.T) {
 
 	// give the queue a chance to run
 	qd.flushEvents()
+	time.Sleep(1 * time.Second)
 
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 1, qd.eventQueue.Size())

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -57,7 +57,7 @@ func TestQueueEventDispatcher_DispatchEvent(t *testing.T) {
 	// check the queue
 	assert.Equal(t, 0, qd.eventQueue.Size())
 
-	metric := *qd.GetMetrics().(*DefaultMetrics)
+	metric := qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(1), metric.SuccessFlushCount)
 	assert.Equal(t, int64(0), metric.FailFlushCount)
@@ -86,7 +86,7 @@ func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 0, qd.eventQueue.Size())
 
-	metric := *qd.GetMetrics().(*DefaultMetrics)
+	metric := qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 0, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
 	assert.Equal(t, int64(1), metric.FailFlushCount)
@@ -122,8 +122,7 @@ func TestQueueEventDispatcher_FailDispath(t *testing.T) {
 
 	// check the queue. bad event type should be removed.  but, not sent.
 	assert.Equal(t, 1, qd.eventQueue.Size())
-
-	metric := *qd.GetMetrics().(*DefaultMetrics)
+	metric := qd.GetMetrics().(*DefaultMetrics)
 	assert.Equal(t, 1, metric.QueueSize)
 	assert.Equal(t, int64(0), metric.SuccessFlushCount)
 	assert.True(t, metric.RetryFlushCount > 1)

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type CountingDispatcher struct {
-	eventCount int
+	eventCount   int
 	visitorCount int
 }
 
@@ -38,7 +38,9 @@ func (c *CountingDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 	c.visitorCount += len(event.Event.Visitors)
 	return true, nil
 }
-
+func (c *CountingDispatcher) GetMetrics() Metrics {
+	return nil
+}
 
 type MockDispatcher struct {
 	ShouldFail bool
@@ -54,6 +56,9 @@ func (m *MockDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 	return true, nil
 }
 
+func (f *MockDispatcher) GetMetrics() Metrics {
+	return nil
+}
 func NewMockDispatcher(queueSize int, shouldFail bool) *MockDispatcher {
 	return &MockDispatcher{Events: NewInMemoryQueue(queueSize), ShouldFail: shouldFail}
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -17,7 +17,7 @@ set -e
 
 workdir=.cover
 profile="$workdir/cover.out"
-mode=count
+mode=atomic
 
 generate_cover_data() {
     rm -rf "$workdir"
@@ -25,7 +25,7 @@ generate_cover_data() {
 
     for pkg in "$@"; do
         f="$workdir/$(echo $pkg | tr / -).cover"
-        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+        go test --race -covermode="$mode" -coverprofile="$f" "$pkg"
     done
 
     echo "mode: $mode" >"$profile"

--- a/tests/integration/optlyplugins/proxy_dispatcher.go
+++ b/tests/integration/optlyplugins/proxy_dispatcher.go
@@ -36,6 +36,11 @@ func (d *ProxyEventDispatcher) DispatchEvent(event event.LogEvent) (bool, error)
 	return true, nil
 }
 
+// DispatchEvent dispatches event with callback
+func (d *ProxyEventDispatcher) GetMetrics() event.Metrics {
+	return nil
+}
+
 // GetEvents returns dispatched events
 func (d *ProxyEventDispatcher) GetEvents() []event.Batch {
 	if d.events == nil {


### PR DESCRIPTION
## Summary

* This provides the metrics on dispatcher queue that gets the LogEvent for dispatching. Metrics include primarily the size of the queue and the flush states: successful, failed, retried. 

* This PR is the initial work that needs to be done to support dispatcher metrics on sidedoor:
https://optimizely.atlassian.net/browse/OASIS-5667

