### PR TITLE
Add explicit JSON tags for OptimizelyConfig.

### DIFF
--- a/pkg/config/optimizely_config.go
+++ b/pkg/config/optimizely_config.go
@@ -21,40 +21,40 @@ import "github.com/optimizely/go-sdk/pkg/entities"
 
 // OptimizelyConfig is a snapshot of the experiments and features in the project config
 type OptimizelyConfig struct {
-	Revision       string
-	ExperimentsMap map[string]OptimizelyExperiment
-	FeaturesMap    map[string]OptimizelyFeature
+	Revision       string                          `json:"revision"`
+	ExperimentsMap map[string]OptimizelyExperiment `json:"experimentsMap"`
+	FeaturesMap    map[string]OptimizelyFeature    `json:"featuresMap"`
 }
 
 // OptimizelyExperiment has experiment info
 type OptimizelyExperiment struct {
-	ID            string
-	Key           string
-	VariationsMap map[string]OptimizelyVariation
+	ID            string                         `json:"id"`
+	Key           string                         `json:"key"`
+	VariationsMap map[string]OptimizelyVariation `json:"variationsMap"`
 }
 
 // OptimizelyFeature has feature info
 type OptimizelyFeature struct {
-	ID             string
-	Key            string
-	ExperimentsMap map[string]OptimizelyExperiment
-	VariablesMap   map[string]OptimizelyVariable
+	ID             string                          `json:"id"`
+	Key            string                          `json:"key"`
+	ExperimentsMap map[string]OptimizelyExperiment `json:"experimentsMap"`
+	VariablesMap   map[string]OptimizelyVariable   `json:"variablesMap"`
 }
 
 // OptimizelyVariation has variation info
 type OptimizelyVariation struct {
-	ID             string
-	Key            string
-	FeatureEnabled bool
-	VariablesMap   map[string]OptimizelyVariable
+	ID             string                        `json:"id"`
+	Key            string                        `json:"key"`
+	FeatureEnabled bool                          `json:"featureEnabled"`
+	VariablesMap   map[string]OptimizelyVariable `json:"variablesMap"`
 }
 
 // OptimizelyVariable has variable info
 type OptimizelyVariable struct {
-	ID    string
-	Key   string
-	Type  string
-	Value string
+	ID    string `json:"id"`
+	Key   string `json:"key"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 func getVariableByIDMap(features []entities.Feature) (variableByIDMap map[string]entities.Variable) {


### PR DESCRIPTION
## Summary
* Add JSON tags to OptimizelyConfig

Marshaling of the `OptimizelyConfig` into JSON was picking up the literal struct field names. This change uses JSON tags to map the struct fields to a more JSON friendlier representation.

### Before:
```json
"ExperimentsMap": {
    "sample_test": {
        "ID": "10000",
        "Key": "sample_test",
        "VariationsMap": {
            "sample_variation": {
                "FeatureEnabled": true,
                "ID": "20000",
                "Key": "sample_variation",
                "VariablesMap": {
                    "sample_variable": {
                        "ID": "30000",
                        "Key": "sample_variable",
                        "Type": "string",
                        "Value": "winning"
                    },
```
### After:
```json
"experimentsMap": {
    "sample_test": {
        "id": "10000",
        "key": "sample_test",
        "variationsMap": {
            "sample_variation": {
                "featureEnabled": true,
                "id": "20000",
                "key": "sample_variation",
                "variablesMap": {
                    "sample_variable": {
                        "id": "30000",
                        "key": "sample_variable",
                        "type": "string",
                        "value": "winning"
                    },      
```
