### PR TITLE
feature (multi-rollout): Added support for multiple rollouts.

### DIFF
--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -150,6 +150,48 @@ var testExp1112 = entities.Experiment{
 		entities.Range{EntityID: "2222", EndOfRange: 10000},
 	},
 }
+var testExp1117Var2223 = entities.Variation{ID: "2223", Key: "2223"}
+var testAudience5556 = entities.Audience{ID: "5556"}
+var testExp1117 = entities.Experiment{
+	AudienceConditionTree: &entities.TreeNode{
+		Operator: "and",
+		Nodes: []*entities.TreeNode{
+			&entities.TreeNode{Item: "test_audience_5556"},
+		},
+	},
+	ID:  "1117",
+	Key: testExp1111Key,
+	Variations: map[string]entities.Variation{
+		"2223": testExp1117Var2223,
+	},
+	VariationKeyToIDMap: map[string]string{
+		"2223": "2223",
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2223", EndOfRange: 10000},
+	},
+}
+var testExp1118Var2224 = entities.Variation{ID: "2224", Key: "2224"}
+var testAudience5557 = entities.Audience{ID: "5557"}
+var testExp1118 = entities.Experiment{
+	AudienceConditionTree: &entities.TreeNode{
+		Operator: "and",
+		Nodes: []*entities.TreeNode{
+			&entities.TreeNode{Item: "test_audience_5557"},
+		},
+	},
+	ID:  "1118",
+	Key: testExp1111Key,
+	Variations: map[string]entities.Variation{
+		"2224": testExp1118Var2224,
+	},
+	VariationKeyToIDMap: map[string]string{
+		"2224": "2224",
+	},
+	TrafficAllocation: []entities.Range{
+		entities.Range{EntityID: "2224", EndOfRange: 10000},
+	},
+}
 
 const testFeatRollout3334Key = "test_feature_rollout_3334_key"
 
@@ -158,7 +200,7 @@ var testFeatRollout3334 = entities.Feature{
 	Key: testFeatRollout3334Key,
 	Rollout: entities.Rollout{
 		ID:          "4444",
-		Experiments: []entities.Experiment{testExp1112},
+		Experiments: []entities.Experiment{testExp1112, testExp1117, testExp1118},
 	},
 }
 

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -22,9 +22,8 @@ import (
 
 	"github.com/optimizely/go-sdk/pkg/decision/evaluator"
 	"github.com/optimizely/go-sdk/pkg/decision/reasons"
-	"github.com/optimizely/go-sdk/pkg/logging"
-
 	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/optimizely/go-sdk/pkg/logging"
 )
 
 // RolloutService makes a feature decision for a given feature rollout

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -125,7 +125,6 @@ func (s *RolloutServiceTestSuite) TestGetDecisionHappyPath() {
 }
 
 func (s *RolloutServiceTestSuite) TestGetDecisionFallbacksToLastWhenFailsBucketing() {
-	// Test experiment passes targeting but not bucketing
 	testExperiment1112BucketerDecision := ExperimentDecision{
 		Decision: Decision{
 			Reason: reasons.NotBucketedIntoVariation,
@@ -162,7 +161,6 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFallbacksToLastWhenFailsBucketi
 }
 
 func (s *RolloutServiceTestSuite) TestGetDecisionWhenFallbackBucketingFails() {
-	// Test experiment passes targeting but not bucketing
 	testExperiment1112BucketerDecision := ExperimentDecision{
 		Decision: Decision{
 			Reason: reasons.NotBucketedIntoVariation,

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -65,6 +65,40 @@ func (s *RolloutServiceTestSuite) SetupTest() {
 	s.mockConfig.On("GetAudienceMap").Return(testAudienceMap)
 }
 
+func (s *RolloutServiceTestSuite) TestGetDecisionWithEmptyRolloutID() {
+
+	testRolloutService := RolloutService{}
+	feature := &testFeatRollout3334
+	feature.Rollout.ID = ""
+	featureDecisionContext := FeatureDecisionContext{
+		Feature:       feature,
+		ProjectConfig: s.mockConfig,
+	}
+	expectedFeatureDecision := FeatureDecision{
+		Source:   Rollout,
+		Decision: Decision{Reason: reasons.NoRolloutForFeature},
+	}
+	decision, _ := testRolloutService.GetDecision(featureDecisionContext, s.testUserContext)
+	s.Equal(expectedFeatureDecision, decision)
+}
+
+func (s *RolloutServiceTestSuite) TestGetDecisionWithNoExperiments() {
+
+	testRolloutService := RolloutService{}
+	feature := &testFeatRollout3334
+	feature.Rollout.Experiments = []entities.Experiment{}
+	featureDecisionContext := FeatureDecisionContext{
+		Feature:       feature,
+		ProjectConfig: s.mockConfig,
+	}
+	expectedFeatureDecision := FeatureDecision{
+		Source:   Rollout,
+		Decision: Decision{Reason: reasons.RolloutHasNoExperiments},
+	}
+	decision, _ := testRolloutService.GetDecision(featureDecisionContext, s.testUserContext)
+	s.Equal(expectedFeatureDecision, decision)
+}
+
 func (s *RolloutServiceTestSuite) TestGetDecisionHappyPath() {
 	// Test experiment passes targeting and bucketing
 	testExperimentBucketerDecision := ExperimentDecision{


### PR DESCRIPTION
## Summary
Added support for multiple rollouts in `rollout_service`, this includes:
- Evaluating next available experiment if audience evaluation fails for previous.
- Falling back to the last experiment evaluation if bucketing fails for any of the experiments.