### PR TITLE
fix: fix getValue on optimizelyJson built from a map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
         - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
-        - pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
+        - mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
         - go get -v -d ./...
         # This pkg not in go 1.10
         - go get github.com/stretchr/testify

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ jobs:
         - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
         - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
         - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
+        - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
+        - pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
         - go get -v -d ./...
         # This pkg not in go 1.10
         - go get github.com/stretchr/testify

--- a/pkg/optimizelyjson/optimizely_json.go
+++ b/pkg/optimizelyjson/optimizely_json.go
@@ -79,7 +79,10 @@ func (optlyJson *OptimizelyJSON) GetValue(jsonPath string, schema interface{}) e
 	}
 
 	if jsonPath == "" { // populate the whole schema
-		return json.Unmarshal([]byte(optlyJson.payload), schema)
+		if optlyJson.payload != "" {
+			return json.Unmarshal([]byte(optlyJson.payload), schema)
+		}
+		return populateSchema(optlyJson.data)
 	}
 
 	splitJSONPath := strings.Split(jsonPath, ".")

--- a/pkg/optimizelyjson/optimizely_json_test.go
+++ b/pkg/optimizelyjson/optimizely_json_test.go
@@ -193,6 +193,12 @@ func (suite *OptimizelyJsonTestSuite) TestGetValueEmptyJsonKeyWholeSchema() {
 		Field6: nil,
 	}
 	suite.Equal(expected, sc)
+
+	sc = schema{}
+	optimizelyJsonFromMap := NewOptimizelyJSONfromMap(suite.data)
+	err = optimizelyJsonFromMap.GetValue("", &sc)
+	suite.NoError(err)
+	suite.Equal(expected, sc)
 }
 
 func (suite *OptimizelyJsonTestSuite) TestGetValueValidJsonKeyPartialSchema() {

--- a/pkg/optimizelyjson/optimizely_json_test.go
+++ b/pkg/optimizelyjson/optimizely_json_test.go
@@ -219,7 +219,14 @@ func (suite *OptimizelyJsonTestSuite) TestGetValueValidJsonKeyPartialSchema() {
 	suite.Equal(expected, sc)
 
 	// check if it does not destroy original object
+	sc = schema{}
 	err = suite.optimizelyJson.GetValue("field4", &sc)
+	suite.NoError(err)
+	suite.Equal(expected, sc)
+
+	sc = schema{}
+	optimizelyJsonFromMap := NewOptimizelyJSONfromMap(suite.data)
+	err = optimizelyJsonFromMap.GetValue("field4", &sc)
 	suite.NoError(err)
 	suite.Equal(expected, sc)
 }


### PR DESCRIPTION
## Summary
- fixing a bug for getValue: when optimizleyJSON was built from a map, then getValue did not parse correctly with empty json_path