### PR TITLE
chore (release): update changelog for release

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.	Changes that have landed but are not yet released.
 
+## [1.1.1] - March 25th, 2020
+## New Features
+- feat: Logging sdk key masked value with every log message.  The masking is by default and can be disabled or set to a custom mapping. [#242](https://github.com/optimizely/go-sdk/pull/242)
+
 ## [1.1.0] - March 6th, 2020
 ## New Features
 - feat: Allow ClientName and Version to be set at compile time. [#227](https://github.com/optimizely/go-sdk/pull/227)

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-var Version = "1.1.0"
+var Version = "1.1.1"
 
 // ClientName is the name of the client
 var ClientName = "go-sdk"


### PR DESCRIPTION
## Summary
Release 1.1.1 with support for logging sdk key (masked by default) included in logs.  This is to handle the situation of multiple projects in one go-sdk instance.