### PR TITLE
add readme-sync integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDKS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,8 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        #- mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; done; popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,4 +123,4 @@ jobs:
       script:
         # we need to be in $TRAVIS_BUILD_DIR in order to run the following git diff properly
         - cd $TRAVIS_BUILD_DIR
-        - git diff --quiet $TRAVIS_COMMIT_RANGE -- docs/ || ( cd $HOME/readme-sync2 && npx ts-node sync/index.ts --apiKey $README_SYNC_API_KEY --version 4.0 --docs docs/readme-sync/ )
+        - git diff --quiet $TRAVIS_COMMIT_RANGE -- docs/readme-sync || ( cd $HOME/readme-sync2 && npx ts-node sync/index.ts --apiKey $README_SYNC_API_KEY --version 4.0 --docs docs/readme-sync/ )

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,7 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        #- mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; done && popd
-        - pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ls -al $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; ( [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i ) || true; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,9 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        #- mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; done && popd
+        - pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do ls -al $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,88 +13,88 @@ stages:
   - 'Integration tests'
   - 'Source clear'
 jobs:
-#  include:
+  include:
+    - stage: 'Lint markdown files'
+      os: linux
+      language: generic
+      install: gem install awesome_bot
+      script:
+        - find . -type f -name '*.md' -exec awesome_bot {} \;
+
 #    - stage: 'Lint markdown files'
 #      os: linux
 #      language: generic
-#      install: gem install awesome_bot
-#      script:
-#        - find . -type f -name '*.md' -exec awesome_bot {} \;
-#
-##    - stage: 'Lint markdown files'
-##      os: linux
-##      language: generic
-##      before_install: skip
-##      install:
-##        - npm i -g markdown-spellcheck
-##      before_script:
-##        - wget --quiet https://raw.githubusercontent.com/optimizely/mdspell-config/master/.spelling
-##      script:
-##        - mdspell -a -n -r --en-us '**/*.md'
-##      after_success: skip
-#
-#    - stage: 'Lint'
-#      env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
-#      script:
-#        - make install lint
-#
-#    - &test
-#      stage: 'Unit test'
-#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-#      script:
-#        - make cover
-#
-#    - <<: *test
-#      stage: 'Unit test'
-#      env: GIMME_GO_VERSION=1.10.x
+#      before_install: skip
+#      install:
+#        - npm i -g markdown-spellcheck
 #      before_script:
-#        # GO module was not introduced earlier. need symlink to search in GOPATH
-#        - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
+#        - wget --quiet https://raw.githubusercontent.com/optimizely/mdspell-config/master/.spelling
 #      script:
-#        # Need to download packages explicitly
-#        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
-#        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
-#        - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
-#        - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
-#        - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
-#        - mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
-#        - go get -v -d ./...
-#        # This pkg not in go 1.10
-#        - go get github.com/stretchr/testify
-#        - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-#        # -coverprofile was not introduced in 1.10
-#        - make test
-#
-#    - <<: *test
-#      stage: 'Unit test'
-#      env: GIMME_GO_VERSION=1.14.x
-#      before_script:
-#        - go get github.com/mattn/goveralls
-#      after_success:
-#        - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
-#
-#    - stage: 'Benchmark test'
-#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-#      script:
-#        - make benchmark
-#
-#    - stage: 'Integration tests'
-#      env: SDK=go SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-#      cache: false
-#      language: minimal
-#      install: skip
-#      before_script:
-#        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
-#      script:
-#        - $HOME/travisci-tools/trigger-script-with-status-update.sh
-#      after_success: travis_terminate 0
-#    
-#    - stage: 'Source clear'
-#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-#      language: go
-#      addons:
-#        srcclr: true
-#      script: go get -v -d ./...
+#        - mdspell -a -n -r --en-us '**/*.md'
+#      after_success: skip
+
+    - stage: 'Lint'
+      env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
+      script:
+        - make install lint
+
+    - &test
+      stage: 'Unit test'
+      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+      script:
+        - make cover
+
+    - <<: *test
+      stage: 'Unit test'
+      env: GIMME_GO_VERSION=1.10.x
+      before_script:
+        # GO module was not introduced earlier. need symlink to search in GOPATH
+        - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
+      script:
+        # Need to download packages explicitly
+        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
+        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
+        - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
+        - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
+        - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
+        - mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
+        - go get -v -d ./...
+        # This pkg not in go 1.10
+        - go get github.com/stretchr/testify
+        - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
+        # -coverprofile was not introduced in 1.10
+        - make test
+
+    - <<: *test
+      stage: 'Unit test'
+      env: GIMME_GO_VERSION=1.14.x
+      before_script:
+        - go get github.com/mattn/goveralls
+      after_success:
+        - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
+
+    - stage: 'Benchmark test'
+      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+      script:
+        - make benchmark
+
+    - stage: 'Integration tests'
+      env: SDK=go SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+      cache: false
+      language: minimal
+      install: skip
+      before_script:
+        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
+      script:
+        - $HOME/travisci-tools/trigger-script-with-status-update.sh
+      after_success: travis_terminate 0
+    
+    - stage: 'Source clear'
+      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+      language: go
+      addons:
+        srcclr: true
+      script: go get -v -d ./...
 
     - stage: 'Readme-sync'
       name: 'run script if changes are detected in docs/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ git:
 install:
   - eval "$(gimme)"
 stages:
-  - 'Readme-sync'
   - 'Lint markdown files'
   - 'Lint'
   - 'Unit test'
   - 'Benchmark test'  
   - 'Integration tests'
   - 'Source clear'
+  - 'Readme-sync'
 jobs:
   include:
     - stage: 'Lint markdown files'
@@ -101,7 +101,7 @@ jobs:
       cache: false
 
       # translation: if we're merging into master branch...
-      #if: type = push AND branch = master
+      if: type = push AND branch = master
 
       language: node_js
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,15 @@ jobs:
         - mkdir -p $HOME/readme-sync2/docs/sdk-reference-guides
         # ${TRAVIS_REPO_SLUG#optimizely/} translates to go-sdk
         - ln -s $TRAVIS_BUILD_DIR/docs $HOME/readme-sync2/docs/sdk-reference-guides/${TRAVIS_REPO_SLUG#optimizely/}
+
+        # now we need to get all the other *-sdk repos too
+        #
+        # first we list all possible sdks and inside the for loop, remove the one we are updating
+        - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDKS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs" ] && ln -s $i/docs $HOME/readme-sync2/docs/sdk-reference-guides/$i;  done && popd
+        # check our work
+        - ls -al $HOME/sdks
+        - ls -al $HOME/readme-sync2/docs/sdk-reference-guides
       script:
         # we need to be in $TRAVIS_BUILD_DIR in order to run the following git diff properly
         - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,8 +116,7 @@ jobs:
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        #- mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; done; popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ jobs:
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
         #- mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ln -s $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
         - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; done && popd
-        - pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do ls -al $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i; done && popd
+        - pushd $HOME/sdks && for i in ${ALL_SDK_REPOS//${TRAVIS_REPO_SLUG#optimizely/}}; do [ -d "$HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i" ] && ls -al $HOME/sdks/$i/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
         - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,19 +108,19 @@ jobs:
         - mkdir $HOME/readme-sync2 && pushd $HOME/readme-sync2 && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/readme-sync2.git && popd
         - source ~/.nvm/nvm.sh && cd $HOME/readme-sync2 && nvm install && npm install
         # this preps the input directory for readme-sync script
-        - mkdir -p $HOME/readme-sync2/docs/sdk-reference-guides
-        # ${TRAVIS_REPO_SLUG#optimizely/} translates to go-sdk
-        - ln -s $TRAVIS_BUILD_DIR/docs $HOME/readme-sync2/docs/sdk-reference-guides/${TRAVIS_REPO_SLUG#optimizely/}
+        - mkdir -p $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides
+        # ${TRAVIS_REPO_SLUG#optimizely/} translates to go-sdk docs/readme-sync/sdk-reference-guides/go-sdk
+        - ln -s $TRAVIS_BUILD_DIR/docs/readme-sync/sdk-reference-guides/${TRAVIS_REPO_SLUG#optimizely/} $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/${TRAVIS_REPO_SLUG#optimizely/}
 
         # now we need to get all the other *-sdk repos too
         #
         # first we list all possible sdks and inside the for loop, remove the one we are updating
         - export ALL_SDK_REPOS="android-sdk csharp-sdk go-sdk java-sdk javascript-sdk objective-c-sdk python-sdk react-sdk ruby-sdk swift-sdk"
-        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDKS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs" ] && ln -s $i/docs $HOME/readme-sync2/docs/sdk-reference-guides/$i;  done && popd
+        - mkdir $HOME/sdks && pushd $HOME/sdks && for i in ${ALL_SDKS//${TRAVIS_REPO_SLUG#optimizely/}}; do git clone https://github.com/optimizely/$i; [ -d "$i/docs/readme-sync" ] && ln -s $i/docs/readme-sync/sdk-reference-guides/$i $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides/$i; done && popd
         # check our work
         - ls -al $HOME/sdks
-        - ls -al $HOME/readme-sync2/docs/sdk-reference-guides
+        - ls -al $HOME/readme-sync2/docs/readme-sync/sdk-reference-guides
       script:
         # we need to be in $TRAVIS_BUILD_DIR in order to run the following git diff properly
         - cd $TRAVIS_BUILD_DIR
-        - git diff --quiet $TRAVIS_COMMIT_RANGE -- docs/ || ( cd $HOME/readme-sync2 && npx ts-node sync/index.ts --apiKey $README_SYNC_API_KEY --version 4.0 --docs docs/ )
+        - git diff --quiet $TRAVIS_COMMIT_RANGE -- docs/ || ( cd $HOME/readme-sync2 && npx ts-node sync/index.ts --apiKey $README_SYNC_API_KEY --version 4.0 --docs docs/readme-sync/ )

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: minimal
 env: GO111MODULE=on
 git:
-  depth: 1
+  depth: false
 install:
   - eval "$(gimme)"
 stages:
-  - name: 'Lint markdown files'
+  - 'Readme-sync'
+  - 'Lint markdown files'
   - 'Lint'
   - 'Unit test'
   - 'Benchmark test'  
@@ -19,8 +20,6 @@ jobs:
       install: gem install awesome_bot
       script:
         - find . -type f -name '*.md' -exec awesome_bot {} \;
-      notifications:
-        email: false
 
 #    - stage: 'Lint markdown files'
 #      os: linux
@@ -96,3 +95,23 @@ jobs:
       addons:
         srcclr: true
       script: go get -v -d ./...
+
+    - stage: 'Readme-sync'
+      name: 'run script if changes are detected in docs/'
+      cache: false
+
+      # translation: if we're merging into master branch...
+      if: type = push AND branch = master
+
+      language: node_js
+      install:
+        - mkdir $HOME/readme-sync2 && pushd $HOME/readme-sync2 && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/readme-sync2.git && popd
+        - source ~/.nvm/nvm.sh && cd $HOME/readme-sync2 && nvm install && npm install
+        # this preps the input directory for readme-sync script
+        - mkdir -p $HOME/readme-sync2/docs/sdk-reference-guides
+        # ${TRAVIS_REPO_SLUG#optimizely/} translates to go-sdk
+        - ln -s $TRAVIS_BUILD_DIR/docs $HOME/readme-sync2/docs/sdk-reference-guides/${TRAVIS_REPO_SLUG#optimizely/}
+      script:
+        # we need to be in $TRAVIS_BUILD_DIR in order to run the following git diff properly
+        - cd $TRAVIS_BUILD_DIR
+        - git diff --quiet $TRAVIS_COMMIT_RANGE -- docs/ || ( cd $HOME/readme-sync2 && npx ts-node sync/index.ts --apiKey $README_SYNC_API_KEY --version 4.0 --docs docs/ )

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,95 +13,95 @@ stages:
   - 'Integration tests'
   - 'Source clear'
 jobs:
-  include:
-    - stage: 'Lint markdown files'
-      os: linux
-      language: generic
-      install: gem install awesome_bot
-      script:
-        - find . -type f -name '*.md' -exec awesome_bot {} \;
-
+#  include:
 #    - stage: 'Lint markdown files'
 #      os: linux
 #      language: generic
-#      before_install: skip
-#      install:
-#        - npm i -g markdown-spellcheck
-#      before_script:
-#        - wget --quiet https://raw.githubusercontent.com/optimizely/mdspell-config/master/.spelling
+#      install: gem install awesome_bot
 #      script:
-#        - mdspell -a -n -r --en-us '**/*.md'
-#      after_success: skip
-
-    - stage: 'Lint'
-      env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
-      script:
-        - make install lint
-
-    - &test
-      stage: 'Unit test'
-      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-      script:
-        - make cover
-
-    - <<: *test
-      stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.10.x
-      before_script:
-        # GO module was not introduced earlier. need symlink to search in GOPATH
-        - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
-      script:
-        # Need to download packages explicitly
-        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
-        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
-        - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
-        - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
-        - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
-        - mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
-        - go get -v -d ./...
-        # This pkg not in go 1.10
-        - go get github.com/stretchr/testify
-        - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        # -coverprofile was not introduced in 1.10
-        - make test
-
-    - <<: *test
-      stage: 'Unit test'
-      env: GIMME_GO_VERSION=1.14.x
-      before_script:
-        - go get github.com/mattn/goveralls
-      after_success:
-        - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
-
-    - stage: 'Benchmark test'
-      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-      script:
-        - make benchmark
-
-    - stage: 'Integration tests'
-      env: SDK=go SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-      cache: false
-      language: minimal
-      install: skip
-      before_script:
-        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
-      script:
-        - $HOME/travisci-tools/trigger-script-with-status-update.sh
-      after_success: travis_terminate 0
-    
-    - stage: 'Source clear'
-      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
-      language: go
-      addons:
-        srcclr: true
-      script: go get -v -d ./...
+#        - find . -type f -name '*.md' -exec awesome_bot {} \;
+#
+##    - stage: 'Lint markdown files'
+##      os: linux
+##      language: generic
+##      before_install: skip
+##      install:
+##        - npm i -g markdown-spellcheck
+##      before_script:
+##        - wget --quiet https://raw.githubusercontent.com/optimizely/mdspell-config/master/.spelling
+##      script:
+##        - mdspell -a -n -r --en-us '**/*.md'
+##      after_success: skip
+#
+#    - stage: 'Lint'
+#      env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
+#      script:
+#        - make install lint
+#
+#    - &test
+#      stage: 'Unit test'
+#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+#      script:
+#        - make cover
+#
+#    - <<: *test
+#      stage: 'Unit test'
+#      env: GIMME_GO_VERSION=1.10.x
+#      before_script:
+#        # GO module was not introduced earlier. need symlink to search in GOPATH
+#        - mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $HOME/build/optimizely optimizely && popd
+#      script:
+#        # Need to download packages explicitly
+#        - mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $TRAVIS_BUILD_DIR
+#        - pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
+#        - mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $TRAVIS_BUILD_DIR
+#        - pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
+#        - mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $TRAVIS_BUILD_DIR
+#        - mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
+#        - go get -v -d ./...
+#        # This pkg not in go 1.10
+#        - go get github.com/stretchr/testify
+#        - pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
+#        # -coverprofile was not introduced in 1.10
+#        - make test
+#
+#    - <<: *test
+#      stage: 'Unit test'
+#      env: GIMME_GO_VERSION=1.14.x
+#      before_script:
+#        - go get github.com/mattn/goveralls
+#      after_success:
+#        - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
+#
+#    - stage: 'Benchmark test'
+#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+#      script:
+#        - make benchmark
+#
+#    - stage: 'Integration tests'
+#      env: SDK=go SDK_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+#      cache: false
+#      language: minimal
+#      install: skip
+#      before_script:
+#        - mkdir $HOME/travisci-tools && pushd $HOME/travisci-tools && git init && git pull https://$CI_USER_TOKEN@github.com/optimizely/travisci-tools.git && popd
+#      script:
+#        - $HOME/travisci-tools/trigger-script-with-status-update.sh
+#      after_success: travis_terminate 0
+#    
+#    - stage: 'Source clear'
+#      env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
+#      language: go
+#      addons:
+#        srcclr: true
+#      script: go get -v -d ./...
 
     - stage: 'Readme-sync'
       name: 'run script if changes are detected in docs/'
       cache: false
 
       # translation: if we're merging into master branch...
-      if: type = push AND branch = master
+      #if: type = push AND branch = master
 
       language: node_js
       install:

--- a/docs/readme-sync/sdk-reference-guides/go-sdk/010 - install-sdk-go.md
+++ b/docs/readme-sync/sdk-reference-guides/go-sdk/010 - install-sdk-go.md
@@ -1,5 +1,5 @@
 ---
-title: "Install SDK"
+title: "aInstall SDK"
 excerpt: ""
 slug: "install-sdk-go"
 hidden: false

--- a/docs/readme-sync/sdk-reference-guides/go-sdk/010 - install-sdk-go.md
+++ b/docs/readme-sync/sdk-reference-guides/go-sdk/010 - install-sdk-go.md
@@ -1,5 +1,5 @@
 ---
-title: "aInstall SDK"
+title: "Install SDK"
 excerpt: ""
 slug: "install-sdk-go"
 hidden: false


### PR DESCRIPTION
@fscelliott i significantly improved our original PoC for readme-sync integration, now instead of triggering builds in external repos, i bring the readme-sync2 repo to the go-sdk build and run everything locally. ie. we are no longer dependant on the script/run_readme_sync.sh script (in readme-sync2) anymore, we can just get rid of that.

this change makes it a lot more robust since it has many fewer moving parts and it's actually faster because we end up cloning a lot less stuff.

one important thing to note is that this stage will only work if the docs/ directory (and the markdown files inside) are already existing in the repo so some other PR that adds these will need to be merged ahead of this PR.