### PR TITLE
feat: Add blocking timeout in polling config manager.

### DIFF
--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -332,34 +332,3 @@ func (cm *PollingProjectConfigManager) sendConfigUpdateNotification() {
 		}
 	}
 }
-
-// // waitForConfigAvailability waits till blocking timeout for config availability
-// func (cm *PollingProjectConfigManager) waitForConfigAvailability() {
-// 	// Only wait if config not available
-// 	if !cm.isConfigAvailable {
-// 		select {
-// 		case <-cm.configAvailabilityChannel: // Config was made available
-// 		case <-time.After(cm.blockingTimeout): // Timed out
-// 		}
-// 	}
-// }
-
-// // setConfigAvailability updates config availability status to true
-// func (cm *PollingProjectConfigManager) setConfigAvailability() {
-// 	cm.isConfigAvailable = true
-// 	// Check if waiting for config availability status
-// 	if cm.isWaitingForConfigAvailability() {
-// 		// notifying channel about availability
-// 		cm.configAvailabilityChannel <- true
-// 		// end waiting
-// 		cm.setWaitingStatus(0)
-// 	}
-// }
-
-// func (cm *PollingProjectConfigManager) setWaitingStatus(status int32) {
-// 	atomic.StoreInt32(&cm.waitingForConfigAvailability, status)
-// }
-
-// func (cm *PollingProjectConfigManager) isWaitingForConfigAvailability() bool {
-// 	return atomic.LoadInt32(&cm.waitingForConfigAvailability) == 1
-// }

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -244,9 +244,10 @@ func NewAsyncPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...
 
 // GetConfig returns the project config
 func (cm *PollingProjectConfigManager) GetConfig() (ProjectConfig, error) {
+	// since syncconfig is also inside a lock, we have to wait outside rlock.
+	utils.WaitForChannelToCloseOrTimeout(cm.configAvailable, cm.blockingTimeout)
 	cm.configLock.RLock()
 	defer cm.configLock.RUnlock()
-	utils.WaitForChannelToCloseOrTimeout(cm.configAvailable, cm.blockingTimeout)
 	if cm.projectConfig == nil {
 		return cm.projectConfig, cm.err
 	}

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -36,7 +36,7 @@ import (
 // DefaultPollingInterval sets default interval for polling manager
 const DefaultPollingInterval = 5 * time.Minute // default to 5 minutes for polling
 
-// DefaultBlockingTimeout sets timeout to block the config call until config has been initialized
+// DefaultBlockingTimeout is the default timeout for blocking in the GetConfig method until a config has been initialized
 const DefaultBlockingTimeout = 10 * time.Second // default to 10 seconds
 
 // ModifiedSince header key for request

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-20, Optimizely, Inc. and contributors                     *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-20, Optimizely, Inc. and contributors                     *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -163,6 +163,7 @@ func TestGetConfigForPollingConfigManagerWaitsForTimeoutForInvalidDatafile(t *te
 
 	start := time.Now()
 	expectedExecutionTime := start.Add(blockingTimeout)
+	// blocking api for specified time.
 	_, _ = configManager.GetConfig()
 	actualExecutionTime := start.Add(time.Since(start))
 	assert.WithinDuration(t, expectedExecutionTime, actualExecutionTime, 10*time.Millisecond)
@@ -181,6 +182,7 @@ func TestGetConfigForAsyncPollingConfigManagerWaitsForTimeoutForInvalidDatafile(
 	configManager.SyncConfig()
 	start := time.Now()
 	expectedExecutionTime := start.Add(blockingTimeout)
+	// blocking api for specified time.
 	_, _ = configManager.GetConfig()
 	actualExecutionTime := start.Add(time.Since(start))
 	assert.WithinDuration(t, expectedExecutionTime, actualExecutionTime, 10*time.Millisecond)

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-20, Optimizely, Inc. and contributors                     *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-20, Optimizely, Inc. and contributors                     *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/utils/channel_utils.go
+++ b/pkg/utils/channel_utils.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/utils/channel_utils.go
+++ b/pkg/utils/channel_utils.go
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package utils //
+package utils
+
+import "time"
+
+// IsChannelClosed will check if the given channel is closed
+func IsChannelClosed(ch chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitForChannelToCloseOrTimeout will wait for the channel to close or timeout
+func WaitForChannelToCloseOrTimeout(ch chan struct{}, blockingTimeout time.Duration) {
+	select {
+	case <-ch:
+		break
+	case <-time.After(blockingTimeout):
+		break
+	}
+}

--- a/pkg/utils/channel_utils.go
+++ b/pkg/utils/channel_utils.go
@@ -20,7 +20,7 @@ package utils
 import "time"
 
 // IsChannelClosed will check if the given channel is closed
-func IsChannelClosed(ch chan struct{}) bool {
+func IsChannelClosed(ch <-chan struct{}) bool {
 	select {
 	case <-ch:
 		return true
@@ -30,7 +30,7 @@ func IsChannelClosed(ch chan struct{}) bool {
 }
 
 // WaitForChannelToCloseOrTimeout will wait for the channel to close or timeout
-func WaitForChannelToCloseOrTimeout(ch chan struct{}, blockingTimeout time.Duration) {
+func WaitForChannelToCloseOrTimeout(ch <-chan struct{}, blockingTimeout time.Duration) {
 	select {
 	case <-ch:
 		break

--- a/pkg/utils/channel_utils_test.go
+++ b/pkg/utils/channel_utils_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/utils/channel_utils_test.go
+++ b/pkg/utils/channel_utils_test.go
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * Copyright 2019, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsChannelClosed(t *testing.T) {
+	var ch = make(chan struct{})
+	assert.Equal(t, false, IsChannelClosed(ch))
+	close(ch)
+	assert.Equal(t, true, IsChannelClosed(ch))
+}
+
+func TestWaitForChannelToCloseOrTimeoutStopsWaitingWhenChannelIsClosed(t *testing.T) {
+	var ch = make(chan struct{})
+	var finishedWaiting bool
+	go func() {
+		WaitForChannelToCloseOrTimeout(ch, 10*time.Second)
+		finishedWaiting = true
+	}()
+	close(ch)
+	time.Sleep(5 * time.Millisecond)
+	// Check WaitForChannelToCloseOrTimeout finishes waiting when channel is closed
+	assert.Equal(t, true, finishedWaiting)
+}
+
+func TestWaitForChannelToCloseOrTimeoutWaitsForTimeoutWhenChannelIsNotClosed(t *testing.T) {
+	var ch = make(chan struct{})
+	blockingTimeOut := 1 * time.Second
+	var expectedExecutionTime time.Time
+	var actualExecutionTime time.Time
+	go func() {
+		// Keep track of execution time
+		start := time.Now()
+		expectedExecutionTime = start.Add(blockingTimeOut)
+		WaitForChannelToCloseOrTimeout(ch, blockingTimeOut)
+		actualExecutionTime = start.Add(time.Since(start))
+	}()
+	// Wait for execution to finish
+	time.Sleep(1005 * time.Millisecond)
+	// Verify method timed out
+	assert.WithinDuration(t, expectedExecutionTime, actualExecutionTime, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Summary
This introduces blocking timeout in PollingConfigManager. Config Manager will block any calling go-routine until the config is available or the timeout occurs.