### PR TITLE
refac(config): Move config interfaces back into config package

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -73,5 +73,21 @@ func main() {
 		client.WithPollingConfigManager(time.Second, nil),
 		client.WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
+
+	datafilePollingInterval := 2 * time.Second
+	eventBatchSize := 20
+	eventQueueSize := 1500
+	eventFlushInterval := 10 * time.Second
+
+	// Instantiate a client with custom configuration
+	optimizelyClient, _ = optimizelyFactory.Client(
+		client.WithPollingConfigManager(datafilePollingInterval, nil),
+		client.WithBatchEventProcessor(
+			eventBatchSize,
+			eventQueueSize,
+			eventFlushInterval,
+	),
+)
+
 	optimizelyClient.Close()
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -74,20 +74,5 @@ func main() {
 		client.WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 
-	datafilePollingInterval := 2 * time.Second
-	eventBatchSize := 20
-	eventQueueSize := 1500
-	eventFlushInterval := 10 * time.Second
-
-	// Instantiate a client with custom configuration
-	optimizelyClient, _ = optimizelyFactory.Client(
-		client.WithPollingConfigManager(datafilePollingInterval, nil),
-		client.WithBatchEventProcessor(
-			eventBatchSize,
-			eventQueueSize,
-			eventFlushInterval,
-	),
-)
-
 	optimizelyClient.Close()
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/google/uuid v1.1.1
 	github.com/json-iterator/go v1.1.7
+	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.3.0
 	github.com/stretchr/testify v1.4.0
 	github.com/twmb/murmur3 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.3.0 h1:OQIvuDgm00gWVWGTf4m4mCt6W1/0YqU7Ntg0mySWgaI=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,10 +20,10 @@ package client
 import (
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/config"
 	"runtime/debug"
 	"strconv"
 
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,10 +20,10 @@ package client
 import (
 	"errors"
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"runtime/debug"
 	"strconv"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
@@ -36,7 +36,7 @@ var logger = logging.GetLogger("Client")
 
 // OptimizelyClient is the entry point to the Optimizely SDK
 type OptimizelyClient struct {
-	ConfigManager      pkg.ProjectConfigManager
+	ConfigManager      config.ProjectConfigManager
 	DecisionService    decision.Service
 	EventProcessor     event.Processor
 	notificationCenter notification.Center
@@ -476,7 +476,7 @@ func (o *OptimizelyClient) RemoveOnTrack(id int) error {
 }
 
 // GetProjectConfig returns the current ProjectConfig or nil if the instance is not valid.
-func (o *OptimizelyClient) GetProjectConfig() (projectConfig pkg.ProjectConfig, err error) {
+func (o *OptimizelyClient) GetProjectConfig() (projectConfig config.ProjectConfig, err error) {
 
 	projectConfig, err = o.ConfigManager.GetConfig()
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/config"
 	"sync"
 	"testing"
 
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"sync"
 	"testing"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
@@ -103,7 +103,7 @@ func (m *MockNotificationCenter) Send(notificationType notification.Type, notifi
 }
 
 type TestConfig struct {
-	pkg.ProjectConfig
+	config.ProjectConfig
 }
 
 func (TestConfig) GetEventByKey(key string) (entities.Event, error) {

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/event"
@@ -34,7 +33,7 @@ type OptimizelyFactory struct {
 	SDKKey   string
 	Datafile []byte
 
-	configManager      pkg.ProjectConfigManager
+	configManager      config.ProjectConfigManager
 	decisionService    decision.Service
 	eventDispatcher    event.Dispatcher
 	eventProcessor     event.Processor
@@ -123,7 +122,7 @@ func WithPollingConfigManager(pollingInterval time.Duration, initDataFile []byte
 }
 
 // WithConfigManager sets polling config manager on a client.
-func WithConfigManager(configManager pkg.ProjectConfigManager) OptionFunc {
+func WithConfigManager(configManager config.ProjectConfigManager) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.configManager = configManager
 	}
@@ -181,7 +180,7 @@ func WithExecutionContext(executionContext utils.ExecutionCtx) OptionFunc {
 
 // StaticClient returns a client initialized with a static project config.
 func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
-	var configManager pkg.ProjectConfigManager
+	var configManager config.ProjectConfigManager
 
 	if f.SDKKey != "" {
 		staticConfigManager, err := config.NewStaticProjectConfigManagerFromURL(f.SDKKey)

--- a/pkg/client/fixtures_test.go
+++ b/pkg/client/fixtures_test.go
@@ -19,8 +19,8 @@ package client
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/config"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
@@ -33,7 +33,7 @@ import (
  */
 
 type MockProjectConfig struct {
-	pkg.ProjectConfig
+	config.ProjectConfig
 	mock.Mock
 }
 
@@ -79,17 +79,17 @@ func (c *MockProjectConfig) GetBotFiltering() bool {
 }
 
 type MockProjectConfigManager struct {
-	projectConfig pkg.ProjectConfig
+	projectConfig config.ProjectConfig
 	mock.Mock
 }
 
-func (p *MockProjectConfigManager) GetConfig() (pkg.ProjectConfig, error) {
+func (p *MockProjectConfigManager) GetConfig() (config.ProjectConfig, error) {
 	if p.projectConfig != nil {
 		return p.projectConfig, nil
 	}
 
 	args := p.Called()
-	return args.Get(0).(pkg.ProjectConfig), args.Error(1)
+	return args.Get(0).(config.ProjectConfig), args.Error(1)
 }
 
 func (p *MockProjectConfigManager) OnProjectConfigUpdate(callback func(notification.ProjectConfigUpdateNotification)) (int, error) {
@@ -126,10 +126,10 @@ func (m *MockEventProcessor) ProcessEvent(event event.UserEvent) bool {
 }
 
 type PanickingConfigManager struct {
-	pkg.ProjectConfigManager
+	config.ProjectConfigManager
 }
 
-func (m *PanickingConfigManager) GetConfig() (pkg.ProjectConfig, error) {
+func (m *PanickingConfigManager) GetConfig() (config.ProjectConfig, error) {
 	panic("I'm panicking")
 }
 

--- a/pkg/client/fixtures_test.go
+++ b/pkg/client/fixtures_test.go
@@ -19,8 +19,8 @@ package client
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/config"
 
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -1,3 +1,20 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package config //
 package config
 
 import (

--- a/pkg/config/interface.go.go
+++ b/pkg/config/interface.go.go
@@ -1,21 +1,4 @@
-/****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
- *                                                                          *
- * Licensed under the Apache License, Version 2.0 (the "License");          *
- * you may not use this file except in compliance with the License.         *
- * You may obtain a copy of the License at                                  *
- *                                                                          *
- *    http://www.apache.org/licenses/LICENSE-2.0                            *
- *                                                                          *
- * Unless required by applicable law or agreed to in writing, software      *
- * distributed under the License is distributed on an "AS IS" BASIS,        *
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
- * See the License for the specific language governing permissions and      *
- * limitations under the License.                                           *
- ***************************************************************************/
-
-// Package pkg //
-package pkg
+package config
 
 import (
 	"github.com/optimizely/go-sdk/pkg/entities"

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
 	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
@@ -60,7 +59,7 @@ type PollingProjectConfigManager struct {
 
 	configLock    sync.RWMutex
 	err           error
-	projectConfig pkg.ProjectConfig
+	projectConfig ProjectConfig
 }
 
 // OptionFunc is used to provide custom configuration to the PollingProjectConfigManager.
@@ -208,7 +207,7 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 }
 
 // GetConfig returns the project config
-func (cm *PollingProjectConfigManager) GetConfig() (pkg.ProjectConfig, error) {
+func (cm *PollingProjectConfigManager) GetConfig() (ProjectConfig, error) {
 	cm.configLock.RLock()
 	defer cm.configLock.RUnlock()
 	if cm.projectConfig == nil {

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/utils"
@@ -30,7 +29,7 @@ import (
 
 // StaticProjectConfigManager maintains a static copy of the project config
 type StaticProjectConfigManager struct {
-	projectConfig pkg.ProjectConfig
+	projectConfig ProjectConfig
 	configLock    sync.Mutex
 }
 
@@ -61,14 +60,14 @@ func NewStaticProjectConfigManagerFromPayload(payload []byte) (*StaticProjectCon
 }
 
 // NewStaticProjectConfigManager creates a new instance of the manager with the given project config
-func NewStaticProjectConfigManager(config pkg.ProjectConfig) *StaticProjectConfigManager {
+func NewStaticProjectConfigManager(config ProjectConfig) *StaticProjectConfigManager {
 	return &StaticProjectConfigManager{
 		projectConfig: config,
 	}
 }
 
 // GetConfig returns the project config
-func (cm *StaticProjectConfigManager) GetConfig() (pkg.ProjectConfig, error) {
+func (cm *StaticProjectConfigManager) GetConfig() (ProjectConfig, error) {
 	cm.configLock.Lock()
 	defer cm.configLock.Unlock()
 	return cm.projectConfig, nil

--- a/pkg/decision/entities.go
+++ b/pkg/decision/entities.go
@@ -18,7 +18,7 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
@@ -26,13 +26,13 @@ import (
 // ExperimentDecisionContext contains the information needed to be able to make a decision for a given experiment
 type ExperimentDecisionContext struct {
 	Experiment    *entities.Experiment
-	ProjectConfig pkg.ProjectConfig
+	ProjectConfig config.ProjectConfig
 }
 
 // FeatureDecisionContext contains the information needed to be able to make a decision for a given feature
 type FeatureDecisionContext struct {
 	Feature       *entities.Feature
-	ProjectConfig pkg.ProjectConfig
+	ProjectConfig config.ProjectConfig
 	Variable      entities.Variable
 }
 

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -22,14 +22,14 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/stretchr/testify/mock"
 )
 
 // Mock implementation of ProjectConfig
 type mockProjectConfig struct {
-	pkg.ProjectConfig
+	config.ProjectConfig
 	mock.Mock
 }
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -20,13 +20,11 @@ package event
 import (
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/config"
 	"strings"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg"
-
 	guuid "github.com/google/uuid"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/utils"
@@ -35,8 +33,6 @@ import (
 var efLogger = logging.GetLogger("EventFactory")
 
 const impressionKey string = "campaign_activated"
-const clientKey string = pkg.ClientName
-const clientVersion string = pkg.Version
 const attributeType = "custom"
 const specialPrefix = "$opt_"
 const botFilteringKey = "$opt_bot_filtering"
@@ -58,8 +54,8 @@ func CreateEventContext(projectConfig config.ProjectConfig) Context {
 	context.ProjectID = projectConfig.GetProjectID()
 	context.Revision = projectConfig.GetRevision()
 	context.AccountID = projectConfig.GetAccountID()
-	context.ClientName = clientKey
-	context.ClientVersion = clientVersion
+	context.ClientName = ClientName
+	context.ClientVersion = Version
 	context.AnonymizeIP = projectConfig.GetAnonymizeIP()
 	context.BotFiltering = projectConfig.GetBotFiltering()
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -20,6 +20,7 @@ package event
 import (
 	"errors"
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"strings"
 	"time"
 
@@ -52,7 +53,7 @@ func makeTimestamp() int64 {
 }
 
 // CreateEventContext creates and returns EventContext
-func CreateEventContext(projectConfig pkg.ProjectConfig) Context {
+func CreateEventContext(projectConfig config.ProjectConfig) Context {
 	context := Context{}
 	context.ProjectID = projectConfig.GetProjectID()
 	context.Revision = projectConfig.GetRevision()
@@ -65,7 +66,7 @@ func CreateEventContext(projectConfig pkg.ProjectConfig) Context {
 	return context
 }
 
-func createImpressionEvent(projectConfig pkg.ProjectConfig, experiment entities.Experiment,
+func createImpressionEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
 	variation entities.Variation, attributes map[string]interface{}) ImpressionEvent {
 
 	impression := ImpressionEvent{}
@@ -80,7 +81,7 @@ func createImpressionEvent(projectConfig pkg.ProjectConfig, experiment entities.
 }
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
-func CreateImpressionUserEvent(projectConfig pkg.ProjectConfig, experiment entities.Experiment,
+func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
 	variation entities.Variation,
 	userContext entities.UserContext) UserEvent {
 
@@ -116,7 +117,7 @@ func createImpressionVisitor(userEvent UserEvent) Visitor {
 }
 
 // create a conversion event
-func createConversionEvent(projectConfig pkg.ProjectConfig, event entities.Event, attributes, eventTags map[string]interface{}) ConversionEvent {
+func createConversionEvent(projectConfig config.ProjectConfig, event entities.Event, attributes, eventTags map[string]interface{}) ConversionEvent {
 	conversion := ConversionEvent{}
 
 	conversion.Key = event.Key
@@ -128,7 +129,7 @@ func createConversionEvent(projectConfig pkg.ProjectConfig, event entities.Event
 }
 
 // CreateConversionUserEvent creates and returns ConversionEvent for user
-func CreateConversionUserEvent(projectConfig pkg.ProjectConfig, event entities.Event, userContext entities.UserContext, eventTags map[string]interface{}) UserEvent {
+func CreateConversionUserEvent(projectConfig config.ProjectConfig, event entities.Event, userContext entities.UserContext, eventTags map[string]interface{}) UserEvent {
 
 	userEvent := UserEvent{}
 	userEvent.Timestamp = makeTimestamp()
@@ -221,7 +222,7 @@ func createBatchEvent(userEvent UserEvent, visitor Visitor) Batch {
 }
 
 // get visitor attributes from user attributes
-func getEventAttributes(projectConfig pkg.ProjectConfig, attributes map[string]interface{}) []VisitorAttribute {
+func getEventAttributes(projectConfig config.ProjectConfig, attributes map[string]interface{}) []VisitorAttribute {
 	var eventAttributes = []VisitorAttribute{}
 
 	for key, value := range attributes {

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -18,11 +18,11 @@
 package event
 
 import (
-	"github.com/optimizely/go-sdk/pkg/config"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/utils"
 	"github.com/stretchr/testify/assert"

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -18,18 +18,18 @@
 package event
 
 import (
+	"github.com/optimizely/go-sdk/pkg/config"
 	"math/rand"
 	"testing"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 type TestConfig struct {
-	pkg.ProjectConfig
+	config.ProjectConfig
 }
 
 func (TestConfig) GetAttributeByKey(string) (entities.Attribute, error) {

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -14,8 +14,8 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
-// Package pkg //
-package pkg
+// Package event //
+package event
 
 // Version is the current version of the client
 const Version = "1.0.0-rc1"

--- a/tests/integration/optlyplugins/userprofileservice/utils.go
+++ b/tests/integration/optlyplugins/userprofileservice/utils.go
@@ -17,7 +17,7 @@
 package userprofileservice
 
 import (
-	"github.com/optimizely/go-sdk/pkg"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/tests/integration/models"
 )
@@ -29,7 +29,7 @@ type UPSHelper interface {
 }
 
 // CreateUserProfileService creates a user profile service with the given parameters
-func CreateUserProfileService(config pkg.ProjectConfig, apiOptions models.APIOptions) decision.UserProfileService {
+func CreateUserProfileService(config config.ProjectConfig, apiOptions models.APIOptions) decision.UserProfileService {
 	var userProfileService decision.UserProfileService
 	switch apiOptions.UserProfileServiceType {
 	case "NormalService":

--- a/tests/integration/support/utils.go
+++ b/tests/integration/support/utils.go
@@ -18,15 +18,13 @@ package support
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/optimizely/go-sdk/pkg"
-
-	"gopkg.in/yaml.v3"
 )
 
 func sortArrayofMaps(array []map[string]interface{}, sortKey string) []map[string]interface{} {
@@ -46,7 +44,7 @@ func sortArrayofMaps(array []map[string]interface{}, sortKey string) []map[strin
 	return array
 }
 
-func parseYamlArray(s string, config pkg.ProjectConfig) ([]map[string]interface{}, error) {
+func parseYamlArray(s string, config config.ProjectConfig) ([]map[string]interface{}, error) {
 	var array []map[string]interface{}
 	parsedString := parseTemplate(s, config)
 	if err := yaml.Unmarshal([]byte(parsedString), &array); err != nil {
@@ -55,7 +53,7 @@ func parseYamlArray(s string, config pkg.ProjectConfig) ([]map[string]interface{
 	return array, nil
 }
 
-func parseTemplate(s string, config pkg.ProjectConfig) string {
+func parseTemplate(s string, config config.ProjectConfig) string {
 
 	parsedString := strings.Replace(s, "{{datafile.projectId}}", config.GetProjectID(), -1)
 

--- a/tests/integration/support/utils.go
+++ b/tests/integration/support/utils.go
@@ -18,7 +18,6 @@ package support
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"regexp"
 	"sort"
 	"strings"

--- a/tests/integration/support/utils.go
+++ b/tests/integration/support/utils.go
@@ -18,13 +18,13 @@ package support
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/config"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/optimizely/go-sdk/pkg/config"
 )
 
 func sortArrayofMaps(array []map[string]interface{}, sortKey string) []map[string]interface{} {

--- a/tests/integration/support/utils.go
+++ b/tests/integration/support/utils.go
@@ -18,6 +18,7 @@ package support
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"regexp"
 	"sort"
 	"strings"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/optimizely/go-sdk/pkg/config"
+
+	"gopkg.in/yaml.v3"
 )
 
 func sortArrayofMaps(array []map[string]interface{}, sortKey string) []map[string]interface{} {


### PR DESCRIPTION
# Summary
- Moves the project config struct and project config manager interface from `pkg` into `config` so we don't have anything hanging off of the `pkg` package.
- Used Goland to to a refactor --> move

# Tests
- Unit tests