### PR TITLE
fix(1.8): go 1.8 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - go get -v -d ./...
         # This pkg not in go 1.8
         - go get github.com/stretchr/testify
-        - pushd $GOPATH/src/github.com/stretchr/testify && go checkout v1.4.0 && popd
+        - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
         # -coverprofile was not introduced in 1.8
         - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ jobs:
         # Need to download packages explicitly
         - go get -v -d ./...
         # This pkg not in go 1.8
-        - go get github.com/stretchr/testify@v1.4.0
+        - go get github.com/stretchr/testify
+        - pushd $GOPATH/src/github.com/stretchr/testify && go checkout v1.4.0 && popd
         # -coverprofile was not introduced in 1.8
         - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
         # Need to download packages explicitly
         - go get -v -d ./...
         # This pkg not in go 1.8
-        - go get github.com/stretchr/testify
+        - go get github.com/stretchr/testify@v1.4.0
         # -coverprofile was not introduced in 1.8
         - make test
 


### PR DESCRIPTION
### Summary
- go 1.8 was unable to run unit tests because of `stretcher/testify` introduced new methods in the interface which we are not implementing. 
- checkedout specific branch which doesn't have that new method in the interface.  Here's the commit caused issue. 
https://github.com/stretchr/testify/commit/ea72eb91592e90d15a9e03ffe61f02493135d843

### Testplan 
- All unit tests and FSC are running fine. 