### PR TITLE
fix(notification): race detected send notification issue

### DIFF
--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -81,13 +81,12 @@ func (am *AtomicManager) Send(notification interface{}) {
 	}
 }
 
-// Copy handlers and return it.
-func (am *AtomicManager) copyHandlers() map[uint32]func(interface{}) {
+// Return a copy of the given handlers
+func (am *AtomicManager) copyHandlers() (handlers []func(interface{})) {
 	am.lock.RLock()
 	defer am.lock.RUnlock()
-	m := make(map[uint32]func(interface{}), len(am.handlers))
-	for k, v := range am.handlers {
-		m[k] = v
+	for _, v := range am.handlers {
+		handlers = append(handlers, v)
 	}
-	return m
+	return handlers
 }

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -66,7 +66,17 @@ func (am *AtomicManager) Remove(id int) {
 
 // Send sends the notification to the registered handlers
 func (am *AtomicManager) Send(notification interface{}) {
-	for _, handler := range am.handlers {
+	handlers := am.copyHandlers()
+	for _, handler := range handlers {
 		handler(notification)
 	}
+}
+
+// Copy handlers and return it.
+func (am *AtomicManager) copyHandlers() map[uint32]func(interface{}) {
+	m := make(map[uint32]func(interface{}), len(am.handlers))
+	for k, v := range am.handlers {
+		m[k] = v
+	}
+	return m
 }

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -74,9 +74,9 @@ func (am *AtomicManager) Remove(id int) {
 
 // Send sends the notification to the registered handlers
 func (am *AtomicManager) Send(notification interface{}) {
+	// copying handler to avoid race condition
 	handlers := am.copyHandlers()
 	for _, handler := range handlers {
-		// copying handler to avoid race condition
 		handler(notification)
 	}
 }

--- a/pkg/notification/manager_test.go
+++ b/pkg/notification/manager_test.go
@@ -50,3 +50,55 @@ func TestAtomicManager(t *testing.T) {
 	// Sanity check by calling remove with a incorrect handler id
 	atomicManager.Remove(55)
 }
+
+func TestSendtRaceCondition(t *testing.T) {
+	sync := make(chan interface{})
+	payload := map[string]interface{}{
+		"key": "test",
+	}
+	atomicManager := NewAtomicManager()
+	result1, result2 := 0, 0
+	listenerCalled := false
+
+	listener1 := func(interface{}) {
+	}
+
+	listener2 := func(interface{}) {
+		// Add listener2 internally to assert deadlock
+		result2, _ = atomicManager.Add(listener1)
+		// Remove all added listeners
+		atomicManager.Remove(result1)
+		atomicManager.Remove(result2)
+		listenerCalled = true
+	}
+	result1, _ = atomicManager.Add(listener2)
+
+	go func() {
+		atomicManager.Send(payload)
+		// notifying that notification is sent.
+		sync <- ""
+	}()
+
+	<-sync
+
+	assert.Equal(t, 1, result1)
+	assert.Equal(t, 2, result2)
+	assert.Equal(t, true, listenerCalled)
+}
+
+func TestAddRaceCondition(t *testing.T) {
+	sync := make(chan interface{})
+	atomicManager := NewAtomicManager()
+
+	listener1 := func(interface{}) {
+
+	}
+	result1, _ := atomicManager.Add(listener1)
+	go func() {
+		atomicManager.Remove(result1)
+		sync <- ""
+	}()
+
+	<-sync
+	assert.Equal(t, len(atomicManager.handlers), 0)
+}

--- a/pkg/notification/manager_test.go
+++ b/pkg/notification/manager_test.go
@@ -51,7 +51,7 @@ func TestAtomicManager(t *testing.T) {
 	atomicManager.Remove(55)
 }
 
-func TestSendtRaceCondition(t *testing.T) {
+func TestSendRaceCondition(t *testing.T) {
 	sync := make(chan interface{})
 	payload := map[string]interface{}{
 		"key": "test",
@@ -79,10 +79,11 @@ func TestSendtRaceCondition(t *testing.T) {
 		sync <- ""
 	}()
 
+	atomicManager.Add(listener1)
 	<-sync
 
 	assert.Equal(t, 1, result1)
-	assert.Equal(t, 2, result2)
+	assert.Equal(t, len(atomicManager.handlers), 1)
 	assert.Equal(t, true, listenerCalled)
 }
 


### PR DESCRIPTION
### Summary
- Fixed an issue when notification callbacks were calling Add/Remove of same notification manager. 
- All summary is in this PR. https://github.com/optimizely/go-sdk/pull/219

### TestPlan
- Added unit tests for race detected scenarios.