### PR TITLE
feat: OnEvent should be part of the event processor interface

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -58,6 +58,14 @@ func (m *MockProcessor) ProcessEvent(event event.UserEvent) bool {
 	return result
 }
 
+func (m *MockProcessor) OnEventDispatch(callback func(logEvent event.LogEvent)) (int, error) {
+	return 0, nil
+}
+
+func (m *MockProcessor) RemoveOnEventDispatch(id int) error {
+	return nil
+}
+
 type MockNotificationCenter struct {
 	notification.Center
 	mock.Mock

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -35,6 +35,8 @@ import (
 // Processor processes events
 type Processor interface {
 	ProcessEvent(event UserEvent) bool
+	OnEventDispatch(callback func(logEvent LogEvent)) (int, error)
+	RemoveOnEventDispatch(id int) error
 }
 
 // BatchEventProcessor is used out of the box by the SDK to queue up and batch events to be sent to the Optimizely


### PR DESCRIPTION
## Summary
OnEvent should be part of the event processor interface, and not only on BatchEventProcessor