### PR TITLE
chore: Prepare 1.2.0 release.

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.	Changes that have landed but are not yet released.
 
+## [1.2.0] - May 21st, 2020
+## New Features
+- feat: support for multi-rule rollouts [#247](https://github.com/optimizely/go-sdk/pull/247)
+
 ## [1.1.3] - April 22th, 2020
 ## Bug Fix
 - logger not set for httpDispatcher [#254](https://github.com/optimizely/go-sdk/pull/254)

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-var Version = "1.1.3"
+var Version = "1.2.0"
 
 // ClientName is the name of the client
 var ClientName = "go-sdk"


### PR DESCRIPTION
# Summary
- Release 1.2.0 with support for Multi-rule rollout
- Will create a tag `v1.2.0` from `v.1.1.3` and cherry-pick #247 and the commit from this PR