### PR TITLE
fix: logging nil project config, adding more meaningful error messages

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -479,7 +479,7 @@ func (o *OptimizelyClient) RemoveOnTrack(id int) error {
 func (o *OptimizelyClient) getProjectConfig() (projectConfig config.ProjectConfig, err error) {
 
 	if isNil(o.ConfigManager) {
-		return nil, errors.New("project config is not initialized")
+		return nil, errors.New("project config manager is not initialized")
 	}
 	projectConfig, err = o.ConfigManager.GetConfig()
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -41,6 +41,10 @@ func ValidProjectConfigManager() *MockProjectConfigManager {
 	return p
 }
 
+func InValidProjectConfigManager() *MockProjectConfigManager {
+	return nil
+}
+
 type MockProcessor struct {
 	Events []event.UserEvent
 	mock.Mock
@@ -1190,6 +1194,18 @@ func TestGetProjectConfigIsValid(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, mockConfigManager.projectConfig, actual)
+}
+
+func TestGetProjectConfigIsInValid(t *testing.T) {
+
+	client := OptimizelyClient{
+		ConfigManager: InValidProjectConfigManager(),
+	}
+
+	actual, err := client.getProjectConfig()
+
+	assert.NotNil(t, err)
+	assert.Nil(t, actual)
 }
 
 func TestGetOptimizelyConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Activate() returned vague runtime error (referencing null pointer).  After analysis and debugging, found 2 scenarios causing this:
- nil project config
- decision context is empty but variation is not nil somehow.

Added some protective logic against null references across client methods. 