### PR TITLE
Allow ClientName and Version to be set at compile time.

### DIFF
--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-const Version = "1.0.0"
+var Version = "1.0.0"
 
 // ClientName is the name of the client
-const ClientName = "go-sdk"
+var ClientName = "go-sdk"


### PR DESCRIPTION
## Summary
* Change `const` to `var` to allow being overridden.

A requirement of Optimizely Agent is to differentiate events originating from Agent vs the native go-sdk. Making these symbols variables allows the Agent build to set them during compile time via linker flags. Ex:
```
-X github.com/optimizely/go-sdk/pkg/event.ClientName=Agent
```