### PR TITLE
feat: set specific error from default project config manager when CDN returns 403 response

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/optimizely/go-sdk"
 	"github.com/optimizely/go-sdk/pkg/client"
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/event"
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
@@ -17,8 +18,6 @@ func main() {
 	sdkKey := "4SLpaJA1r1pgE6T2CoMs9q"
 	logging.SetLogLevel(logging.LogLevelDebug)
 
-	/************* Simple usage ********************/
-
 	user := optimizely.UserContext(
 		"mike ng",
 		map[string]interface{}{
@@ -26,8 +25,20 @@ func main() {
 			"likes_donuts": true,
 		},
 	)
-	optimizelyClient, err := optimizely.Client(sdkKey)
-	enabled, _ := optimizelyClient.IsFeatureEnabled("mutext_feat", user)
+
+	/************* Bad SDK Key  ********************/
+
+	optimizelyClient, err := optimizely.Client("some_key")
+	enabled, err := optimizelyClient.IsFeatureEnabled("mutext_feat", user)
+	if err == config.Err403Forbidden {
+		fmt.Println("A Valid 403 error received:", config.Err403Forbidden)
+	}
+
+	/************* Simple usage ********************/
+
+	optimizelyClient, err = optimizely.Client(sdkKey)
+	enabled, _ = optimizelyClient.IsFeatureEnabled("mutext_feat", user)
+
 	fmt.Printf("Is feature enabled? %v\n", enabled)
 
 	/************* StaticClient ********************/

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -46,7 +46,7 @@ const LastModified = "Last-Modified"
 const DatafileURLTemplate = "https://cdn.optimizely.com/datafiles/%s.json"
 
 // Err403Forbidden is 403Forbidden specific error
-var Err403Forbidden = errors.New("unable to fetch fresh datafile, reason (http status code): 403 Forbidden")
+var Err403Forbidden = errors.New("unable to fetch fresh datafile (consider rechecking SDK key), status code: 403 Forbidden")
 
 var cmLogger = logging.GetLogger("PollingConfigManager")
 

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -585,6 +585,9 @@ func TestPollingInterval(t *testing.T) {
 
 	assert.Equal(t, configManager.pollingInterval, 5*time.Second)
 	assert.Equal(t, asyncConfigManager.pollingInterval, 5*time.Second)
+
+	assert.Equal(t, configManager.err, Err403Forbidden)
+	assert.Nil(t, asyncConfigManager.err)
 }
 
 func TestInitialDatafile(t *testing.T) {


### PR DESCRIPTION
## Summary

Assigning error to a predefined error variable when CDN returns 403 response helps consumers such as sidedoor. Currently these consumers have to search the error message string for the text "403", which is not really convenient. 