### PR TITLE
fix:  instantiate event processor with dispatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
       script:
         # Need to download packages explicitly
-        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git 
+        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
         # This pkg not in go 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
       script:
         # Need to download packages explicitly
-        - go get -f -u  github.com/twmb/murmur3 
+        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git 
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
         # This pkg not in go 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
       script:
         # Need to download packages explicitly
-        - go get -d github.com/twmb/murmur3 
+        - go get -f -u  github.com/twmb/murmur3 
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
         # This pkg not in go 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
       script:
         # Need to download packages explicitly
-        - go get github.com/twmb/murmur3 
+        - go get -d github.com/twmb/murmur3 
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
         # This pkg not in go 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ jobs:
         # This pkg not in go 1.8
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
+        - go get github.com/twmb/murmur3 
+        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         # -coverprofile was not introduced in 1.8
         - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,12 @@ jobs:
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
       script:
         # Need to download packages explicitly
+        - go get github.com/twmb/murmur3 
+        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
         # This pkg not in go 1.8
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        - go get github.com/twmb/murmur3 
-        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         # -coverprofile was not introduced in 1.8
         - make test
 

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -154,18 +154,18 @@ func NewBatchEventProcessor(options ...BPOptionConfig) *BatchEventProcessor {
 		p.Q = NewInMemoryQueue(p.MaxQueueSize)
 	}
 
-	return p
-}
-
-// Start initializes the event processor
-func (p *BatchEventProcessor) Start(ctx context.Context) {
 	if p.EventDispatcher == nil {
 		dispatcher := NewQueueEventDispatcher(p.metricsRegistry)
-		defer dispatcher.flushEvents()
 		p.EventDispatcher = dispatcher
 	}
 
-	pLogger.Debug("Batch event processor started")
+	return p
+}
+
+// Start does not do any initialization, just starts the ticker
+func (p *BatchEventProcessor) Start(ctx context.Context) {
+
+	pLogger.Info("Batch event processor started")
 	p.startTicker(ctx)
 }
 

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -65,7 +65,7 @@ func newExecutionContext() *utils.ExecGroup {
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	eg := newExecutionContext()
 	processor := NewBatchEventProcessor()
-	processor.EventDispatcher = nil
+	processor.EventDispatcher = NewQueueEventDispatcher(processor.metricsRegistry)
 	eg.Go(processor.Start)
 
 	impression := BuildTestImpressionEvent()


### PR DESCRIPTION
## Summary
- before dispatcher was initialized in go routine, which was wrong.
- now dispatcher is initialized in constructor, and just ticker starts in go routine. 
