### PR TITLE
Refactor ExecutionCtx into ExecGroup.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,7 +40,7 @@ type OptimizelyClient struct {
 	DecisionService    decision.Service
 	EventProcessor     event.Processor
 	notificationCenter notification.Center
-	executionCtx       utils.ExecutionCtx
+	execGroup          *utils.ExecGroup
 }
 
 // Activate returns the key of the variation the user is bucketed into and queues up an impression event to be sent to
@@ -488,5 +488,5 @@ func (o *OptimizelyClient) GetProjectConfig() (projectConfig config.ProjectConfi
 
 // Close closes the Optimizely instance and stops any ongoing tasks from its children components.
 func (o *OptimizelyClient) Close() {
-	o.executionCtx.TerminateAndWait()
+	o.execGroup.TerminateAndWait()
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -28,30 +28,12 @@ import (
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
 	"github.com/optimizely/go-sdk/pkg/notification"
+	"github.com/optimizely/go-sdk/pkg/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
-
-var exeCtxSignalFlag bool
-
-type ExecutionCtx struct {
-	Wg  *sync.WaitGroup
-	Ctx context.Context
-}
-
-func (ctx ExecutionCtx) TerminateAndWait() {
-	exeCtxSignalFlag = true
-}
-
-func (ctx ExecutionCtx) GetContext() context.Context {
-	return ctx.Ctx
-}
-
-func (ctx ExecutionCtx) GetWaitSync() *sync.WaitGroup {
-	return ctx.Wg
-}
 
 func ValidProjectConfigManager() *MockProjectConfigManager {
 	p := new(MockProjectConfigManager)
@@ -1934,17 +1916,24 @@ func TestClose(t *testing.T) {
 	mockProcessor := &MockProcessor{}
 	mockDecisionService := new(MockDecisionService)
 
+	eg := utils.NewExecGroup(context.Background())
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	eg.Go(func(ctx context.Context) {
+		<-ctx.Done()
+		wg.Done()
+	})
+
 	client := OptimizelyClient{
 		ConfigManager:   ValidProjectConfigManager(),
 		DecisionService: mockDecisionService,
 		EventProcessor:  mockProcessor,
-		executionCtx:    new(ExecutionCtx),
+		execGroup:       eg,
 	}
 
-	assert.False(t, exeCtxSignalFlag)
 	client.Close()
-	assert.True(t, exeCtxSignalFlag)
-
+	wg.Wait()
 }
 
 type ClientTestSuiteTrackEvent struct {

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sync"
@@ -170,20 +171,18 @@ func (cm *PollingProjectConfigManager) SyncConfig(datafile []byte) {
 }
 
 // Start starts the polling
-func (cm *PollingProjectConfigManager) Start(exeCtx utils.ExecutionCtx) {
-	go func() {
-		cmLogger.Debug("Polling Config Manager Initiated")
-		t := time.NewTicker(cm.pollingInterval)
-		for {
-			select {
-			case <-t.C:
-				cm.SyncConfig([]byte{})
-			case <-exeCtx.GetContext().Done():
-				cmLogger.Debug("Polling Config Manager Stopped")
-				return
-			}
+func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
+	cmLogger.Debug("Polling Config Manager Initiated")
+	t := time.NewTicker(cm.pollingInterval)
+	for {
+		select {
+		case <-t.C:
+			cm.SyncConfig([]byte{})
+		case <-ctx.Done():
+			cmLogger.Debug("Polling Config Manager Stopped")
+			return
 		}
-	}()
+	}
 }
 
 // NewPollingProjectConfigManager returns an instance of the polling config manager with the customized configuration

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -18,7 +18,6 @@
 package event
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"sync"
@@ -166,13 +165,10 @@ func (ed *QueueEventDispatcher) flushEvents() {
 }
 
 // NewQueueEventDispatcher creates a Dispatcher that queues in memory and then sends via go routine.
-func NewQueueEventDispatcher(ctx context.Context) Dispatcher {
-	dispatcher := &QueueEventDispatcher{eventQueue: NewInMemoryQueue(defaultQueueSize), Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()}, metrics: &DefaultMetrics{}}
-
-	go func() {
-		<-ctx.Done()
-		dispatcher.flushEvents()
-	}()
-
-	return dispatcher
+func NewQueueEventDispatcher() *QueueEventDispatcher {
+	return &QueueEventDispatcher{
+		eventQueue: NewInMemoryQueue(defaultQueueSize),
+		Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()},
+		metrics:    &DefaultMetrics{},
+	}
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -18,13 +18,13 @@
 package event
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
-	"github.com/optimizely/go-sdk/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -129,7 +129,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 		WithFlushInterval(10),
 		WithEventDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
-	processor.Start(utils.NewCancelableExecutionCtx())
+	go processor.Start(context.Background())
 
 	processor.ProcessEvent(impressionUserEvent)
 
@@ -147,7 +147,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 	processor := NewBatchEventProcessor(WithFlushInterval(10),
 		WithEventDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
 
-	processor.Start(utils.NewCancelableExecutionCtx())
+	go processor.Start(context.Background())
 
 	processor.ProcessEvent(conversionUserEvent)
 

--- a/pkg/utils/execgroup.go
+++ b/pkg/utils/execgroup.go
@@ -18,29 +18,46 @@
 package utils
 
 import (
-	"reflect"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"context"
+	"github.com/optimizely/go-sdk/pkg/logging"
+	"sync"
 )
 
-func TestNewCancelableExecutionCtx(t *testing.T) {
+var logger = logging.GetLogger("ExecGroup")
 
-	var exeCtx ExecutionCtx
-	exeCtx = NewCancelableExecutionCtx()
-
-	assert.True(t, reflect.TypeOf(exeCtx) == reflect.TypeOf(&CancelableExecutionCtx{}))
-	assert.NotNil(t, exeCtx.GetContext())
-	assert.NotNil(t, exeCtx.GetWaitSync())
+// ExecGroup is a utility for managing graceful, blocking cancellation of goroutines.
+type ExecGroup struct {
+	wg         *sync.WaitGroup
+	ctx        context.Context
+	cancelFunc context.CancelFunc
 }
 
-func TestTerminateAndWait(t *testing.T) {
+// NewExecGroup returns constructed object
+func NewExecGroup(ctx context.Context) *ExecGroup {
+	nctx, cancelFn := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
 
-	exeCtx := &CancelableExecutionCtx{}
-	exeCtx.TerminateAndWait()
-	assert.Nil(t, exeCtx.CancelFunc)
+	return &ExecGroup{wg: &wg, ctx: nctx, cancelFunc: cancelFn}
+}
 
-	exeCtx = NewCancelableExecutionCtx()
-	exeCtx.TerminateAndWait()
-	assert.NotNil(t, exeCtx.CancelFunc)
+// Go initiates a goroutine with the inputted function. Each invocation increments a shared WaitGroup
+// before being initiated. Once the supplied function exits the WaitGroup is decremented.
+// A common ctx is passed to each input function to signal a shutdown sequence.
+func (c ExecGroup) Go(f func(ctx context.Context)) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		f(c.ctx)
+	}()
+}
+
+// TerminateAndWait sends termination signal and waits
+func (c ExecGroup) TerminateAndWait() {
+
+	if c.cancelFunc == nil {
+		logger.Error("failed to shut down Execution Context properly", nil)
+		return
+	}
+	c.cancelFunc()
+	c.wg.Wait()
 }


### PR DESCRIPTION
## Summary
* Allow `OptimizelyFactory` to accept a plain old **context** object (POCO)
* Rework `ExecutionCtx` into `ExecGroup` (ala `errgroup`)
* Refactor `Start` methods to *NOT* manage their own goroutines, but assume to be executed within one (this is similar to `http.ListenAndServe`)

This refactor started when I wanted to manage the `OptimizelyClient` lifecycle in my application, but was surprised that I couldn't easily just pass in my own cancellable context. Instead I had to implement my own `ExecutableCtx`, which also had concepts I didn't feel were immediately relevant to what I was trying to accomplish. Digging further I saw how the `ExecutableCtx` was being used it followed more of the semantics of an [errgroup](https://godoc.org/golang.org/x/sync/errgroup) which means simply managing a "group" of goroutines.

An added side effect of this change is that `ExecGroup` is isolated to the client pkg and it's not leaked into the other implementations. Everything now just has to deal with `context` and overriding the default `context` feels much more idiomatic.

