### PR TITLE
feature (logging): Logging sdk key with every log message.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
     - <<: *test
       stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.10.x
+      env: GIMME_GO_VERSION=1.11.x
       before_script:
         # GO module was not introduced earlier. need symlink to search in GOPATH
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
@@ -56,10 +56,10 @@ jobs:
         - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
-        # This pkg not in go 1.10
+        # This pkg not in go 1.11
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        # -coverprofile was not introduced in 1.10
+        # -coverprofile was not introduced in 1.11
         - make test
 
     - <<: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
     - <<: *test
       stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.11.x
+      env: GIMME_GO_VERSION=1.10.x
       before_script:
         # GO module was not introduced earlier. need symlink to search in GOPATH
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
@@ -56,10 +56,10 @@ jobs:
         - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
-        # This pkg not in go 1.11
+        # This pkg not in go 1.10
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        # -coverprofile was not introduced in 1.11
+        # -coverprofile was not introduced in 1.10
         - make test
 
     - <<: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
     - <<: *test
       stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.8.x
+      env: GIMME_GO_VERSION=1.10.x
       before_script:
         # GO module was not introduced earlier. need symlink to search in GOPATH
         - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
@@ -56,15 +56,15 @@ jobs:
         - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - go get -v -d ./...
-        # This pkg not in go 1.8
+        # This pkg not in go 1.10
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        # -coverprofile was not introduced in 1.8
+        # -coverprofile was not introduced in 1.10
         - make test
 
     - <<: *test
       stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.13.x
+      env: GIMME_GO_VERSION=1.14.x
       before_script:
         - go get github.com/mattn/goveralls
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         # Need to download packages explicitly
         - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
-        - go get -v -d ./...
+        # - go get -v -d ./...
         # This pkg not in go 1.10
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         # Need to download packages explicitly
         - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
-        # - go get -v -d ./...
+        - go get -v -d ./...
         # This pkg not in go 1.10
         - go get github.com/stretchr/testify
         - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,8 +33,6 @@ import (
 	"github.com/optimizely/go-sdk/pkg/utils"
 )
 
-var logger = logging.GetLogger("Client")
-
 // OptimizelyClient is the entry point to the Optimizely SDK
 type OptimizelyClient struct {
 	ConfigManager      config.ProjectConfigManager
@@ -42,6 +40,7 @@ type OptimizelyClient struct {
 	EventProcessor     event.Processor
 	notificationCenter notification.Center
 	execGroup          *utils.ExecGroup
+	logger             logging.OptimizelyLogProducer
 }
 
 // Activate returns the key of the variation the user is bucketed into and queues up an impression event to be sent to
@@ -59,14 +58,14 @@ func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.U
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("Activate call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	decisionContext, experimentDecision, err := o.getExperimentDecision(experimentKey, userContext)
 	if err != nil {
-		logger.Error("received an error while computing experiment decision", err)
+		o.logger.Error("received an error while computing experiment decision", err)
 		return result, err
 	}
 
@@ -95,14 +94,14 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("IsFeatureEnabled call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	decisionContext, featureDecision, err := o.getFeatureDecision(featureKey, "", userContext)
 	if err != nil {
-		logger.Error("received an error while computing feature decision", err)
+		o.logger.Error("received an error while computing feature decision", err)
 		return result, err
 	}
 
@@ -113,9 +112,9 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 	}
 
 	if result {
-		logger.Info(fmt.Sprintf(`Feature "%s" is enabled for user "%s".`, featureKey, userContext.ID))
+		o.logger.Info(fmt.Sprintf(`Feature "%s" is enabled for user "%s".`, featureKey, userContext.ID))
 	} else {
-		logger.Info(fmt.Sprintf(`Feature "%s" is not enabled for user "%s".`, featureKey, userContext.ID))
+		o.logger.Info(fmt.Sprintf(`Feature "%s" is not enabled for user "%s".`, featureKey, userContext.ID))
 	}
 
 	if featureDecision.Source == decision.FeatureTest && featureDecision.Variation != nil {
@@ -141,14 +140,14 @@ func (o *OptimizelyClient) GetEnabledFeatures(userContext entities.UserContext) 
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("GetEnabledFeatures call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	projectConfig, err := o.getProjectConfig()
 	if err != nil {
-		logger.Error("Error retrieving ProjectConfig", err)
+		o.logger.Error("Error retrieving ProjectConfig", err)
 		return enabledFeatures, err
 	}
 
@@ -241,7 +240,7 @@ func (o *OptimizelyClient) GetAllFeatureVariables(featureKey string, userContext
 	variableMap = make(map[string]interface{})
 	decisionContext, featureDecision, err := o.getFeatureDecision(featureKey, "", userContext)
 	if err != nil {
-		logger.Error("Optimizely SDK tracking error", err)
+		o.logger.Error("Optimizely SDK tracking error", err)
 		return enabled, variableMap, err
 	}
 
@@ -251,7 +250,7 @@ func (o *OptimizelyClient) GetAllFeatureVariables(featureKey string, userContext
 
 	feature := decisionContext.Feature
 	if feature == nil {
-		logger.Warning(fmt.Sprintf(`feature "%s" does not exist`, featureKey))
+		o.logger.Warning(fmt.Sprintf(`feature "%s" does not exist`, featureKey))
 		return enabled, variableMap, nil
 	}
 
@@ -275,7 +274,7 @@ func (o *OptimizelyClient) GetAllFeatureVariables(featureKey string, userContext
 			out, err = strconv.Atoi(val)
 		case entities.String:
 		default:
-			logger.Warning(fmt.Sprintf(`type "%s" is unknown, returning string`, varType))
+			o.logger.Warning(fmt.Sprintf(`type "%s" is unknown, returning string`, varType))
 		}
 
 		variableMap[v.Key] = out
@@ -298,14 +297,14 @@ func (o *OptimizelyClient) GetVariation(experimentKey string, userContext entiti
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("GetVariation call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	_, experimentDecision, err := o.getExperimentDecision(experimentKey, userContext)
 	if err != nil {
-		logger.Error("received an error while computing experiment decision", err)
+		o.logger.Error("received an error while computing experiment decision", err)
 	}
 
 	if experimentDecision.Variation != nil {
@@ -330,14 +329,14 @@ func (o *OptimizelyClient) Track(eventKey string, userContext entities.UserConte
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("Track call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	projectConfig, e := o.getProjectConfig()
 	if e != nil {
-		logger.Error("Optimizely SDK tracking error", e)
+		o.logger.Error("Optimizely SDK tracking error", e)
 		return e
 	}
 
@@ -345,7 +344,7 @@ func (o *OptimizelyClient) Track(eventKey string, userContext entities.UserConte
 
 	if e != nil {
 		errorMessage := fmt.Sprintf(`Unable to get event for key "%s": %s`, eventKey, e)
-		logger.Warning(errorMessage)
+		o.logger.Warning(errorMessage)
 		return nil
 	}
 
@@ -353,7 +352,7 @@ func (o *OptimizelyClient) Track(eventKey string, userContext entities.UserConte
 	if o.EventProcessor.ProcessEvent(userEvent) && o.notificationCenter != nil {
 		trackNotification := notification.TrackNotification{EventKey: eventKey, UserContext: userContext, EventTags: eventTags, ConversionEvent: *userEvent.Conversion}
 		if err = o.notificationCenter.Send(notification.Track, trackNotification); err != nil {
-			logger.Warning("Problem with sending notification")
+			o.logger.Warning("Problem with sending notification")
 		}
 	}
 
@@ -373,23 +372,23 @@ func (o *OptimizelyClient) getFeatureDecision(featureKey, variableKey string, us
 				err = errors.New("unexpected error")
 			}
 			errorMessage := fmt.Sprintf("getFeatureDecision call, optimizely SDK is panicking with the error:")
-			logger.Error(errorMessage, err)
-			logger.Debug(string(debug.Stack()))
+			o.logger.Error(errorMessage, err)
+			o.logger.Debug(string(debug.Stack()))
 		}
 	}()
 
 	userID := userContext.ID
-	logger.Debug(fmt.Sprintf(`Evaluating feature "%s" for user "%s".`, featureKey, userID))
+	o.logger.Debug(fmt.Sprintf(`Evaluating feature "%s" for user "%s".`, featureKey, userID))
 
 	projectConfig, e := o.getProjectConfig()
 	if e != nil {
-		logger.Error("Error calling getFeatureDecision", e)
+		o.logger.Error("Error calling getFeatureDecision", e)
 		return decisionContext, featureDecision, e
 	}
 
 	feature, e := projectConfig.GetFeatureByKey(featureKey)
 	if e != nil {
-		logger.Warning(fmt.Sprintf(`Could not get feature for key "%s": %s`, featureKey, e))
+		o.logger.Warning(fmt.Sprintf(`Could not get feature for key "%s": %s`, featureKey, e))
 		return decisionContext, featureDecision, nil
 	}
 
@@ -397,7 +396,7 @@ func (o *OptimizelyClient) getFeatureDecision(featureKey, variableKey string, us
 	if variableKey != "" {
 		variable, err = projectConfig.GetVariableByKey(feature.Key, variableKey)
 		if err != nil {
-			logger.Warning(fmt.Sprintf(`Could not get variable for key "%s": %s`, variableKey, err))
+			o.logger.Warning(fmt.Sprintf(`Could not get variable for key "%s": %s`, variableKey, err))
 			return decisionContext, featureDecision, nil
 		}
 	}
@@ -410,7 +409,7 @@ func (o *OptimizelyClient) getFeatureDecision(featureKey, variableKey string, us
 
 	featureDecision, err = o.DecisionService.GetFeatureDecision(decisionContext, userContext)
 	if err != nil {
-		logger.Warning(fmt.Sprintf(`Received error while making a decision for feature "%s": %s`, featureKey, err))
+		o.logger.Warning(fmt.Sprintf(`Received error while making a decision for feature "%s": %s`, featureKey, err))
 		return decisionContext, featureDecision, nil
 	}
 
@@ -420,7 +419,7 @@ func (o *OptimizelyClient) getFeatureDecision(featureKey, variableKey string, us
 func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userContext entities.UserContext) (decisionContext decision.ExperimentDecisionContext, experimentDecision decision.ExperimentDecision, err error) {
 
 	userID := userContext.ID
-	logger.Debug(fmt.Sprintf(`Evaluating experiment "%s" for user "%s".`, experimentKey, userID))
+	o.logger.Debug(fmt.Sprintf(`Evaluating experiment "%s" for user "%s".`, experimentKey, userID))
 
 	projectConfig, e := o.getProjectConfig()
 	if e != nil {
@@ -429,7 +428,7 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 
 	experiment, e := projectConfig.GetExperimentByKey(experimentKey)
 	if e != nil {
-		logger.Warning(fmt.Sprintf(`Could not get experiment for key "%s": %s`, experimentKey, e))
+		o.logger.Warning(fmt.Sprintf(`Could not get experiment for key "%s": %s`, experimentKey, e))
 		return decisionContext, experimentDecision, nil
 	}
 
@@ -440,15 +439,15 @@ func (o *OptimizelyClient) getExperimentDecision(experimentKey string, userConte
 
 	experimentDecision, err = o.DecisionService.GetExperimentDecision(decisionContext, userContext)
 	if err != nil {
-		logger.Warning(fmt.Sprintf(`Received error while making a decision for experiment "%s": %s`, experimentKey, err))
+		o.logger.Warning(fmt.Sprintf(`Received error while making a decision for experiment "%s": %s`, experimentKey, err))
 		return decisionContext, experimentDecision, nil
 	}
 
 	if experimentDecision.Variation != nil {
 		result := experimentDecision.Variation.Key
-		logger.Info(fmt.Sprintf(`User "%s" is bucketed into variation "%s" of experiment "%s".`, userContext.ID, result, experimentKey))
+		o.logger.Info(fmt.Sprintf(`User "%s" is bucketed into variation "%s" of experiment "%s".`, userContext.ID, result, experimentKey))
 	} else {
-		logger.Info(fmt.Sprintf(`User "%s" is not bucketed into any variation for experiment "%s": %s.`, userContext.ID, experimentKey, experimentDecision.Reason))
+		o.logger.Info(fmt.Sprintf(`User "%s" is not bucketed into any variation for experiment "%s": %s.`, userContext.ID, experimentKey, experimentDecision.Reason))
 	}
 
 	return decisionContext, experimentDecision, err
@@ -469,12 +468,12 @@ func (o *OptimizelyClient) OnTrack(callback func(eventKey string, userContext en
 			}
 		}
 		if !success {
-			logger.Warning(fmt.Sprintf("Unable to convert notification payload %v into TrackNotification", payload))
+			o.logger.Warning(fmt.Sprintf("Unable to convert notification payload %v into TrackNotification", payload))
 		}
 	}
 	id, err := o.notificationCenter.AddHandler(notification.Track, handler)
 	if err != nil {
-		logger.Warning("Problem with adding notification handler")
+		o.logger.Warning("Problem with adding notification handler")
 		return 0, err
 	}
 	return id, nil
@@ -486,7 +485,7 @@ func (o *OptimizelyClient) RemoveOnTrack(id int) error {
 		return fmt.Errorf("no notification center found")
 	}
 	if err := o.notificationCenter.RemoveHandler(id, notification.Track); err != nil {
-		logger.Warning("Problem with removing notification handler")
+		o.logger.Warning("Problem with removing notification handler")
 		return err
 	}
 	return nil

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2043,7 +2043,7 @@ func TestClose(t *testing.T) {
 	mockProcessor := &MockProcessor{}
 	mockDecisionService := new(MockDecisionService)
 
-	eg := utils.NewExecGroup(logging.GetLogger("", "ExecGroup"), context.Background())
+	eg := utils.NewExecGroup(context.Background(), logging.GetLogger("", "ExecGroup"))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -148,6 +148,7 @@ func TestTrack(t *testing.T) {
 		ConfigManager:   ValidProjectConfigManager(),
 		DecisionService: mockDecisionService,
 		EventProcessor:  mockProcessor,
+		logger:logging.GetLogger("", ""),
 	}
 
 	err := client.Track("sample_conversion", entities.UserContext{ID: "1212121", Attributes: map[string]interface{}{}}, map[string]interface{}{})
@@ -167,6 +168,7 @@ func TestTrackFailEventNotFound(t *testing.T) {
 		ConfigManager:   ValidProjectConfigManager(),
 		DecisionService: mockDecisionService,
 		EventProcessor:  mockProcessor,
+		logger:logging.GetLogger("", ""),
 	}
 
 	err := client.Track("bob", entities.UserContext{ID: "1212121", Attributes: map[string]interface{}{}}, map[string]interface{}{})
@@ -184,6 +186,7 @@ func TestTrackPanics(t *testing.T) {
 		ConfigManager:   new(PanickingConfigManager),
 		DecisionService: mockDecisionService,
 		EventProcessor:  mockProcessor,
+		logger:logging.GetLogger("", ""),
 	}
 
 	err := client.Track("bob", entities.UserContext{ID: "1212121", Attributes: map[string]interface{}{}}, map[string]interface{}{})
@@ -200,6 +203,7 @@ func TestGetEnabledFeaturesPanic(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -246,6 +250,7 @@ func TestGetFeatureVariableBooleanWithValidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.GetFeatureVariableBoolean(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, true, result)
@@ -292,6 +297,7 @@ func TestGetFeatureVariableBooleanWithInvalidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableBoolean(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, false, result)
@@ -339,6 +345,7 @@ func TestGetFeatureVariableBooleanWithInvalidValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableBoolean(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, false, result)
@@ -386,6 +393,7 @@ func TestGetFeatureVariableBooleanWithEmptyValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableBoolean(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, false, result)
@@ -433,6 +441,7 @@ func TestGetFeatureVariableBooleanReturnsDefaultValueIfFeatureNotEnabled(t *test
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableBoolean(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, false, result)
@@ -452,6 +461,7 @@ func TestGetFeatureVariableBoolPanic(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -498,6 +508,7 @@ func TestGetFeatureVariableDoubleWithValidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.GetFeatureVariableDouble(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, float64(5), result)
@@ -544,6 +555,7 @@ func TestGetFeatureVariableDoubleWithInvalidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableDouble(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, float64(0), result)
@@ -591,6 +603,7 @@ func TestGetFeatureVariableDoubleWithInvalidValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableDouble(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, float64(0), result)
@@ -638,6 +651,7 @@ func TestGetFeatureVariableDoubleWithEmptyValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableDouble(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, float64(0), result)
@@ -685,6 +699,7 @@ func TestGetFeatureVariableDoubleReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableDouble(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, float64(4), result)
@@ -704,6 +719,7 @@ func TestGetFeatureVariableDoublePanic(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -750,6 +766,7 @@ func TestGetFeatureVariableIntegerWithValidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.GetFeatureVariableInteger(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, 5, result)
@@ -796,6 +813,7 @@ func TestGetFeatureVariableIntegerWithInvalidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableInteger(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, 0, result)
@@ -843,6 +861,7 @@ func TestGetFeatureVariableIntegerWithInvalidValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableInteger(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, 0, result)
@@ -890,6 +909,7 @@ func TestGetFeatureVariableIntegerWithEmptyValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableInteger(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, 0, result)
@@ -937,6 +957,8 @@ func TestGetFeatureVariableIntegerReturnsDefaultValueIfFeatureNotEnabled(t *test
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
+
 	}
 	result, err := client.GetFeatureVariableInteger(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, 4, result)
@@ -956,6 +978,7 @@ func TestGetFeatureVariableIntegerPanic(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -1002,6 +1025,7 @@ func TestGetFeatureVariableStringWithValidValue(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.GetFeatureVariableString(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, testVariableValue, result)
@@ -1048,6 +1072,7 @@ func TestGetFeatureVariableStringWithInvalidValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableString(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, "", result)
@@ -1095,6 +1120,7 @@ func TestGetFeatureVariableStringWithEmptyValueType(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableString(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, "", result)
@@ -1142,6 +1168,7 @@ func TestGetFeatureVariableStringReturnsDefaultValueIfFeatureNotEnabled(t *testi
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetFeatureVariableString(testFeatureKey, testVariableKey, testUserContext)
 	assert.Equal(t, "defaultString", result)
@@ -1161,6 +1188,7 @@ func TestGetFeatureVariableStringPanic(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -1179,6 +1207,7 @@ func TestGetFeatureVariableErrorCases(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	_, err1 := client.GetFeatureVariableBoolean("test_feature_key", "test_variable_key", testUserContext)
 	_, err2 := client.GetFeatureVariableDouble("test_feature_key", "test_variable_key", testUserContext)
@@ -1198,6 +1227,7 @@ func TestGetProjectConfigIsValid(t *testing.T) {
 
 	client := OptimizelyClient{
 		ConfigManager: mockConfigManager,
+		logger:logging.GetLogger("", ""),
 	}
 
 	actual, err := client.getProjectConfig()
@@ -1210,6 +1240,7 @@ func TestGetProjectConfigIsInValid(t *testing.T) {
 
 	client := OptimizelyClient{
 		ConfigManager: InValidProjectConfigManager(),
+		logger:logging.GetLogger("", ""),
 	}
 
 	actual, err := client.getProjectConfig()
@@ -1223,6 +1254,7 @@ func TestGetOptimizelyConfig(t *testing.T) {
 
 	client := OptimizelyClient{
 		ConfigManager: mockConfigManager,
+		logger:logging.GetLogger("", ""),
 	}
 
 	optimizelyConfig := client.GetOptimizelyConfig()
@@ -1268,6 +1300,7 @@ func TestGetFeatureDecisionValid(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	_, featureDecision, err := client.getFeatureDecision(testFeatureKey, testVariableKey, testUserContext)
@@ -1313,6 +1346,7 @@ func TestGetFeatureDecisionErrProjectConfig(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	_, _, err := client.getFeatureDecision(testFeatureKey, testVariableKey, testUserContext)
@@ -1356,6 +1390,7 @@ func TestGetFeatureDecisionPanicProjectConfig(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	_, _, err := client.getFeatureDecision(testFeatureKey, testVariableKey, testUserContext)
@@ -1390,6 +1425,7 @@ func TestGetFeatureDecisionPanicDecisionService(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: &PanickingDecisionService{},
+		logger:logging.GetLogger("", ""),
 	}
 
 	_, _, err := client.getFeatureDecision(testFeatureKey, testVariableKey, testUserContext)
@@ -1435,6 +1471,7 @@ func TestGetFeatureDecisionErrFeatureDecision(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	_, decision, err := client.getFeatureDecision(testFeatureKey, testVariableKey, testUserContext)
@@ -1513,6 +1550,7 @@ func TestGetAllFeatureVariables(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	enabled, variationMap, err := client.GetAllFeatureVariables(testFeatureKey, testUserContext)
@@ -1562,6 +1600,7 @@ func TestGetAllFeatureVariablesWithError(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	enabled, variationMap, err := client.GetAllFeatureVariables(testFeatureKey, testUserContext)
@@ -1585,6 +1624,7 @@ func TestGetAllFeatureVariablesWithoutFeature(t *testing.T) {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	enabled, variationMap, err := client.GetAllFeatureVariables(invalidFeatureKey, testUserContext)
@@ -1665,6 +1705,7 @@ func (s *ClientTestSuiteAB) TestActivate() {
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
 		EventProcessor:  s.mockEventProcessor,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey1, err1 := testClient.Activate("test_exp_1", testUserContext)
@@ -1687,6 +1728,7 @@ func (s *ClientTestSuiteAB) TestActivatePanics() {
 	testClient := OptimizelyClient{
 		ConfigManager:   new(PanickingConfigManager),
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey, err := testClient.Activate("test_exp_1", testUserContext)
@@ -1702,6 +1744,7 @@ func (s *ClientTestSuiteAB) TestActivateInvalidConfig() {
 	mockConfigManager.On("GetConfig").Return(s.mockConfig, expectedError)
 	testClient := OptimizelyClient{
 		ConfigManager: mockConfigManager,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey, err := testClient.Activate("test_exp_1", testUserContext)
@@ -1729,6 +1772,7 @@ func (s *ClientTestSuiteAB) TestGetVariation() {
 	testClient := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey, err := testClient.GetVariation("test_exp_1", testUserContext)
@@ -1758,6 +1802,7 @@ func (s *ClientTestSuiteAB) TestGetVariationWithDecisionError() {
 	testClient := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey, err := testClient.GetVariation("test_exp_1", testUserContext)
@@ -1774,6 +1819,7 @@ func (s *ClientTestSuiteAB) TestGetVariationPanics() {
 	testClient := OptimizelyClient{
 		ConfigManager:   new(PanickingConfigManager),
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 
 	variationKey, err := testClient.GetVariation("test_exp_1", testUserContext)
@@ -1824,6 +1870,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabled() {
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.IsFeatureEnabled(testFeature.Key, testUserContext)
 	s.True(result)
@@ -1861,6 +1908,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledWithDecisionError() {
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
 		EventProcessor:  s.mockEventProcessor,
+		logger:logging.GetLogger("", ""),
 	}
 
 	// should still return the decision because the error is non-fatal
@@ -1882,6 +1930,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledErrorCases() {
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.IsFeatureEnabled(testFeatureKey, testUserContext)
 	s.False(result)
@@ -1895,6 +1944,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledErrorCases() {
 	client = OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.IsFeatureEnabled(testFeatureKey, testUserContext)
 	s.NoError(err)
@@ -1909,6 +1959,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledPanic() {
 
 	client := OptimizelyClient{
 		ConfigManager: &PanickingConfigManager{},
+		logger:logging.GetLogger("", ""),
 	}
 
 	// ensure that the client calms back down and recovers
@@ -1956,6 +2007,7 @@ func (s *ClientTestSuiteFM) TestGetEnabledFeatures() {
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetEnabledFeatures(testUserContext)
 	s.NoError(err)
@@ -1976,6 +2028,7 @@ func (s *ClientTestSuiteFM) TestGetEnabledFeaturesErrorCases() {
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		logger:logging.GetLogger("", ""),
 	}
 	result, err := client.GetEnabledFeatures(testUserContext)
 	s.Error(err)
@@ -2003,6 +2056,7 @@ func TestClose(t *testing.T) {
 		DecisionService: mockDecisionService,
 		EventProcessor:  mockProcessor,
 		execGroup:       eg,
+		logger:logging.GetLogger("", ""),
 	}
 
 	client.Close()
@@ -2026,6 +2080,7 @@ func (s *ClientTestSuiteTrackEvent) SetupTest() {
 		DecisionService:    s.mockDecisionService,
 		EventProcessor:     s.mockProcessor,
 		notificationCenter: notification.NewNotificationCenter(),
+		logger:logging.GetLogger("", ""),
 	}
 }
 
@@ -2204,6 +2259,7 @@ func (s *ClientTestSuiteTrackNotification) SetupTest() {
 		DecisionService:    s.mockDecisionService,
 		EventProcessor:     s.mockProcessor,
 		notificationCenter: notification.NewNotificationCenter(),
+		logger:logging.GetLogger("", ""),
 	}
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"strconv"
 	"sync"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/event"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/utils"
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"strconv"
 	"sync"
 	"testing"
@@ -1988,7 +1989,7 @@ func TestClose(t *testing.T) {
 	mockProcessor := &MockProcessor{}
 	mockDecisionService := new(MockDecisionService)
 
-	eg := utils.NewExecGroup(context.Background())
+	eg := utils.NewExecGroup(logging.GetLogger("", "ExecGroup"), context.Background())
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1870,6 +1870,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabled() {
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
 		DecisionService: s.mockDecisionService,
+		EventProcessor: s.mockEventProcessor,
 		logger:logging.GetLogger("", ""),
 	}
 	result, _ := client.IsFeatureEnabled(testFeature.Key, testUserContext)

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -20,12 +20,12 @@ package client
 import (
 	"context"
 	"errors"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/event"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/metrics"
 	"github.com/optimizely/go-sdk/pkg/registry"
 	"github.com/optimizely/go-sdk/pkg/utils"

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -214,7 +214,7 @@ func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 		configManager = staticConfigManager
 
 	} else if f.Datafile != nil {
-		staticConfigManager, err := config.NewStaticProjectConfigManagerFromPayload(logging.GetLogger(f.SDKKey, "StaticProjectConfigManagerFromPayload"), f.Datafile)
+		staticConfigManager, err := config.NewStaticProjectConfigManagerFromPayload(f.Datafile, logging.GetLogger(f.SDKKey, "StaticProjectConfigManagerFromPayload"))
 
 		if err != nil {
 			return nil, err

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -74,7 +74,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 		ctx = context.Background()
 	}
 
-	eg := utils.NewExecGroup(logging.GetLogger(f.SDKKey, "ExecGroup"), ctx)
+	eg := utils.NewExecGroup(ctx, logging.GetLogger(f.SDKKey, "ExecGroup"))
 	appClient := &OptimizelyClient{execGroup: eg,
 		notificationCenter: registry.GetNotificationCenter(f.SDKKey),
 		logger: logging.GetLogger(f.SDKKey, "OptimizelyClient")}

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -77,7 +77,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	eg := utils.NewExecGroup(ctx, logging.GetLogger(f.SDKKey, "ExecGroup"))
 	appClient := &OptimizelyClient{execGroup: eg,
 		notificationCenter: registry.GetNotificationCenter(f.SDKKey),
-		logger: logging.GetLogger(f.SDKKey, "OptimizelyClient")}
+		logger:             logging.GetLogger(f.SDKKey, "OptimizelyClient")}
 
 	if f.configManager != nil {
 		appClient.ConfigManager = f.configManager

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -102,12 +102,8 @@ func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
 	configManager := config.NewStaticProjectConfigManager(projectConfig, logging.GetLogger("", "StaticProjectConfigManager"))
 	decisionService := new(MockDecisionService)
-	processor := &event.BatchEventProcessor{
-		MaxQueueSize:    100,
-		FlushInterval:   100,
-		Q:               event.NewInMemoryQueue(100),
-		EventDispatcher: &MockDispatcher{Events: []event.LogEvent{}},
-	}
+	processor := event.NewBatchEventProcessor(event.WithQueueSize(100),event.WithFlushInterval(100),
+		event.WithQueue(event.NewInMemoryQueue(100)), event.WithEventDispatcher(&MockDispatcher{Events: []event.LogEvent{}}))
 
 	optimizelyClient, err := factory.Client(WithConfigManager(configManager), WithDecisionService(decisionService), WithEventProcessor(processor))
 	assert.NoError(t, err)

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 	"errors"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/event"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/metrics"
 	"github.com/optimizely/go-sdk/pkg/utils"
 

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"errors"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync"
 	"testing"
@@ -87,7 +88,7 @@ func TestClientWithPollingConfigManager(t *testing.T) {
 func TestClientWithProjectConfigManagerInOptions(t *testing.T) {
 	factory := OptimizelyFactory{}
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
-	configManager := config.NewStaticProjectConfigManager(projectConfig)
+	configManager := config.NewStaticProjectConfigManager(projectConfig, logging.GetLogger("", ""))
 
 	optimizelyClient, err := factory.Client(WithConfigManager(configManager))
 	assert.NoError(t, err)
@@ -99,7 +100,7 @@ func TestClientWithProjectConfigManagerInOptions(t *testing.T) {
 func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 	factory := OptimizelyFactory{}
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
-	configManager := config.NewStaticProjectConfigManager(projectConfig)
+	configManager := config.NewStaticProjectConfigManager(projectConfig, logging.GetLogger("", "StaticProjectConfigManager"))
 	decisionService := new(MockDecisionService)
 	processor := &event.BatchEventProcessor{
 		MaxQueueSize:    100,

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -20,13 +20,11 @@ package datafileprojectconfig
 import (
 	"errors"
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig/mappers"
 	"github.com/optimizely/go-sdk/pkg/entities"
-	"github.com/optimizely/go-sdk/pkg/logging"
 )
-
-var logger = logging.GetLogger("DatafileProjectConfig")
 
 var datafileVersions = map[string]struct{}{
 	"4": {},
@@ -175,7 +173,7 @@ func (c DatafileProjectConfig) GetGroupByID(groupID string) (entities.Group, err
 }
 
 // NewDatafileProjectConfig initializes a new datafile from a json byte array using the default JSON datafile parser
-func NewDatafileProjectConfig(jsonDatafile []byte) (*DatafileProjectConfig, error) {
+func NewDatafileProjectConfig(logger logging.OptimizelyLogProducer, jsonDatafile []byte) (*DatafileProjectConfig, error) {
 	datafile, err := Parse(jsonDatafile)
 	if err != nil {
 		logger.Error("Error parsing datafile", err)

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -20,10 +20,10 @@ package datafileprojectconfig
 import (
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig/mappers"
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 var datafileVersions = map[string]struct{}{

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -173,7 +173,7 @@ func (c DatafileProjectConfig) GetGroupByID(groupID string) (entities.Group, err
 }
 
 // NewDatafileProjectConfig initializes a new datafile from a json byte array using the default JSON datafile parser
-func NewDatafileProjectConfig(logger logging.OptimizelyLogProducer, jsonDatafile []byte) (*DatafileProjectConfig, error) {
+func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogProducer) (*DatafileProjectConfig, error) {
 	datafile, err := Parse(jsonDatafile)
 	if err != nil {
 		logger.Error("Error parsing datafile", err)

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -19,6 +19,7 @@ package datafileprojectconfig
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -27,12 +28,12 @@ import (
 )
 
 func TestNewDatafileProjectConfigNil(t *testing.T) {
-	projectConfig, err := NewDatafileProjectConfig(nil)
+	projectConfig, err := NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), nil)
 	assert.Error(t, err)
 	assert.Nil(t, projectConfig)
 
 	jsonDatafileStr := `{"accountID": "123", "revision": "1", "projectId": "12345", "version": "2"}`
-	projectConfig, err = NewDatafileProjectConfig([]byte(jsonDatafileStr))
+	projectConfig, err = NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), []byte(jsonDatafileStr))
 	assert.Error(t, err)
 	assert.Nil(t, projectConfig)
 }
@@ -41,7 +42,7 @@ func TestNewDatafileProjectConfigNotNil(t *testing.T) {
 	dpc := DatafileProjectConfig{accountID: "123", revision: "1", projectID: "12345"}
 	jsonDatafileStr := `{"accountID": "123", "revision": "1", "projectId": "12345", "version": "4"}`
 	jsonDatafile := []byte(jsonDatafileStr)
-	projectConfig, err := NewDatafileProjectConfig(jsonDatafile)
+	projectConfig, err := NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), jsonDatafile)
 	assert.Nil(t, err)
 	assert.NotNil(t, projectConfig)
 	assert.Equal(t, dpc.accountID, projectConfig.accountID)

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 func TestNewDatafileProjectConfigNil(t *testing.T) {
-	projectConfig, err := NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), nil)
+	projectConfig, err := NewDatafileProjectConfig(nil, logging.GetLogger("", "DatafileProjectConfig"))
 	assert.Error(t, err)
 	assert.Nil(t, projectConfig)
 
 	jsonDatafileStr := `{"accountID": "123", "revision": "1", "projectId": "12345", "version": "2"}`
-	projectConfig, err = NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), []byte(jsonDatafileStr))
+	projectConfig, err = NewDatafileProjectConfig([]byte(jsonDatafileStr), logging.GetLogger("", "DatafileProjectConfig"))
 	assert.Error(t, err)
 	assert.Nil(t, projectConfig)
 }
@@ -42,7 +42,7 @@ func TestNewDatafileProjectConfigNotNil(t *testing.T) {
 	dpc := DatafileProjectConfig{accountID: "123", revision: "1", projectID: "12345"}
 	jsonDatafileStr := `{"accountID": "123", "revision": "1", "projectId": "12345", "version": "4"}`
 	jsonDatafile := []byte(jsonDatafileStr)
-	projectConfig, err := NewDatafileProjectConfig(logging.GetLogger("", "DatafileProjectConfig"), jsonDatafile)
+	projectConfig, err := NewDatafileProjectConfig(jsonDatafile, logging.GetLogger("", "DatafileProjectConfig"))
 	assert.Nil(t, err)
 	assert.NotNil(t, projectConfig)
 	assert.Equal(t, dpc.accountID, projectConfig.accountID)

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -19,10 +19,10 @@ package datafileprojectconfig
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -51,7 +51,7 @@ func (s *OptimizelyConfigTestSuite) SetupTest() {
 		s.Fail("error opening file " + dataFileName)
 	}
 
-	projectMgr, err := NewStaticProjectConfigManagerFromPayload(logging.GetLogger("", "NewStaticProjectConfigManagerFromPayload"), dataFile)
+	projectMgr, err := NewStaticProjectConfigManagerFromPayload(dataFile, logging.GetLogger("", "NewStaticProjectConfigManagerFromPayload"))
 	if err != nil {
 		s.Fail("error creating project manager")
 	}

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"encoding/json"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"io/ioutil"
 	"testing"
 
@@ -50,7 +51,7 @@ func (s *OptimizelyConfigTestSuite) SetupTest() {
 		s.Fail("error opening file " + dataFileName)
 	}
 
-	projectMgr, err := NewStaticProjectConfigManagerFromPayload(dataFile)
+	projectMgr, err := NewStaticProjectConfigManagerFromPayload(logging.GetLogger("", "NewStaticProjectConfigManagerFromPayload"), dataFile)
 	if err != nil {
 		s.Fail("error creating project manager")
 	}

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -20,12 +20,12 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/registry"
 	"github.com/optimizely/go-sdk/pkg/utils"

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -143,7 +143,7 @@ func (cm *PollingProjectConfigManager) SyncConfig() {
 		cm.lastModified = lastModified
 	}
 
-	projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(logging.GetLogger(cm.sdkKey, "NewDatafileProjectConfig"), datafile)
+	projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(datafile, logging.GetLogger(cm.sdkKey, "NewDatafileProjectConfig"))
 	if err != nil {
 		cm.logger.Warning("failed to create project config")
 		closeMutex(errors.New("unable to parse datafile"))
@@ -289,8 +289,7 @@ func (cm *PollingProjectConfigManager) setInitialDatafile(datafile []byte) {
 	if len(datafile) != 0 {
 		cm.configLock.Lock()
 		defer cm.configLock.Unlock()
-		projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(logging.GetLogger(cm.sdkKey, "DatafileProjectConfig"),
-			datafile)
+		projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(datafile, logging.GetLogger(cm.sdkKey, "DatafileProjectConfig"))
 		if projectConfig != nil {
 			err = cm.setConfig(projectConfig)
 		}

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -18,13 +18,13 @@ package config
 
 import (
 	"context"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/utils"
 

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -106,7 +106,7 @@ func TestNewAsyncPollingProjectConfigManagerWithOptions(t *testing.T) {
 func TestSyncConfigFetchesDatafileUsingRequester(t *testing.T) {
 
 	mockDatafile := []byte(`{"revision":"42","version": "4"}`)
-	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile)
+	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile, http.Header{}, http.StatusOK, nil)
 
@@ -153,7 +153,7 @@ func TestNewPollingProjectConfigManagerWithSimilarDatafileRevisions(t *testing.T
 	// Test newer datafile should not replace the older one if revisions are the same
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"42","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -188,7 +188,7 @@ func TestNewAsyncPollingProjectConfigManagerWithSimilarDatafileRevisions(t *test
 	// Test newer datafile should not replace the older one if revisions are the same
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"42","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -221,7 +221,7 @@ func TestNewAsyncPollingProjectConfigManagerWithSimilarDatafileRevisions(t *test
 
 func TestNewPollingProjectConfigManagerWithLastModifiedDates(t *testing.T) {
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
 	mockRequester := new(MockRequester)
 	modifiedDate := "Wed, 16 Oct 2019 20:16:45 GMT"
 	responseHeaders := http.Header{}
@@ -275,8 +275,8 @@ func TestNewPollingProjectConfigManagerWithDifferentDatafileRevisions(t *testing
 	// Test newer datafile should replace the older one if revisions are different
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -311,8 +311,8 @@ func TestNewAsyncPollingProjectConfigManagerWithDifferentDatafileRevisions(t *te
 	// Test newer datafile should replace the older one if revisions are different
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -347,8 +347,8 @@ func TestNewPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 	mockDatafile1 := []byte("NOT-VALID")
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
 
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil).Times(1)
 
@@ -380,8 +380,8 @@ func TestNewAsyncPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 	mockDatafile1 := []byte("NOT-VALID")
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
 
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil).Times(1)
 
@@ -445,7 +445,7 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 
 func TestNewAsyncPollingProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1, logger)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil)
 

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -45,7 +45,7 @@ func (m *MockRequester) Get(uri string, headers ...utils.Header) (response []byt
 var logger = logging.GetLogger("polling_manager_test", "PollingManager")
 
 func newExecGroup() *utils.ExecGroup {
-	return utils.NewExecGroup(logger, context.Background())
+	return utils.NewExecGroup(context.Background(), logger)
 }
 
 // assertion method to periodically check target function each tick.

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -41,8 +42,10 @@ func (m *MockRequester) Get(uri string, headers ...utils.Header) (response []byt
 	return args.Get(0).([]byte), args.Get(1).(http.Header), args.Int(2), args.Error(3)
 }
 
+var logger = logging.GetLogger("polling_manager_test", "PollingManager")
+
 func newExecGroup() *utils.ExecGroup {
-	return utils.NewExecGroup(context.Background())
+	return utils.NewExecGroup(logger, context.Background())
 }
 
 // assertion method to periodically check target function each tick.
@@ -103,7 +106,7 @@ func TestNewAsyncPollingProjectConfigManagerWithOptions(t *testing.T) {
 func TestSyncConfigFetchesDatafileUsingRequester(t *testing.T) {
 
 	mockDatafile := []byte(`{"revision":"42","version": "4"}`)
-	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile)
+	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile, http.Header{}, http.StatusOK, nil)
 
@@ -150,7 +153,7 @@ func TestNewPollingProjectConfigManagerWithSimilarDatafileRevisions(t *testing.T
 	// Test newer datafile should not replace the older one if revisions are the same
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"42","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -185,7 +188,7 @@ func TestNewAsyncPollingProjectConfigManagerWithSimilarDatafileRevisions(t *test
 	// Test newer datafile should not replace the older one if revisions are the same
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"42","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -218,7 +221,7 @@ func TestNewAsyncPollingProjectConfigManagerWithSimilarDatafileRevisions(t *test
 
 func TestNewPollingProjectConfigManagerWithLastModifiedDates(t *testing.T) {
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
 	mockRequester := new(MockRequester)
 	modifiedDate := "Wed, 16 Oct 2019 20:16:45 GMT"
 	responseHeaders := http.Header{}
@@ -272,8 +275,8 @@ func TestNewPollingProjectConfigManagerWithDifferentDatafileRevisions(t *testing
 	// Test newer datafile should replace the older one if revisions are different
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -308,8 +311,8 @@ func TestNewAsyncPollingProjectConfigManagerWithDifferentDatafileRevisions(t *te
 	// Test newer datafile should replace the older one if revisions are different
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile2, http.Header{}, http.StatusOK, nil)
 
@@ -344,8 +347,8 @@ func TestNewPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 	mockDatafile1 := []byte("NOT-VALID")
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
 
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil).Times(1)
 
@@ -377,8 +380,8 @@ func TestNewAsyncPollingProjectConfigManagerWithErrorHandling(t *testing.T) {
 	mockDatafile1 := []byte("NOT-VALID")
 	mockDatafile2 := []byte(`{"revision":"43","botFiltering":false,"version": "4"}`)
 
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
-	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile2)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
+	projectConfig2, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile2)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil).Times(1)
 
@@ -442,7 +445,7 @@ func TestNewPollingProjectConfigManagerOnDecision(t *testing.T) {
 
 func TestNewAsyncPollingProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile1 := []byte(`{"revision":"42","botFiltering":true,"version": "4"}`)
-	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(mockDatafile1)
+	projectConfig1, _ := datafileprojectconfig.NewDatafileProjectConfig(logger, mockDatafile1)
 	mockRequester := new(MockRequester)
 	mockRequester.On("Get", []utils.Header(nil)).Return(mockDatafile1, http.Header{}, http.StatusOK, nil)
 

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -20,10 +20,10 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/optimizely/go-sdk/pkg/utils"
 )

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -50,12 +50,12 @@ func NewStaticProjectConfigManagerFromURL(sdkKey string) (*StaticProjectConfigMa
 		return nil, e
 	}
 
-	return NewStaticProjectConfigManagerFromPayload(logger, datafile)
+	return NewStaticProjectConfigManagerFromPayload(datafile, logger)
 }
 
 // NewStaticProjectConfigManagerFromPayload returns new instance of StaticProjectConfigManager for payload
-func NewStaticProjectConfigManagerFromPayload(logger logging.OptimizelyLogProducer, payload []byte) (*StaticProjectConfigManager, error) {
-	projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(logger, payload)
+func NewStaticProjectConfigManagerFromPayload(payload []byte, logger logging.OptimizelyLogProducer) (*StaticProjectConfigManager, error) {
+	projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(payload, logger)
 
 	if err != nil {
 		return nil, err

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"errors"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"testing"
 
@@ -25,9 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var tlogger = logging.GetLogger("", "staticManager")
+
 func TestNewStaticProjectConfigManager(t *testing.T) {
 	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
-	configManager := NewStaticProjectConfigManager(projectConfig)
+	configManager := NewStaticProjectConfigManager(projectConfig, tlogger)
 
 	actual, _ := configManager.GetConfig()
 	assert.Equal(t, projectConfig, actual)
@@ -36,15 +39,15 @@ func TestNewStaticProjectConfigManager(t *testing.T) {
 func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123""}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
 	assert.Error(t, err)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123",}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile)
+	configManager, err = NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
 	assert.Error(t, err)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile)
+	configManager, err = NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
 	assert.Nil(t, err)
 
 	assert.Nil(t, configManager.optimizelyConfig)
@@ -56,7 +59,7 @@ func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 func TestStaticGetOptimizelyConfig(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
 	assert.Nil(t, err)
 
 	assert.Nil(t, configManager.optimizelyConfig)
@@ -75,7 +78,7 @@ func TestNewStaticProjectConfigManagerFromURL(t *testing.T) {
 
 func TestNewStaticProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
 	assert.Nil(t, err)
 
 	callback := func(notification notification.ProjectConfigUpdateNotification) {

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -18,11 +18,12 @@ package config
 
 import (
 	"errors"
-	"github.com/optimizely/go-sdk/pkg/logging"
-	"github.com/optimizely/go-sdk/pkg/notification"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
+	"github.com/optimizely/go-sdk/pkg/logging"
+	"github.com/optimizely/go-sdk/pkg/notification"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -40,15 +40,15 @@ func TestNewStaticProjectConfigManager(t *testing.T) {
 func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123""}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
 	assert.Error(t, err)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123",}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
+	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
 	assert.Error(t, err)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
+	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
 	assert.Nil(t, err)
 
 	assert.Nil(t, configManager.optimizelyConfig)
@@ -60,7 +60,7 @@ func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 func TestStaticGetOptimizelyConfig(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
 	assert.Nil(t, err)
 
 	assert.Nil(t, configManager.optimizelyConfig)
@@ -79,7 +79,7 @@ func TestNewStaticProjectConfigManagerFromURL(t *testing.T) {
 
 func TestNewStaticProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(tlogger, mockDatafile)
+	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
 	assert.Nil(t, err)
 
 	callback := func(notification notification.ProjectConfigUpdateNotification) {

--- a/pkg/decision/bucketer/experiment_bucketer.go
+++ b/pkg/decision/bucketer/experiment_bucketer.go
@@ -20,6 +20,7 @@ package bucketer
 import (
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // ExperimentBucketer is used to bucket the user into a particular entity in the experiment's traffic alloc range
@@ -33,9 +34,9 @@ type MurmurhashExperimentBucketer struct {
 }
 
 // NewMurmurhashExperimentBucketer returns a new instance of the murmurhash experiment bucketer
-func NewMurmurhashExperimentBucketer(hashSeed uint32) *MurmurhashExperimentBucketer {
+func NewMurmurhashExperimentBucketer(logger logging.OptimizelyLogProducer, hashSeed uint32) *MurmurhashExperimentBucketer {
 	return &MurmurhashExperimentBucketer{
-		bucketer: MurmurhashBucketer{hashSeed: hashSeed},
+		bucketer: MurmurhashBucketer{hashSeed: hashSeed, logger:logger},
 	}
 }
 

--- a/pkg/decision/bucketer/experiment_bucketer_test.go
+++ b/pkg/decision/bucketer/experiment_bucketer_test.go
@@ -1,6 +1,7 @@
 package bucketer
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
@@ -46,7 +47,7 @@ func TestBucketExclusionGroups(t *testing.T) {
 		},
 	}
 
-	bucketer := NewMurmurhashExperimentBucketer(DefaultHashSeed)
+	bucketer := NewMurmurhashExperimentBucketer(logging.GetLogger("","TestBucketExclusionGroups" ), DefaultHashSeed)
 	// ppid2 + 1886780722 (groupId) will generate bucket value of 2434 which maps to experiment 1
 	bucketedVariation, reason, _ := bucketer.Bucket("ppid2", experiment1, exclusionGroup)
 	assert.Equal(t, experiment1.Variations["22222"], *bucketedVariation)

--- a/pkg/decision/bucketer/murmurhashbucketer.go
+++ b/pkg/decision/bucketer/murmurhashbucketer.go
@@ -46,10 +46,10 @@ type MurmurhashBucketer struct {
 }
 
 // NewMurmurhashBucketer returns a new instance of the murmurhash bucketer
-func NewMurmurhashBucketer(sdkKey string, hashSeed uint32) *MurmurhashBucketer {
+func NewMurmurhashBucketer(logger logging.OptimizelyLogProducer, hashSeed uint32) *MurmurhashBucketer {
 	return &MurmurhashBucketer{
 		hashSeed: hashSeed,
-		logger: logging.GetLogger(sdkKey, "MurmurhashBucketer"),
+		logger: logger,
 	}
 }
 

--- a/pkg/decision/bucketer/murmurhashbucketer.go
+++ b/pkg/decision/bucketer/murmurhashbucketer.go
@@ -19,10 +19,11 @@ package bucketer
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"math"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/twmb/murmur3"
 )
 

--- a/pkg/decision/bucketer/murmurhashbucketer.go
+++ b/pkg/decision/bucketer/murmurhashbucketer.go
@@ -19,14 +19,13 @@ package bucketer
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"math"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/twmb/murmur3"
 )
 
-var logger = logging.GetLogger("MurmurhashBucketer")
 var maxHashValue = float32(math.Pow(2, 32))
 
 // DefaultHashSeed is the hash seed to use for murmurhash
@@ -42,12 +41,14 @@ type Bucketer interface {
 // MurmurhashBucketer generates the bucketing value using the mmh3 algorightm
 type MurmurhashBucketer struct {
 	hashSeed uint32
+	logger   logging.OptimizelyLogProducer
 }
 
 // NewMurmurhashBucketer returns a new instance of the murmurhash bucketer
-func NewMurmurhashBucketer(hashSeed uint32) *MurmurhashBucketer {
+func NewMurmurhashBucketer(sdkKey string, hashSeed uint32) *MurmurhashBucketer {
 	return &MurmurhashBucketer{
 		hashSeed: hashSeed,
+		logger: logging.GetLogger(sdkKey, "MurmurhashBucketer"),
 	}
 }
 
@@ -55,7 +56,7 @@ func NewMurmurhashBucketer(hashSeed uint32) *MurmurhashBucketer {
 func (b MurmurhashBucketer) Generate(bucketingKey string) int {
 	hasher := murmur3.SeedNew32(b.hashSeed)
 	if _, err := hasher.Write([]byte(bucketingKey)); err != nil {
-		logger.Error(fmt.Sprintf("Unable to generate a hash for the bucketing key=%s", bucketingKey), err)
+		b.logger.Error(fmt.Sprintf("Unable to generate a hash for the bucketing key=%s", bucketingKey), err)
 	}
 	hashCode := hasher.Sum32()
 	ratio := float32(hashCode) / maxHashValue

--- a/pkg/decision/bucketer/murmurhashbucketer_test.go
+++ b/pkg/decision/bucketer/murmurhashbucketer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBucketToEntity(t *testing.T) {
-	bucketer := NewMurmurhashBucketer(DefaultHashSeed)
+	bucketer := NewMurmurhashBucketer("", DefaultHashSeed)
 
 	experimentID := "1886780721"
 	experimentID2 := "1886780722"

--- a/pkg/decision/bucketer/murmurhashbucketer_test.go
+++ b/pkg/decision/bucketer/murmurhashbucketer_test.go
@@ -2,6 +2,7 @@ package bucketer
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestBucketToEntity(t *testing.T) {
-	bucketer := NewMurmurhashBucketer("", DefaultHashSeed)
+	bucketer := NewMurmurhashBucketer(logging.GetLogger("", "TestBucketToEntity"), DefaultHashSeed)
 
 	experimentID := "1886780721"
 	experimentID2 := "1886780722"
@@ -51,7 +52,7 @@ func TestBucketToEntity(t *testing.T) {
 }
 
 func TestGenerateBucketValue(t *testing.T) {
-	bucketer := NewMurmurhashBucketer("", DefaultHashSeed)
+	bucketer := NewMurmurhashBucketer(logging.GetLogger("", "TestGenerateBucketValue"), DefaultHashSeed)
 
 	// copied from unit tests in the other SDKs
 	experimentID := "1886780721"

--- a/pkg/decision/bucketer/murmurhashbucketer_test.go
+++ b/pkg/decision/bucketer/murmurhashbucketer_test.go
@@ -51,7 +51,7 @@ func TestBucketToEntity(t *testing.T) {
 }
 
 func TestGenerateBucketValue(t *testing.T) {
-	bucketer := NewMurmurhashBucketer(DefaultHashSeed)
+	bucketer := NewMurmurhashBucketer("", DefaultHashSeed)
 
 	// copied from unit tests in the other SDKs
 	experimentID := "1886780721"

--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -64,15 +64,13 @@ func NewCompositeExperimentService(sdkKey string, options ...CESOptionFunc) *Com
 
 	// Prepend overrides if supplied
 	if compositeExperimentService.overrideStore != nil {
-		overrideService := NewExperimentOverrideService(logging.GetLogger(sdkKey, "ExperimentOverrideService"),
-			compositeExperimentService.overrideStore)
+		overrideService := NewExperimentOverrideService(compositeExperimentService.overrideStore, logging.GetLogger(sdkKey, "ExperimentOverrideService"))
 		experimentServices = append([]ExperimentService{overrideService}, experimentServices...)
 	}
 
 	experimentBucketerService := NewExperimentBucketerService(logging.GetLogger(sdkKey, "ExperimentBucketerService"))
 	if compositeExperimentService.userProfileService != nil {
-		persistingExperimentService := NewPersistingExperimentService(logging.GetLogger(sdkKey, "PersistingExperimentService"),
-			experimentBucketerService, compositeExperimentService.userProfileService)
+		persistingExperimentService := NewPersistingExperimentService(compositeExperimentService.userProfileService, experimentBucketerService, logging.GetLogger(sdkKey, "PersistingExperimentService"))
 		experimentServices = append(experimentServices, persistingExperimentService)
 	} else {
 		experimentServices = append(experimentServices, experimentBucketerService)

--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -19,9 +19,8 @@ package decision
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
-
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // CESOptionFunc is used to assign optional configuration options

--- a/pkg/decision/composite_experiment_service_test.go
+++ b/pkg/decision/composite_experiment_service_test.go
@@ -152,7 +152,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionReturnsError() {
 
 func (s *CompositeExperimentTestSuite) TestNewCompositeExperimentService() {
 	// Assert that the service is instantiated with the correct child services in the right order
-	compositeExperimentService := NewCompositeExperimentService()
+	compositeExperimentService := NewCompositeExperimentService("")
 	s.Equal(2, len(compositeExperimentService.experimentServices))
 	s.IsType(&ExperimentWhitelistService{}, compositeExperimentService.experimentServices[0])
 	s.IsType(&ExperimentBucketerService{}, compositeExperimentService.experimentServices[1])
@@ -161,7 +161,7 @@ func (s *CompositeExperimentTestSuite) TestNewCompositeExperimentService() {
 func (s *CompositeExperimentTestSuite) TestNewCompositeExperimentServiceWithCustomOptions() {
 	mockUserProfileService := new(MockUserProfileService)
 	mockExperimentOverrideStore := new(MapExperimentOverridesStore)
-	compositeExperimentService := NewCompositeExperimentService(
+	compositeExperimentService := NewCompositeExperimentService("",
 		WithUserProfileService(mockUserProfileService),
 		WithOverrideStore(mockExperimentOverrideStore),
 	)

--- a/pkg/decision/composite_experiment_service_test.go
+++ b/pkg/decision/composite_experiment_service_test.go
@@ -18,6 +18,7 @@ package decision
 
 import (
 	"errors"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -58,7 +59,8 @@ func (s *CompositeExperimentTestSuite) TestGetDecision() {
 	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext).Return(expectedExperimentDecision, nil)
 
 	compositeExperimentService := &CompositeExperimentService{
-		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
+		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2,},
+		logger:logging.GetLogger("sdkKey", "ExperimentService"),
 	}
 	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(expectedExperimentDecision, decision)
@@ -85,6 +87,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionFallthrough() {
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
+		logger:logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
 	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 
@@ -107,6 +110,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionNoDecisionsMade() {
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
+		logger:logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
 	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 
@@ -142,6 +146,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionReturnsError() {
 			s.mockExperimentService,
 			s.mockExperimentService2,
 		},
+		logger:logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
 	decision, err := compositeExperimentService.GetDecision(testDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)

--- a/pkg/decision/composite_experiment_service_test.go
+++ b/pkg/decision/composite_experiment_service_test.go
@@ -18,12 +18,12 @@ package decision
 
 import (
 	"errors"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 type CompositeExperimentTestSuite struct {

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -18,11 +18,12 @@ package decision
 
 import (
 	"errors"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -157,8 +157,8 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 
 func (s *CompositeFeatureServiceTestSuite) TestNewCompositeFeatureService() {
 	// Assert that the service is instantiated with the correct child services in the right order
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureService := NewCompositeFeatureService("", compositeExperimentService)
 	s.Equal(2, len(compositeFeatureService.featureServices))
 	s.IsType(&FeatureExperimentService{compositeExperimentService: compositeExperimentService}, compositeFeatureService.featureServices[0])
 	s.IsType(&RolloutService{}, compositeFeatureService.featureServices[1])

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -18,6 +18,7 @@ package decision
 
 import (
 	"errors"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
@@ -64,6 +65,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecision() {
 			s.mockFeatureService,
 			s.mockFeatureService2,
 		},
+		logger:logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
 	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)
@@ -91,6 +93,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionFallthrough() {
 			s.mockFeatureService,
 			s.mockFeatureService2,
 		},
+		logger:logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
 	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)
@@ -120,6 +123,8 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsError() {
 			s.mockFeatureService,
 			s.mockFeatureService2,
 		},
+		logger:logging.GetLogger("sdkKey", "CompositeFeatureService"),
+
 	}
 	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)
@@ -146,6 +151,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 			s.mockFeatureService,
 			s.mockFeatureService2,
 		},
+		logger:logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
 	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedDecision, decision)

--- a/pkg/decision/composite_service_test.go
+++ b/pkg/decision/composite_service_test.go
@@ -94,8 +94,8 @@ func (s *CompositeServiceFeatureTestSuite) TestDecisionListeners() {
 
 func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWithFloatVariable() {
 
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureDecisionService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureDecisionService := NewCompositeFeatureService("", compositeExperimentService)
 	s.decisionContext.Variable = entities.Variable{
 		DefaultValue: "23.34",
 		ID:           "1",
@@ -132,8 +132,8 @@ func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWith
 
 func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWithIntegerVariable() {
 
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureDecisionService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureDecisionService := NewCompositeFeatureService("", compositeExperimentService)
 	s.decisionContext.Variable = entities.Variable{
 		DefaultValue: "23",
 		ID:           "1",
@@ -170,8 +170,8 @@ func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWith
 
 func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWithBoolVariable() {
 
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureDecisionService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureDecisionService := NewCompositeFeatureService("", compositeExperimentService)
 	s.decisionContext.Variable = entities.Variable{
 		DefaultValue: "true",
 		ID:           "1",
@@ -208,8 +208,8 @@ func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWith
 
 func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWithWrongTypelVariable() {
 
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureDecisionService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureDecisionService := NewCompositeFeatureService("", compositeExperimentService)
 	s.decisionContext.Variable = entities.Variable{
 		DefaultValue: "string",
 		ID:           "1",
@@ -246,8 +246,8 @@ func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWith
 
 func (s *CompositeServiceFeatureTestSuite) TestDecisionListenersNotificationWithNoVariable() {
 
-	compositeExperimentService := NewCompositeExperimentService()
-	compositeFeatureDecisionService := NewCompositeFeatureService(compositeExperimentService)
+	compositeExperimentService := NewCompositeExperimentService("")
+	compositeFeatureDecisionService := NewCompositeFeatureService("", compositeExperimentService)
 	s.decisionContext.Variable = entities.Variable{} //no variable
 
 	decisionService := &CompositeService{
@@ -284,7 +284,7 @@ func (s *CompositeServiceFeatureTestSuite) TestNewCompositeService() {
 }
 
 func (s *CompositeServiceFeatureTestSuite) TestNewCompositeServiceWithCustomOptions() {
-	compositeExperimentService := NewCompositeExperimentService()
+	compositeExperimentService := NewCompositeExperimentService("")
 	compositeService := NewCompositeService("sdk_key", WithCompositeExperimentService(compositeExperimentService))
 	s.IsType(compositeExperimentService, compositeService.compositeExperimentService)
 	s.IsType(&CompositeFeatureService{}, compositeService.compositeFeatureService)

--- a/pkg/decision/experiment_bucketer_service.go
+++ b/pkg/decision/experiment_bucketer_service.go
@@ -40,7 +40,7 @@ func NewExperimentBucketerService(logger logging.OptimizelyLogProducer) *Experim
 	return &ExperimentBucketerService{
 		logger:logger,
 		audienceTreeEvaluator: evaluator.NewMixedTreeEvaluator(),
-		bucketer:              *bucketer.NewMurmurhashExperimentBucketer(bucketer.DefaultHashSeed),
+		bucketer:              *bucketer.NewMurmurhashExperimentBucketer(logger, bucketer.DefaultHashSeed),
 	}
 }
 

--- a/pkg/decision/experiment_bucketer_service.go
+++ b/pkg/decision/experiment_bucketer_service.go
@@ -19,12 +19,12 @@ package decision
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/optimizely/go-sdk/pkg/decision/bucketer"
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // ExperimentBucketerService makes a decision using the experiment bucketer

--- a/pkg/decision/experiment_override_service.go
+++ b/pkg/decision/experiment_override_service.go
@@ -82,7 +82,7 @@ type ExperimentOverrideService struct {
 }
 
 // NewExperimentOverrideService returns a pointer to an initialized ExperimentOverrideService
-func NewExperimentOverrideService(logger logging.OptimizelyLogProducer, overrides ExperimentOverrideStore) *ExperimentOverrideService {
+func NewExperimentOverrideService(overrides ExperimentOverrideStore, logger logging.OptimizelyLogProducer) *ExperimentOverrideService {
 	return &ExperimentOverrideService{
 		logger: logger,
 		Overrides: overrides,

--- a/pkg/decision/experiment_override_service.go
+++ b/pkg/decision/experiment_override_service.go
@@ -27,8 +27,6 @@ import (
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
-var eosLogger = logging.GetLogger("ExperimentOverrideService")
-
 // ExperimentOverrideKey represents the user ID and experiment associated with an override variation
 type ExperimentOverrideKey struct {
 	ExperimentKey, UserID string
@@ -80,11 +78,13 @@ func (m *MapExperimentOverridesStore) RemoveVariation(overrideKey ExperimentOver
 // Implements the ExperimentService interface
 type ExperimentOverrideService struct {
 	Overrides ExperimentOverrideStore
+	logger    logging.OptimizelyLogProducer
 }
 
 // NewExperimentOverrideService returns a pointer to an initialized ExperimentOverrideService
-func NewExperimentOverrideService(overrides ExperimentOverrideStore) *ExperimentOverrideService {
+func NewExperimentOverrideService(logger logging.OptimizelyLogProducer, overrides ExperimentOverrideStore) *ExperimentOverrideService {
 	return &ExperimentOverrideService{
+		logger: logger,
 		Overrides: overrides,
 	}
 }
@@ -107,7 +107,7 @@ func (s ExperimentOverrideService) GetDecision(decisionContext ExperimentDecisio
 		if variation, ok := decisionContext.Experiment.Variations[variationID]; ok {
 			decision.Variation = &variation
 			decision.Reason = reasons.OverrideVariationAssignmentFound
-			eosLogger.Debug(fmt.Sprintf("Override variation %v found for user %v", variationKey, userContext.ID))
+			s.logger.Debug(fmt.Sprintf("Override variation %v found for user %v", variationKey, userContext.ID))
 			return decision, nil
 		}
 	}

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -18,12 +18,13 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -18,6 +18,7 @@
 package decision
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 	"testing"
 
@@ -36,7 +37,7 @@ type ExperimentOverrideServiceTestSuite struct {
 func (s *ExperimentOverrideServiceTestSuite) SetupTest() {
 	s.mockConfig = new(mockProjectConfig)
 	s.overrides = NewMapExperimentOverridesStore()
-	s.overrideService = NewExperimentOverrideService(s.overrides)
+	s.overrideService = NewExperimentOverrideService(logging.GetLogger("", ""), s.overrides)
 }
 
 func (s *ExperimentOverrideServiceTestSuite) TestOverridesIncludeVariation() {

--- a/pkg/decision/experiment_override_service_test.go
+++ b/pkg/decision/experiment_override_service_test.go
@@ -38,7 +38,7 @@ type ExperimentOverrideServiceTestSuite struct {
 func (s *ExperimentOverrideServiceTestSuite) SetupTest() {
 	s.mockConfig = new(mockProjectConfig)
 	s.overrides = NewMapExperimentOverridesStore()
-	s.overrideService = NewExperimentOverrideService(logging.GetLogger("", ""), s.overrides)
+	s.overrideService = NewExperimentOverrideService(s.overrides, logging.GetLogger("", ""))
 }
 
 func (s *ExperimentOverrideServiceTestSuite) TestOverridesIncludeVariation() {

--- a/pkg/decision/feature_experiment_service.go
+++ b/pkg/decision/feature_experiment_service.go
@@ -24,16 +24,16 @@ import (
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
-var fesLogger = logging.GetLogger("FeatureExperimentService")
-
 // FeatureExperimentService helps evaluate feature test associated with the feature
 type FeatureExperimentService struct {
 	compositeExperimentService ExperimentService
+	logger                     logging.OptimizelyLogProducer
 }
 
 // NewFeatureExperimentService returns a new instance of the FeatureExperimentService
-func NewFeatureExperimentService(compositeExperimentService ExperimentService) *FeatureExperimentService {
+func NewFeatureExperimentService(logger logging.OptimizelyLogProducer, compositeExperimentService ExperimentService) *FeatureExperimentService {
 	return &FeatureExperimentService{
+		logger: logger,
 		compositeExperimentService: compositeExperimentService,
 	}
 }
@@ -50,7 +50,7 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		}
 
 		experimentDecision, err := f.compositeExperimentService.GetDecision(experimentDecisionContext, userContext)
-		fesLogger.Debug(fmt.Sprintf(
+		f.logger.Debug(fmt.Sprintf(
 			`Decision made for feature test with key "%s" for user "%s" with the following reason: "%s".`,
 			feature.Key,
 			userContext.ID,

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -17,6 +17,7 @@
 package decision
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -110,7 +111,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 
 func (s *FeatureExperimentServiceTestSuite) TestNewFeatureExperimentService() {
 	compositeExperimentService := &CompositeExperimentService{}
-	featureExperimentService := NewFeatureExperimentService(compositeExperimentService)
+	featureExperimentService := NewFeatureExperimentService(logging.GetLogger("", ""), compositeExperimentService)
 	s.IsType(compositeExperimentService, featureExperimentService.compositeExperimentService)
 }
 

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -58,6 +58,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecision() {
 
 	featureExperimentService := &FeatureExperimentService{
 		compositeExperimentService: s.mockExperimentService,
+		logger:logging.GetLogger("sdkKey", "FeatureExperimentService"),
 	}
 
 	expectedFeatureDecision := FeatureDecision{
@@ -102,6 +103,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 	}
 	featureExperimentService := &FeatureExperimentService{
 		compositeExperimentService: s.mockExperimentService,
+		logger:logging.GetLogger("sdkKey", "FeatureExperimentService"),
 	}
 	decision, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext)
 	s.Equal(expectedFeatureDecision, decision)
@@ -110,7 +112,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 }
 
 func (s *FeatureExperimentServiceTestSuite) TestNewFeatureExperimentService() {
-	compositeExperimentService := &CompositeExperimentService{}
+	compositeExperimentService := &CompositeExperimentService{logger:logging.GetLogger("sdkKey", "CompositeExperimentService")}
 	featureExperimentService := NewFeatureExperimentService(logging.GetLogger("", ""), compositeExperimentService)
 	s.IsType(compositeExperimentService, featureExperimentService.compositeExperimentService)
 }

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -17,10 +17,11 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/decision/persisting_experiment_service.go
+++ b/pkg/decision/persisting_experiment_service.go
@@ -34,7 +34,7 @@ type PersistingExperimentService struct {
 }
 
 // NewPersistingExperimentService returns a new instance of the PersistingExperimentService
-func NewPersistingExperimentService(logger logging.OptimizelyLogProducer, experimentBucketerService ExperimentService, userProfileService UserProfileService) *PersistingExperimentService {
+func NewPersistingExperimentService(userProfileService UserProfileService, experimentBucketerService ExperimentService, logger logging.OptimizelyLogProducer) *PersistingExperimentService {
 	persistingExperimentService := &PersistingExperimentService{
 		logger: logger,
 		experimentBucketedService: experimentBucketerService,

--- a/pkg/decision/persisting_experiment_service.go
+++ b/pkg/decision/persisting_experiment_service.go
@@ -24,19 +24,19 @@ import (
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
-var pesLogger = logging.GetLogger("PersistingExperimentService")
-
 // PersistingExperimentService attempts to retrieve a saved decision from the user profile service
 // for the user before having the ExperimentBucketerService compute it.
 // If computed, the decision is saved back to the user profile service if provided.
 type PersistingExperimentService struct {
 	experimentBucketedService ExperimentService
 	userProfileService        UserProfileService
+	logger 					  logging.OptimizelyLogProducer
 }
 
 // NewPersistingExperimentService returns a new instance of the PersistingExperimentService
-func NewPersistingExperimentService(experimentBucketerService ExperimentService, userProfileService UserProfileService) *PersistingExperimentService {
+func NewPersistingExperimentService(logger logging.OptimizelyLogProducer, experimentBucketerService ExperimentService, userProfileService UserProfileService) *PersistingExperimentService {
 	persistingExperimentService := &PersistingExperimentService{
+		logger: logger,
 		experimentBucketedService: experimentBucketerService,
 		userProfileService:        userProfileService,
 	}
@@ -80,9 +80,9 @@ func (p PersistingExperimentService) getSavedDecision(decisionContext Experiment
 	if savedVariationID, ok := userProfile.ExperimentBucketMap[decisionKey]; ok {
 		if variation, ok := decisionContext.Experiment.Variations[savedVariationID]; ok {
 			experimentDecision.Variation = &variation
-			pesLogger.Debug(fmt.Sprintf(`User "%s" was previously bucketed into variation "%s" of experiment "%s".`, userContext.ID, variation.Key, decisionContext.Experiment.Key))
+			p.logger.Debug(fmt.Sprintf(`User "%s" was previously bucketed into variation "%s" of experiment "%s".`, userContext.ID, variation.Key, decisionContext.Experiment.Key))
 		} else {
-			pesLogger.Warning(fmt.Sprintf(`User "%s" was previously bucketed into variation with ID "%s" for experiment "%s", but no matching variation was found.`, userContext.ID, savedVariationID, decisionContext.Experiment.Key))
+			p.logger.Warning(fmt.Sprintf(`User "%s" was previously bucketed into variation with ID "%s" for experiment "%s", but no matching variation was found.`, userContext.ID, savedVariationID, decisionContext.Experiment.Key))
 		}
 	}
 
@@ -97,6 +97,6 @@ func (p PersistingExperimentService) saveDecision(userProfile UserProfile, exper
 		}
 		userProfile.ExperimentBucketMap[decisionKey] = decision.Variation.ID
 		p.userProfileService.Save(userProfile)
-		pesLogger.Debug(fmt.Sprintf(`Decision saved for user "%s".`, userProfile.ID))
+		p.logger.Debug(fmt.Sprintf(`Decision saved for user "%s".`, userProfile.ID))
 	}
 }

--- a/pkg/decision/persisting_experiment_service_test.go
+++ b/pkg/decision/persisting_experiment_service_test.go
@@ -18,10 +18,11 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )

--- a/pkg/decision/persisting_experiment_service_test.go
+++ b/pkg/decision/persisting_experiment_service_test.go
@@ -57,8 +57,7 @@ func (s *PersistingExperimentServiceTestSuite) SetupTest() {
 }
 
 func (s *PersistingExperimentServiceTestSuite) TestNilUserProfileService() {
-	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
-		s.mockExperimentService, nil)
+	persistingExperimentService := NewPersistingExperimentService(nil, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
@@ -74,8 +73,7 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationFound() {
 	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(savedUserProfile)
 	s.mockUserProfileService.On("Save", mock.Anything)
 
-	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
-		s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	savedDecision := ExperimentDecision{
 		Variation: &testExp1113Var2224,
@@ -95,8 +93,7 @@ func (s *PersistingExperimentServiceTestSuite) TestNoSavedVariation() {
 	}
 
 	s.mockUserProfileService.On("Save", updatedUserProfile)
-	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
-		s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
@@ -117,8 +114,7 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationNoLongerValid()
 		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
 	}
 	s.mockUserProfileService.On("Save", updatedUserProfile)
-	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
-		s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)

--- a/pkg/decision/persisting_experiment_service_test.go
+++ b/pkg/decision/persisting_experiment_service_test.go
@@ -18,6 +18,7 @@
 package decision
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/entities"
@@ -55,7 +56,8 @@ func (s *PersistingExperimentServiceTestSuite) SetupTest() {
 }
 
 func (s *PersistingExperimentServiceTestSuite) TestNilUserProfileService() {
-	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, nil)
+	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
+		s.mockExperimentService, nil)
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
@@ -71,7 +73,8 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationFound() {
 	s.mockUserProfileService.On("Lookup", testUserContext.ID).Return(savedUserProfile)
 	s.mockUserProfileService.On("Save", mock.Anything)
 
-	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
+		s.mockExperimentService, s.mockUserProfileService)
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	savedDecision := ExperimentDecision{
 		Variation: &testExp1113Var2224,
@@ -91,7 +94,8 @@ func (s *PersistingExperimentServiceTestSuite) TestNoSavedVariation() {
 	}
 
 	s.mockUserProfileService.On("Save", updatedUserProfile)
-	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
+		s.mockExperimentService, s.mockUserProfileService)
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
@@ -112,7 +116,8 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationNoLongerValid()
 		ExperimentBucketMap: map[UserDecisionKey]string{decisionKey: s.testComputedDecision.Variation.ID},
 	}
 	s.mockUserProfileService.On("Save", updatedUserProfile)
-	persistingExperimentService := NewPersistingExperimentService(s.mockExperimentService, s.mockUserProfileService)
+	persistingExperimentService := NewPersistingExperimentService(logging.GetLogger("", "NewPersistingExperimentService"),
+		s.mockExperimentService, s.mockUserProfileService)
 	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -27,19 +27,19 @@ import (
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
-var rsLogger = logging.GetLogger("RolloutService")
-
 // RolloutService makes a feature decision for a given feature rollout
 type RolloutService struct {
 	audienceTreeEvaluator     evaluator.TreeEvaluator
 	experimentBucketerService ExperimentService
+	logger logging.OptimizelyLogProducer
 }
 
 // NewRolloutService returns a new instance of the Rollout service
-func NewRolloutService() *RolloutService {
+func NewRolloutService(sdkKey string) *RolloutService {
 	return &RolloutService{
+		logger:logging.GetLogger(sdkKey, "RolloutService"),
 		audienceTreeEvaluator:     evaluator.NewMixedTreeEvaluator(),
-		experimentBucketerService: NewExperimentBucketerService(),
+		experimentBucketerService: NewExperimentBucketerService(logging.GetLogger(sdkKey, "ExperimentBucketerService")),
 	}
 }
 
@@ -74,7 +74,7 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		evalResult, _ := r.audienceTreeEvaluator.Evaluate(experiment.AudienceConditionTree, condTreeParams)
 		if !evalResult {
 			featureDecision.Reason = reasons.FailedRolloutTargeting
-			rsLogger.Debug(fmt.Sprintf(`User "%s" failed targeting for feature rollout with key "%s".`, userContext.ID, feature.Key))
+			r.logger.Debug(fmt.Sprintf(`User "%s" failed targeting for feature rollout with key "%s".`, userContext.ID, feature.Key))
 			return featureDecision, nil
 		}
 	}
@@ -92,7 +92,7 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 
 	featureDecision.Experiment = experiment
 	featureDecision.Variation = decision.Variation
-	rsLogger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))
+	r.logger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))
 
 	return featureDecision, nil
 }

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -22,9 +22,8 @@ import (
 
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
-	"github.com/optimizely/go-sdk/pkg/logging"
-
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // RolloutService makes a feature decision for a given feature rollout

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -17,17 +17,16 @@
 package decision
 
 import (
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
-
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
+	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
 type RolloutServiceTestSuite struct {

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -134,7 +134,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFailsTargeting() {
 }
 
 func TestNewRolloutService(t *testing.T) {
-	rolloutService := NewRolloutService()
+	rolloutService := NewRolloutService("")
 	assert.IsType(t, &evaluator.MixedTreeEvaluator{}, rolloutService.audienceTreeEvaluator)
 	assert.IsType(t, &ExperimentBucketerService{}, rolloutService.experimentBucketerService)
 }

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -17,6 +17,7 @@
 package decision
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
@@ -75,6 +76,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionHappyPath() {
 	testRolloutService := RolloutService{
 		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
 		experimentBucketerService: s.mockExperimentService,
+		logger:logging.GetLogger("sdkKey", "RolloutService"),
 	}
 	expectedFeatureDecision := FeatureDecision{
 		Experiment: testExp1112,
@@ -101,6 +103,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFailsBucketing() {
 	testRolloutService := RolloutService{
 		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
 		experimentBucketerService: s.mockExperimentService,
+		logger:logging.GetLogger("sdkKey", "RolloutService"),
 	}
 	expectedFeatureDecision := FeatureDecision{
 		Decision: Decision{
@@ -120,6 +123,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFailsTargeting() {
 	testRolloutService := RolloutService{
 		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
 		experimentBucketerService: s.mockExperimentService,
+		logger:logging.GetLogger("sdkKey", "RolloutService"),
 	}
 	expectedFeatureDecision := FeatureDecision{
 		Decision: Decision{
@@ -136,7 +140,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFailsTargeting() {
 func TestNewRolloutService(t *testing.T) {
 	rolloutService := NewRolloutService("")
 	assert.IsType(t, &evaluator.MixedTreeEvaluator{}, rolloutService.audienceTreeEvaluator)
-	assert.IsType(t, &ExperimentBucketerService{}, rolloutService.experimentBucketerService)
+	assert.IsType(t, &ExperimentBucketerService{logger:logging.GetLogger("sdkKey", "ExperimentBucketerService")}, rolloutService.experimentBucketerService)
 }
 
 func TestRolloutServiceTestSuite(t *testing.T) {

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -19,11 +19,11 @@ package event
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/metrics"
 	"github.com/optimizely/go-sdk/pkg/utils"
 )

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -19,11 +19,11 @@ package event
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/metrics"
 	"github.com/optimizely/go-sdk/pkg/utils"
 )
@@ -31,8 +31,6 @@ import (
 const maxRetries = 3
 const defaultQueueSize = 1000
 const sleepTime = 1 * time.Second
-
-var dispatcherLogger = logging.GetLogger("EventDispatcher")
 
 // Dispatcher dispatches events
 type Dispatcher interface {
@@ -42,6 +40,7 @@ type Dispatcher interface {
 // HTTPEventDispatcher is the HTTP implementation of the Dispatcher interface
 type HTTPEventDispatcher struct {
 	requester *utils.HTTPRequester
+	logger logging.OptimizelyLogProducer
 }
 
 // DispatchEvent dispatches event with callback
@@ -53,13 +52,13 @@ func (ed *HTTPEventDispatcher) DispatchEvent(event LogEvent) (bool, error) {
 	// resp.StatusCode == 400 is an error
 	var success bool
 	if err != nil {
-		dispatcherLogger.Error("http.Post failed:", err)
+		ed.logger.Error("http.Post failed:", err)
 		success = false
 	} else {
 		if code == http.StatusNoContent {
 			success = true
 		} else {
-			dispatcherLogger.Error(fmt.Sprintf("http.Post invalid response %d", code), nil)
+			ed.logger.Error(fmt.Sprintf("http.Post invalid response %d", code), nil)
 			success = false
 		}
 	}
@@ -71,6 +70,7 @@ type QueueEventDispatcher struct {
 	eventQueue     Queue
 	eventFlushLock sync.Mutex
 	Dispatcher     Dispatcher
+	logger         logging.OptimizelyLogProducer
 
 	// metrics
 	queueSize         metrics.Gauge
@@ -101,7 +101,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 	ed.queueSize.Set(float64(ed.eventQueue.Size()))
 	for ed.eventQueue.Size() > 0 {
 		if retryCount > maxRetries {
-			dispatcherLogger.Error(fmt.Sprintf("event failed to send %d times. It will retry on next event sent", maxRetries), nil)
+			ed.logger.Error(fmt.Sprintf("event failed to send %d times. It will retry on next event sent", maxRetries), nil)
 			ed.failFlushCounter.Add(1)
 			break
 		}
@@ -114,7 +114,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 		event, ok := items[0].(LogEvent)
 		if !ok {
 			// remove it
-			dispatcherLogger.Error("invalid type passed to event Dispatcher", nil)
+			ed.logger.Error("invalid type passed to event Dispatcher", nil)
 			ed.eventQueue.Remove(1)
 			ed.failFlushCounter.Add(1)
 			continue
@@ -124,12 +124,12 @@ func (ed *QueueEventDispatcher) flushEvents() {
 
 		if err == nil {
 			if success {
-				dispatcherLogger.Debug(fmt.Sprintf("Dispatched log event %+v", event))
+				ed.logger.Debug(fmt.Sprintf("Dispatched log event %+v", event))
 				ed.eventQueue.Remove(1)
 				retryCount = 0
 				ed.sucessFlush.Add(1)
 			} else {
-				dispatcherLogger.Warning("dispatch event failed")
+				ed.logger.Warning("dispatch event failed")
 				// we failed.  Sleep some seconds and try again.
 				time.Sleep(sleepTime)
 				// increase retryCount.  We exit if we have retried x times.
@@ -138,7 +138,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 				ed.retryFlushCounter.Add(1)
 			}
 		} else {
-			dispatcherLogger.Error("Error dispatching ", err)
+			ed.logger.Error("Error dispatching ", err)
 			// we failed.  Sleep some seconds and try again.
 			time.Sleep(sleepTime)
 			// increase retryCount.  We exit if we have retried x times.
@@ -151,7 +151,7 @@ func (ed *QueueEventDispatcher) flushEvents() {
 }
 
 // NewQueueEventDispatcher creates a Dispatcher that queues in memory and then sends via go routine.
-func NewQueueEventDispatcher(metricsRegistry metrics.Registry) *QueueEventDispatcher {
+func NewQueueEventDispatcher(sdkKey string, metricsRegistry metrics.Registry) *QueueEventDispatcher {
 
 	var dispatcherMetricsRegistry metrics.Registry
 	if metricsRegistry != nil {
@@ -162,7 +162,7 @@ func NewQueueEventDispatcher(metricsRegistry metrics.Registry) *QueueEventDispat
 
 	return &QueueEventDispatcher{
 		eventQueue: NewInMemoryQueue(defaultQueueSize),
-		Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester()},
+		Dispatcher: &HTTPEventDispatcher{requester: utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester"))},
 
 		queueSize:         dispatcherMetricsRegistry.GetGauge(metrics.DispatcherQueueSize),
 		retryFlushCounter: dispatcherMetricsRegistry.GetCounter(metrics.DispatcherRetryFlush),

--- a/pkg/event/dispatcher.go
+++ b/pkg/event/dispatcher.go
@@ -168,5 +168,6 @@ func NewQueueEventDispatcher(sdkKey string, metricsRegistry metrics.Registry) *Q
 		retryFlushCounter: dispatcherMetricsRegistry.GetCounter(metrics.DispatcherRetryFlush),
 		failFlushCounter:  dispatcherMetricsRegistry.GetCounter(metrics.DispatcherFailedFlush),
 		sucessFlush:       dispatcherMetricsRegistry.GetCounter(metrics.DispatcherSuccessFlush),
+		logger:            logging.GetLogger(sdkKey, "QueueEventDispatcher"),
 	}
 }

--- a/pkg/event/dispatcher_test.go
+++ b/pkg/event/dispatcher_test.go
@@ -103,7 +103,7 @@ func NewMetricsRegistry() *MetricsRegistry {
 func TestQueueEventDispatcher_DispatchEvent(t *testing.T) {
 	metricsRegistry := NewMetricsRegistry()
 
-	q := NewQueueEventDispatcher(metricsRegistry)
+	q := NewQueueEventDispatcher("", metricsRegistry)
 	sender := &MockDispatcher{Events: NewInMemoryQueue(100)}
 	q.Dispatcher = sender
 
@@ -139,7 +139,7 @@ func TestQueueEventDispatcher_DispatchEvent(t *testing.T) {
 
 func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 	metricsRegistry := NewMetricsRegistry()
-	q := NewQueueEventDispatcher(metricsRegistry)
+	q := NewQueueEventDispatcher("", metricsRegistry)
 	q.Dispatcher = &MockDispatcher{Events: NewInMemoryQueue(100)}
 
 	config := TestConfig{}
@@ -162,7 +162,7 @@ func TestQueueEventDispatcher_InvalidEvent(t *testing.T) {
 
 func TestQueueEventDispatcher_FailDispath(t *testing.T) {
 	metricsRegistry := NewMetricsRegistry()
-	q := NewQueueEventDispatcher(metricsRegistry)
+	q := NewQueueEventDispatcher("", metricsRegistry)
 	q.Dispatcher = &MockDispatcher{ShouldFail: true, Events: NewInMemoryQueue(100)}
 
 	eventTags := map[string]interface{}{"revenue": 55.0, "value": 25.1}

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -230,7 +230,7 @@ func getEventAttributes(projectConfig config.ProjectConfig, attributes map[strin
 		case strings.HasPrefix(key, specialPrefix):
 			visitorAttribute.EntityID = key
 		default:
-			//efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
+			// efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
 			continue
 		}
 		visitorAttribute.Key = key

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -19,18 +19,14 @@ package event
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
 	guuid "github.com/google/uuid"
 	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/utils"
 )
-
-var efLogger = logging.GetLogger("EventFactory")
 
 const impressionKey string = "campaign_activated"
 const attributeType = "custom"
@@ -234,7 +230,7 @@ func getEventAttributes(projectConfig config.ProjectConfig, attributes map[strin
 		case strings.HasPrefix(key, specialPrefix):
 			visitorAttribute.EntityID = key
 		default:
-			efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
+			//efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
 			continue
 		}
 		visitorAttribute.Key = key

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -230,7 +230,6 @@ func getEventAttributes(projectConfig config.ProjectConfig, attributes map[strin
 		case strings.HasPrefix(key, specialPrefix):
 			visitorAttribute.EntityID = key
 		default:
-			// efLogger.Debug(fmt.Sprintf("Unrecognized attribute %s provided. Pruning before sending event to Optimizely.", key))
 			continue
 		}
 		visitorAttribute.Key = key

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -59,13 +59,13 @@ func NewMockDispatcher(queueSize int, shouldFail bool) *MockDispatcher {
 }
 
 func newExecutionContext() *utils.ExecGroup {
-	return utils.NewExecGroup(context.Background())
+	return utils.NewExecGroup(logging.GetLogger("", "NewExecGroup"), context.Background())
 }
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {
 	eg := newExecutionContext()
 	processor := NewBatchEventProcessor()
-	processor.EventDispatcher = NewQueueEventDispatcher(processor.metricsRegistry)
+	processor.EventDispatcher = NewQueueEventDispatcher("", processor.metricsRegistry)
 	eg.Go(processor.Start)
 
 	impression := BuildTestImpressionEvent()
@@ -425,7 +425,7 @@ func TestChanQueueEventProcessor_ProcessImpression(t *testing.T) {
 	processor := NewBatchEventProcessor(
 		WithQueueSize(100),
 		WithQueue(NewInMemoryQueue(100)),
-		WithEventDispatcher(&HTTPEventDispatcher{requester: utils.NewHTTPRequester()}))
+		WithEventDispatcher(&HTTPEventDispatcher{requester: utils.NewHTTPRequester(logging.GetLogger("", "NewHTTPRequester"))}))
 
 	eg.Go(processor.Start)
 

--- a/pkg/event/processor_test.go
+++ b/pkg/event/processor_test.go
@@ -59,7 +59,7 @@ func NewMockDispatcher(queueSize int, shouldFail bool) *MockDispatcher {
 }
 
 func newExecutionContext() *utils.ExecGroup {
-	return utils.NewExecGroup(logging.GetLogger("", "NewExecGroup"), context.Background())
+	return utils.NewExecGroup(context.Background(), logging.GetLogger("", "NewExecGroup"))
 }
 
 func TestDefaultEventProcessor_ProcessImpression(t *testing.T) {

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -40,7 +40,7 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 		_, _ = messBuilder.WriteString(level.String())
 		_, _ = messBuilder.WriteString("]")
 		keys := make([]string, len(fields))
-		for k,_ := range fields {
+		for k := range fields {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -18,9 +18,9 @@
 package logging
 
 import (
-	"fmt"
 	"io"
 	"log"
+	"strings"
 )
 
 // FilteredLevelLogConsumer is an implementation of the OptimizelyLogConsumer that filters by log level
@@ -33,8 +33,17 @@ type FilteredLevelLogConsumer struct {
 func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields map[string]interface{}) {
 	if l.level <= level {
 		// prepends the name and log level to the message
-		message = fmt.Sprintf("[%s][%s] %s", level, fields["name"], message)
-		l.logger.Println(message)
+		messBuilder := strings.Builder{}
+		for _, v := range fields {
+			if s, ok := v.(string); ok {
+				messBuilder.WriteString("[")
+				messBuilder.WriteString(s)
+				messBuilder.WriteString("]")
+			}
+		}
+		messBuilder.WriteString(" ")
+		messBuilder.WriteString(message)
+		l.logger.Println(messBuilder.String())
 	}
 }
 

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -36,22 +36,22 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 	if l.level <= level {
 		// prepends the name and log level to the message
 		messBuilder := strings.Builder{}
-		_, _ = messBuilder.WriteString("[")
 
-		_, _ = messBuilder.WriteString(level.String())
-		_, _ = messBuilder.WriteString("]")
+		fmt.Fprintf(&messBuilder, "[%s]", level.String())
+
 		keys := make([]string, len(fields))
 		for k := range fields {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
+		
 		for _, k := range keys {
 			if s, ok := fields[k].(string);ok && s != "" {
 				fmt.Fprintf(&messBuilder, "[%s]", s)
 			}
 		}
-		_, _ = messBuilder.WriteString(" ")
-		_, _ = messBuilder.WriteString(message)
+		fmt.Fprintf(&messBuilder, " %s", message)
+
 		l.logger.Println(messBuilder.String())
 	}
 }

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -18,6 +18,7 @@
 package logging
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"sort"
@@ -45,13 +46,8 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			if s, ok := fields[k].(string);ok {
-				if s == "" {
-					continue
-				}
-				_, _ = messBuilder.WriteString("[")
-				_, _ = messBuilder.WriteString(s)
-				_, _ = messBuilder.WriteString("]")
+			if s, ok := fields[k].(string);ok && s != "" {
+				fmt.Fprintf(&messBuilder, "[%s]", s)
 			}
 		}
 		_, _ = messBuilder.WriteString(" ")

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -34,6 +34,9 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 	if l.level <= level {
 		// prepends the name and log level to the message
 		messBuilder := strings.Builder{}
+		messBuilder.WriteString("[")
+		messBuilder.WriteString(level.String())
+		messBuilder.WriteString("]")
 		for _, v := range fields {
 			if s, ok := v.(string); ok {
 				messBuilder.WriteString("[")

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -34,18 +34,19 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 	if l.level <= level {
 		// prepends the name and log level to the message
 		messBuilder := strings.Builder{}
-		messBuilder.WriteString("[")
-		messBuilder.WriteString(level.String())
-		messBuilder.WriteString("]")
+		_, _ = messBuilder.WriteString("[")
+
+		_, _ = messBuilder.WriteString(level.String())
+		_, _ = messBuilder.WriteString("]")
 		for _, v := range fields {
 			if s, ok := v.(string); ok {
-				messBuilder.WriteString("[")
-				messBuilder.WriteString(s)
-				messBuilder.WriteString("]")
+				_, _ = messBuilder.WriteString("[")
+				_, _ = messBuilder.WriteString(s)
+				_, _ = messBuilder.WriteString("]")
 			}
 		}
-		messBuilder.WriteString(" ")
-		messBuilder.WriteString(message)
+		_, _ = messBuilder.WriteString(" ")
+		_, _ = messBuilder.WriteString(message)
 		l.logger.Println(messBuilder.String())
 	}
 }

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -20,6 +20,7 @@ package logging
 import (
 	"io"
 	"log"
+	"sort"
 	"strings"
 )
 
@@ -38,8 +39,16 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 
 		_, _ = messBuilder.WriteString(level.String())
 		_, _ = messBuilder.WriteString("]")
-		for _, v := range fields {
-			if s, ok := v.(string); ok {
+		keys := make([]string, len(fields))
+		for k,_ := range fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if s, ok := fields[k].(string);ok {
+				if s == "" {
+					continue
+				}
 				_, _ = messBuilder.WriteString("[")
 				_, _ = messBuilder.WriteString(s)
 				_, _ = messBuilder.WriteString("]")

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -44,7 +44,7 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		
+
 		for _, k := range keys {
 			if s, ok := fields[k].(string);ok && s != "" {
 				fmt.Fprintf(&messBuilder, "[%s]", s)

--- a/pkg/logging/level_log_consumer_test.go
+++ b/pkg/logging/level_log_consumer_test.go
@@ -46,9 +46,10 @@ func TestLogFormatting(t *testing.T) {
 	out := &bytes.Buffer{}
 	newLogger := NewFilteredLevelLogConsumer(LogLevelInfo, out)
 
-	newLogger.Log(LogLevelInfo, "test message", map[string]interface{}{"name": "test-name"})
+	newLogger.Log(LogLevelInfo, "test message", map[string]interface{}{"name": "test-name", "sdkKey": "test-sdkKey"})
 	assert.Contains(t, out.String(), "test message")
 	assert.Contains(t, out.String(), "[Info]")
 	assert.Contains(t, out.String(), "[test-name]")
+	assert.Contains(t, out.String(), "[test-sdkKey]")
 	assert.Contains(t, out.String(), "[Optimizely]")
 }

--- a/pkg/logging/level_log_consumer_test.go
+++ b/pkg/logging/level_log_consumer_test.go
@@ -46,10 +46,10 @@ func TestLogFormatting(t *testing.T) {
 	out := &bytes.Buffer{}
 	newLogger := NewFilteredLevelLogConsumer(LogLevelInfo, out)
 
-	newLogger.Log(LogLevelInfo, "test message", map[string]interface{}{"name": "test-name", "sdkKey": "test-sdkKey"})
+	newLogger.Log(LogLevelInfo, "test message", map[string]interface{}{"name": "test-name", "sdkKey": "testLogFormatting-sdkKey"})
 	assert.Contains(t, out.String(), "test message")
 	assert.Contains(t, out.String(), "[Info]")
 	assert.Contains(t, out.String(), "[test-name]")
-	assert.Contains(t, out.String(), "[test-sdkKey]")
+	assert.Contains(t, out.String(), "[testLogFormatting-sdkKey]")
 	assert.Contains(t, out.String(), "[Optimizely]")
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -35,7 +35,7 @@ func (l LogLevel) String() string {
 var defaultLogConsumer OptimizelyLogConsumer
 var mutex = &sync.Mutex{}
 var sdkKeyMappings = sync.Map{}
-var count int32 = 0
+var count int32
 
 const (
 	// LogLevelDebug log level

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -90,6 +90,19 @@ func GetSdkKeyLogMapping(sdkKey string) string {
 	return ""
 }
 
+// UseSdkKeyForLogging by default the sdk key is masked for logging.
+// This sets it to use the SDK Key and should be set before the creating your client factory.
+func UseSdkKeyForLogging(sdkKey string) {
+	SetSdkKeyLogMapping(sdkKey, sdkKey)
+}
+
+// SetSdkKeyLogMapping sets the logging key to use for the Optimizely sdk key.
+// By default, the sdk key has masking.  This can override the default of optimizely-1,2,3,4,etc..
+// This should be set before creating your Optimizely client factory.
+func SetSdkKeyLogMapping(sdkKey string, logMapping string) {
+	sdkKeyMappings.Store(sdkKey, logMapping)
+}
+
 // NamedLogProducer produces logs prefixed with its name
 type NamedLogProducer struct {
 	fields map[string]interface{}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -74,17 +74,20 @@ func SetLogLevel(logLevel LogLevel) {
 // GetLogger returns a log producer with the given name
 func GetLogger(sdkKey, name string) OptimizelyLogProducer {
 	return NamedLogProducer{
-		fields: map[string]interface{}{"sdkKeyLogMapping":GetSdkKeyLogMapping(sdkKey), "name": name},
+		fields: map[string]interface{}{"aSdkKeyLogMapping":GetSdkKeyLogMapping(sdkKey), "name": name},
 	}
 }
 
 // GetSdkKeyLogMapping returns a string that maps to the sdk key that is used for logging (hiding the sdk key)
 func GetSdkKeyLogMapping(sdkKey string) string {
-	if logMapping, _ := sdkKeyMappings.LoadOrStore(sdkKey, "optimizely-" +
-		strconv.Itoa(int(atomic.AddInt32(&count, 1)))); logMapping != nil {
+	if logMapping, _ := sdkKeyMappings.Load(sdkKey); logMapping != nil {
 		if lm, ok := logMapping.(string);ok {
 			return lm
 		}
+	} else if sdkKey != "" {
+		mapping := "optimizely-" + strconv.Itoa(int(atomic.AddInt32(&count, 1)))
+		sdkKeyMappings.Store(sdkKey, mapping)
+		return mapping
 	}
 
 	return ""

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -99,7 +99,7 @@ func UseSdkKeyForLogging(sdkKey string) {
 // SetSdkKeyLogMapping sets the logging key to use for the Optimizely sdk key.
 // By default, the sdk key has masking.  This can override the default of optimizely-1,2,3,4,etc..
 // This should be set before creating your Optimizely client factory.
-func SetSdkKeyLogMapping(sdkKey string, logMapping string) {
+func SetSdkKeyLogMapping(sdkKey, logMapping string) {
 	sdkKeyMappings.Store(sdkKey, logMapping)
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -78,6 +78,7 @@ func GetLogger(sdkKey, name string) OptimizelyLogProducer {
 	}
 }
 
+// GetSdkKeyLogMapping returns a string that maps to the sdk key that is used for logging (hiding the sdk key)
 func GetSdkKeyLogMapping(sdkKey string) string {
 	if logMapping, _ := sdkKeyMappings.LoadOrStore(sdkKey, "optimizely-" +
 		strconv.Itoa(int(atomic.AddInt32(&count, 1)))); logMapping != nil {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -68,9 +68,9 @@ func SetLogLevel(logLevel LogLevel) {
 }
 
 // GetLogger returns a log producer with the given name
-func GetLogger(name string) OptimizelyLogProducer {
+func GetLogger(sdkKey string, name string) OptimizelyLogProducer {
 	return NamedLogProducer{
-		fields: map[string]interface{}{"name": name},
+		fields: map[string]interface{}{"name": name, "sdkKey":sdkKey},
 	}
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -70,7 +70,7 @@ func SetLogLevel(logLevel LogLevel) {
 // GetLogger returns a log producer with the given name
 func GetLogger(sdkKey string, name string) OptimizelyLogProducer {
 	return NamedLogProducer{
-		fields: map[string]interface{}{"name": name, "sdkKey":sdkKey},
+		fields: map[string]interface{}{"sdkKey":sdkKey, "name": name},
 	}
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -68,7 +68,7 @@ func SetLogLevel(logLevel LogLevel) {
 }
 
 // GetLogger returns a log producer with the given name
-func GetLogger(sdkKey string, name string) OptimizelyLogProducer {
+func GetLogger(sdkKey, name string) OptimizelyLogProducer {
 	return NamedLogProducer{
 		fields: map[string]interface{}{"sdkKey":sdkKey, "name": name},
 	}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -46,7 +46,7 @@ func TestNamedLoggerDebug(t *testing.T) {
 
 	SetLogger(testLogger)
 
-	logProducer := GetLogger(testLogName)
+	logProducer := GetLogger("", testLogName)
 	logProducer.Debug(testLogMessage)
 	testLogger.AssertExpectations(t)
 	assert.Equal(t, []string{testLogMessage}, testLogger.loggedMessages)
@@ -60,7 +60,7 @@ func TestNamedLoggerInfo(t *testing.T) {
 
 	SetLogger(testLogger)
 
-	logProducer := GetLogger(testLogName)
+	logProducer := GetLogger("testSdkKey", testLogName)
 	logProducer.Info(testLogMessage)
 	testLogger.AssertExpectations(t)
 	assert.Equal(t, []string{testLogMessage}, testLogger.loggedMessages)
@@ -74,7 +74,7 @@ func TestNamedLoggerWarning(t *testing.T) {
 
 	SetLogger(testLogger)
 
-	logProducer := GetLogger(testLogName)
+	logProducer := GetLogger("testSdkKey", testLogName)
 	logProducer.Warning(testLogMessage)
 	testLogger.AssertExpectations(t)
 	assert.Equal(t, []string{testLogMessage}, testLogger.loggedMessages)
@@ -89,7 +89,7 @@ func TestNamedLoggerError(t *testing.T) {
 	SetLogger(testLogger)
 
 	err := errors.New("I am an error object")
-	logProducer := GetLogger(testLogName)
+	logProducer := GetLogger("", testLogName)
 	logProducer.Error(testLogMessage, err)
 	testLogger.AssertExpectations(t)
 	assert.Equal(t, []string{expectedLogMessage}, testLogger.loggedMessages)

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -19,6 +19,7 @@ package logging
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,6 +154,48 @@ func TestLogSdkKey(t *testing.T) {
 	assert.Contains(t, out.String(), "[TestLogSdkKeyOverride]")
 	assert.Contains(t, out.String(), key)
 	assert.Contains(t, out.String(), "[Optimizely]")
+}
+
+func TestLoggingOrder(t *testing.T) {
+	out := &bytes.Buffer{}
+	newLogger := NewFilteredLevelLogConsumer(LogLevelDebug, out)
+
+	SetLogger(newLogger)
+
+	key := "TestLoggingOrder-sdkKey"
+
+	logger := GetLogger(key, "TestLoggingOrder")
+	logger.Debug("test message")
+
+	key = GetSdkKeyLogMapping(key)
+
+	response := out.String()
+
+	assert.Contains(t, response, "test message")
+	assert.Contains(t, response, "[Debug][" + key +"][TestLoggingOrder] test message" )
+	assert.True(t, strings.HasPrefix(response, "[Optimizely]"))
+
+}
+
+func TestLoggingOrderEmpty(t *testing.T) {
+	out := &bytes.Buffer{}
+	newLogger := NewFilteredLevelLogConsumer(LogLevelDebug, out)
+
+	SetLogger(newLogger)
+
+	key := ""
+
+	logger := GetLogger(key, "TestLoggingOrder")
+	logger.Debug("test message")
+
+	key = GetSdkKeyLogMapping(key)
+
+	response := out.String()
+
+	assert.Contains(t, response, "test message")
+	assert.Contains(t, response, "[Debug][TestLoggingOrder] test message" )
+	assert.True(t, strings.HasPrefix(response, "[Optimizely]"))
+
 }
 
 func TestSetLogLevel(t *testing.T) {

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -93,6 +94,25 @@ func TestNamedLoggerError(t *testing.T) {
 	logProducer.Error(testLogMessage, err)
 	testLogger.AssertExpectations(t)
 	assert.Equal(t, []string{expectedLogMessage}, testLogger.loggedMessages)
+}
+
+func TestNamedLoggerFields(t *testing.T) {
+	out := &bytes.Buffer{}
+	newLogger := NewFilteredLevelLogConsumer(LogLevelDebug, out)
+
+	SetLogger(newLogger)
+
+	logger := GetLogger("TestNamedLoggerFields-sdkKey", "TestNamedLoggerFields")
+	logger.Debug("test message")
+
+	key := GetSdkKeyLogMapping("TestNamedLoggerFields-sdkKey")
+	assert.Contains(t, out.String(), "test message")
+	assert.Contains(t, out.String(), "[Debug]")
+	assert.Contains(t, out.String(), "[TestNamedLoggerFields]")
+	assert.Contains(t, out.String(), key)
+	assert.NotContains(t, out.String(), "TestNamedLoggerFields-sdkKey")
+	assert.Contains(t, out.String(), "[Optimizely]")
+
 }
 
 func TestSetLogLevel(t *testing.T) {

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -115,6 +115,46 @@ func TestNamedLoggerFields(t *testing.T) {
 
 }
 
+func TestLogSdkKeyOverride(t *testing.T) {
+	out := &bytes.Buffer{}
+	newLogger := NewFilteredLevelLogConsumer(LogLevelDebug, out)
+
+	SetLogger(newLogger)
+
+	key := "test-test-test"
+	SetSdkKeyLogMapping("TestLogOverride-sdkKey", key)
+
+	logger := GetLogger("TestLogOverride-sdkKey", "TestLogSdkKeyOverride")
+	logger.Debug("test message")
+
+	assert.Contains(t, out.String(), "test message")
+	assert.Contains(t, out.String(), "[Debug]")
+	assert.Contains(t, out.String(), "[TestLogSdkKeyOverride]")
+	assert.Contains(t, out.String(), key)
+	assert.NotContains(t, out.String(), "TestNamedLoggerFields-sdkKey")
+	assert.Contains(t, out.String(), "[Optimizely]")
+}
+
+func TestLogSdkKey(t *testing.T) {
+	out := &bytes.Buffer{}
+	newLogger := NewFilteredLevelLogConsumer(LogLevelDebug, out)
+
+	SetLogger(newLogger)
+
+	key := "TestLogSdkKey-sdkKey"
+
+	UseSdkKeyForLogging(key)
+
+	logger := GetLogger(key, "TestLogSdkKeyOverride")
+	logger.Debug("test message")
+
+	assert.Contains(t, out.String(), "test message")
+	assert.Contains(t, out.String(), "[Debug]")
+	assert.Contains(t, out.String(), "[TestLogSdkKeyOverride]")
+	assert.Contains(t, out.String(), key)
+	assert.Contains(t, out.String(), "[Optimizely]")
+}
+
 func TestSetLogLevel(t *testing.T) {
 	testLogger := new(MockOptimizelyLogger)
 	testLogger.On("SetLogLevel", LogLevelError)

--- a/pkg/notification/center.go
+++ b/pkg/notification/center.go
@@ -17,7 +17,10 @@
 // Package notification //
 package notification
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
+)
 
 // Center handles all notification listeners. It keeps track of the Manager for each type of notification.
 type Center interface {
@@ -33,10 +36,10 @@ type DefaultCenter struct {
 
 // NewNotificationCenter returns a new notification center
 func NewNotificationCenter() *DefaultCenter {
-	decisionNotificationManager := NewAtomicManager()
-	projectConfigUpdateNotificationManager := NewAtomicManager()
-	processLogEventNotificationManager := NewAtomicManager()
-	trackNotificationManager := NewAtomicManager()
+	decisionNotificationManager := NewAtomicManager(logging.GetLogger("", "AtomicManager"))
+	projectConfigUpdateNotificationManager := NewAtomicManager(logging.GetLogger("", "AtomicManager"))
+	processLogEventNotificationManager := NewAtomicManager(logging.GetLogger("", "AtomicManager"))
+	trackNotificationManager := NewAtomicManager(logging.GetLogger("", "AtomicManager"))
 	managerMap := make(map[Type]Manager)
 	managerMap[Decision] = decisionNotificationManager
 	managerMap[ProjectConfigUpdate] = projectConfigUpdateNotificationManager

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -19,13 +19,10 @@ package notification
 
 import (
 	"fmt"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 	"sync/atomic"
-
-	"github.com/optimizely/go-sdk/pkg/logging"
 )
-
-var managerLogger = logging.GetLogger("NotificationManager")
 
 // Manager is a generic interface for managing notifications of a particular type
 type Manager interface {
@@ -39,11 +36,13 @@ type AtomicManager struct {
 	handlers map[uint32]func(interface{})
 	counter  uint32
 	lock     sync.RWMutex
+	logger   logging.OptimizelyLogProducer
 }
 
 // NewAtomicManager creates a new instance of the atomic manager
-func NewAtomicManager() *AtomicManager {
+func NewAtomicManager(logger logging.OptimizelyLogProducer) *AtomicManager {
 	return &AtomicManager{
+		logger: logger,
 		handlers: make(map[uint32]func(interface{})),
 	}
 }
@@ -68,7 +67,7 @@ func (am *AtomicManager) Remove(id int) {
 		delete(am.handlers, handlerID)
 		return
 	}
-	managerLogger.Debug(fmt.Sprintf("Handler for id:%d not found", id))
+	am.logger.Debug(fmt.Sprintf("Handler for id:%d not found", id))
 
 }
 

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -19,9 +19,10 @@ package notification
 
 import (
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 	"sync/atomic"
+
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // Manager is a generic interface for managing notifications of a particular type

--- a/pkg/notification/manager_test.go
+++ b/pkg/notification/manager_test.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestAtomicManager(t *testing.T) {
 	mockReceiver.On("handle", payload)
 	mockReceiver.On("handleBetter", payload)
 
-	atomicManager := NewAtomicManager()
+	atomicManager := NewAtomicManager(logging.GetLogger("", ""))
 	result1, _ := atomicManager.Add(mockReceiver.handle)
 	assert.Equal(t, 1, result1)
 
@@ -56,7 +57,7 @@ func TestSendRaceCondition(t *testing.T) {
 	payload := map[string]interface{}{
 		"key": "test",
 	}
-	atomicManager := NewAtomicManager()
+	atomicManager := NewAtomicManager(logging.GetLogger("", ""))
 	result1, result2 := 0, 0
 	listenerCalled := false
 
@@ -89,7 +90,7 @@ func TestSendRaceCondition(t *testing.T) {
 
 func TestAddRaceCondition(t *testing.T) {
 	sync := make(chan interface{})
-	atomicManager := NewAtomicManager()
+	atomicManager := NewAtomicManager(logging.GetLogger("", ""))
 
 	listener1 := func(interface{}) {
 

--- a/pkg/notification/manager_test.go
+++ b/pkg/notification/manager_test.go
@@ -1,8 +1,9 @@
 package notification
 
 import (
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"testing"
+
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/pkg/utils/execgroup.go
+++ b/pkg/utils/execgroup.go
@@ -32,11 +32,11 @@ type ExecGroup struct {
 }
 
 // NewExecGroup returns constructed object
-func NewExecGroup(logger logging.OptimizelyLogProducer, ctx context.Context) *ExecGroup {
+func NewExecGroup(ctx context.Context, logger logging.OptimizelyLogProducer) *ExecGroup {
 	nctx, cancelFn := context.WithCancel(ctx)
 	wg := sync.WaitGroup{}
 
-	return &ExecGroup{wg: &wg, ctx: nctx, cancelFunc: cancelFn}
+	return &ExecGroup{wg: &wg, ctx: nctx, cancelFunc: cancelFn, logger:logger}
 }
 
 // Go initiates a goroutine with the inputted function. Each invocation increments a shared WaitGroup

--- a/pkg/utils/execgroup.go
+++ b/pkg/utils/execgroup.go
@@ -23,17 +23,16 @@ import (
 	"sync"
 )
 
-var logger = logging.GetLogger("ExecGroup")
-
 // ExecGroup is a utility for managing graceful, blocking cancellation of goroutines.
 type ExecGroup struct {
 	wg         *sync.WaitGroup
 	ctx        context.Context
 	cancelFunc context.CancelFunc
+	logger     logging.OptimizelyLogProducer
 }
 
 // NewExecGroup returns constructed object
-func NewExecGroup(ctx context.Context) *ExecGroup {
+func NewExecGroup(logger logging.OptimizelyLogProducer, ctx context.Context) *ExecGroup {
 	nctx, cancelFn := context.WithCancel(ctx)
 	wg := sync.WaitGroup{}
 
@@ -55,7 +54,7 @@ func (c ExecGroup) Go(f func(ctx context.Context)) {
 func (c ExecGroup) TerminateAndWait() {
 
 	if c.cancelFunc == nil {
-		logger.Error("failed to shut down Execution Context properly", nil)
+		c.logger.Error("failed to shut down Execution Context properly", nil)
 		return
 	}
 	c.cancelFunc()

--- a/pkg/utils/execgroup_test.go
+++ b/pkg/utils/execgroup_test.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"context"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"sync"
 	"testing"
 )
@@ -26,7 +27,7 @@ import (
 func TestWithContextCancelFunc(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	eg := NewExecGroup(ctx)
+	eg := NewExecGroup(logging.GetLogger("", ""), ctx)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -41,7 +42,7 @@ func TestWithContextCancelFunc(t *testing.T) {
 
 func TestTerminateAndWait(t *testing.T) {
 
-	eg := NewExecGroup(context.Background())
+	eg := NewExecGroup(logging.GetLogger("", ""), context.Background())
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/utils/execgroup_test.go
+++ b/pkg/utils/execgroup_test.go
@@ -27,7 +27,7 @@ import (
 func TestWithContextCancelFunc(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	eg := NewExecGroup(logging.GetLogger("", ""), ctx)
+	eg := NewExecGroup(ctx, logging.GetLogger("", ""))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -42,7 +42,7 @@ func TestWithContextCancelFunc(t *testing.T) {
 
 func TestTerminateAndWait(t *testing.T) {
 
-	eg := NewExecGroup(logging.GetLogger("", ""), context.Background())
+	eg := NewExecGroup(context.Background(), logging.GetLogger("", ""))
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DATA-DOG/godog"
-	"github.com/DATA-DOG/godog/colors"
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
 	"github.com/optimizely/go-sdk/tests/integration/support"
 )
 

--- a/tests/integration/support/steps.go
+++ b/tests/integration/support/steps.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/optimizely/go-sdk/pkg/decision"
 
-	"github.com/DATA-DOG/godog/gherkin"
+	"github.com/cucumber/gherkin-go"
 	"github.com/google/uuid"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/tests/integration/models"


### PR DESCRIPTION
The sdk key is passed to composite classes and classes that create other objects that require logging.  Small grained classes just accept a logger.  

The logger logs sdk key mapped value by default along with name.
There are setters and getters for the sdk key log mapping.
Added unit test for sdk key in log.

Also updated the travis unit tests from 1.8 to 1.10. and from 1.13 to 1.14.
