### PR TITLE
feat: added authenticated datafile support

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -51,10 +51,10 @@ type OptimizelyFactory struct {
 type OptionFunc func(*OptimizelyFactory)
 
 // Client instantiates a new OptimizelyClient with the given options.
-func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClient, error) {
+func (f *OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClient, error) {
 	// extract options
 	for _, opt := range clientOptions {
-		opt(&f)
+		opt(f)
 	}
 
 	if f.SDKKey == "" && f.Datafile == nil && f.configManager == nil {
@@ -218,7 +218,7 @@ func WithMetricsRegistry(metricsRegistry metrics.Registry) OptionFunc {
 }
 
 // StaticClient returns a client initialized with a static project config.
-func (f OptimizelyFactory) StaticClient() (optlyClient *OptimizelyClient, err error) {
+func (f *OptimizelyFactory) StaticClient() (optlyClient *OptimizelyClient, err error) {
 
 	staticManager := config.NewStaticProjectConfigManager(f.SDKKey, config.WithInitialDatafile(f.Datafile), config.WithDatafileAccessToken(f.DatafileAccessToken))
 

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -33,8 +33,9 @@ import (
 
 // OptimizelyFactory is used to customize and construct an instance of the OptimizelyClient.
 type OptimizelyFactory struct {
-	SDKKey   string
-	Datafile []byte
+	SDKKey            string
+	Datafile          []byte
+	AuthDatafileToken string
 
 	configManager      config.ProjectConfigManager
 	ctx                context.Context
@@ -85,6 +86,7 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 		appClient.ConfigManager = config.NewPollingProjectConfigManager(
 			f.SDKKey,
 			config.WithInitialDatafile(f.Datafile),
+			config.WithAuthDatafileToken(f.AuthDatafileToken),
 		)
 	}
 
@@ -128,11 +130,26 @@ func (f OptimizelyFactory) Client(clientOptions ...OptionFunc) (*OptimizelyClien
 	return appClient, nil
 }
 
+// WithAuthDatafileToken sets authenticated datafile token
+func WithAuthDatafileToken(authDatafileToken string) OptionFunc {
+	return func(f *OptimizelyFactory) {
+		f.AuthDatafileToken = authDatafileToken
+	}
+}
+
 // WithPollingConfigManager sets polling config manager on a client.
 func WithPollingConfigManager(pollingInterval time.Duration, initDataFile []byte) OptionFunc {
 	return func(f *OptimizelyFactory) {
 		f.configManager = config.NewPollingProjectConfigManager(f.SDKKey, config.WithInitialDatafile(initDataFile),
 			config.WithPollingInterval(pollingInterval))
+	}
+}
+
+// WithAuthDatafilePollingConfigManager sets polling config manager with auth datafile token on a client
+func WithAuthDatafilePollingConfigManager(pollingInterval time.Duration, initDataFile []byte, authDatafileToken string) OptionFunc {
+	return func(f *OptimizelyFactory) {
+		f.configManager = config.NewPollingProjectConfigManager(f.SDKKey, config.WithInitialDatafile(initDataFile),
+			config.WithPollingInterval(pollingInterval), config.WithAuthDatafileToken(authDatafileToken))
 	}
 }
 
@@ -201,11 +218,13 @@ func WithMetricsRegistry(metricsRegistry metrics.Registry) OptionFunc {
 }
 
 // StaticClient returns a client initialized with a static project config.
-func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
+func (f OptimizelyFactory) StaticClient() (optlyClient *OptimizelyClient, err error) {
 	var configManager config.ProjectConfigManager
+	var staticConfigManager *config.StaticProjectConfigManager
 
 	if f.SDKKey != "" {
-		staticConfigManager, err := config.NewStaticProjectConfigManagerFromURL(f.SDKKey)
+
+		staticConfigManager, err = config.NewAuthDatafileStaticProjectConfigManagerFromURL(f.SDKKey, f.AuthDatafileToken)
 
 		if err != nil {
 			return nil, err
@@ -214,7 +233,7 @@ func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 		configManager = staticConfigManager
 
 	} else if f.Datafile != nil {
-		staticConfigManager, err := config.NewStaticProjectConfigManagerFromPayload(f.Datafile, logging.GetLogger(f.SDKKey, "StaticProjectConfigManagerFromPayload"))
+		staticConfigManager, err = config.NewStaticProjectConfigManagerFromPayload(f.Datafile, logging.GetLogger(f.SDKKey, "StaticProjectConfigManagerFromPayload"))
 
 		if err != nil {
 			return nil, err
@@ -223,10 +242,10 @@ func (f OptimizelyFactory) StaticClient() (*OptimizelyClient, error) {
 		configManager = staticConfigManager
 	}
 
-	optlyClient, e := f.Client(
+	optlyClient, err = f.Client(
 		WithConfigManager(configManager),
 		WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval),
 	)
 
-	return optlyClient, e
+	return optlyClient, err
 }

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -192,10 +192,12 @@ func TestClientMetrics(t *testing.T) {
 
 func TestClientWithDatafileAccessToken(t *testing.T) {
 	factory := OptimizelyFactory{SDKKey: "1212"}
-
-	optimizelyClient, err := factory.Client(WithDatafileAccessToken("some_token"))
+	accessToken := "some_token"
+	optimizelyClient, err := factory.Client(WithDatafileAccessToken(accessToken))
 	assert.NoError(t, err)
 	assert.NotNil(t, optimizelyClient.ConfigManager)
 	assert.NotNil(t, optimizelyClient.DecisionService)
 	assert.NotNil(t, optimizelyClient.EventProcessor)
+
+	assert.Equal(t, accessToken, factory.DatafileAccessToken)
 }

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"io/ioutil"
 	"testing"
 
@@ -51,10 +50,7 @@ func (s *OptimizelyConfigTestSuite) SetupTest() {
 		s.Fail("error opening file " + dataFileName)
 	}
 
-	projectMgr, err := NewStaticProjectConfigManagerFromPayload(dataFile, logging.GetLogger("", "NewStaticProjectConfigManagerFromPayload"))
-	if err != nil {
-		s.Fail("error creating project manager")
-	}
+	projectMgr := NewStaticProjectConfigManager("", WithInitialDatafile(dataFile))
 
 	s.projectConfig = projectMgr.projectConfig
 

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -194,7 +194,7 @@ func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
 	}
 }
 
-func (cm *PollingProjectConfigManager) setADRequest() {
+func (cm *PollingProjectConfigManager) setAuthDatafileRequest() {
 	if cm.authDatafileToken != "" {
 		headers := []utils.Header{{Name: "Content-Type", Value: "application/json"}, {Name: "Accept", Value: "application/json"}}
 		headers = append(headers, utils.Header{Name: "Authorization", Value: "Bearer " + cm.authDatafileToken})
@@ -217,7 +217,7 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 	for _, opt := range pollingMangerOptions {
 		opt(&pollingProjectConfigManager)
 	}
-	pollingProjectConfigManager.setADRequest()
+	pollingProjectConfigManager.setAuthDatafileRequest()
 	if len(pollingProjectConfigManager.initDatafile) > 0 {
 		pollingProjectConfigManager.setInitialDatafile(pollingProjectConfigManager.initDatafile)
 	} else {
@@ -242,7 +242,7 @@ func NewAsyncPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...
 		opt(&pollingProjectConfigManager)
 	}
 
-	pollingProjectConfigManager.setADRequest()
+	pollingProjectConfigManager.setAuthDatafileRequest()
 	pollingProjectConfigManager.setInitialDatafile(pollingProjectConfigManager.initDatafile)
 	return &pollingProjectConfigManager
 }

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -46,7 +46,7 @@ const LastModified = "Last-Modified"
 const DatafileURLTemplate = "https://cdn.optimizely.com/datafiles/%s.json"
 
 // AuthDatafileURLTemplate is used to construct the endpoint for retrieving authenticated datafile from the CDN
-const AuthDatafileURLTemplate = "https://www.optimizely-cdn.com/datafiles/auth/%s.json"
+const AuthDatafileURLTemplate = "https://config.optimizely.com/datafiles/auth/%s.json"
 
 // Err403Forbidden is 403Forbidden specific error
 var Err403Forbidden = errors.New("unable to fetch fresh datafile (consider rechecking SDK key), status code: 403 Forbidden")
@@ -197,7 +197,7 @@ func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
 	}
 }
 
-func (cm *PollingProjectConfigManager) setDatafileAccessTokenRequest() {
+func (cm *PollingProjectConfigManager) setAuthHeaderIfDatafileAccessTokenPresent() {
 	if cm.datafileAccessToken != "" {
 		headers := []utils.Header{{Name: "Content-Type", Value: "application/json"}, {Name: "Accept", Value: "application/json"}}
 		headers = append(headers, utils.Header{Name: "Authorization", Value: "Bearer " + cm.datafileAccessToken})
@@ -225,7 +225,7 @@ func newConfigManager(sdkKey string, logger logging.OptimizelyLogProducer, confi
 			pollingProjectConfigManager.datafileURLTemplate = DatafileURLTemplate
 		}
 	}
-	pollingProjectConfigManager.setDatafileAccessTokenRequest()
+	pollingProjectConfigManager.setAuthHeaderIfDatafileAccessTokenPresent()
 	return &pollingProjectConfigManager
 }
 
@@ -246,8 +246,9 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 func NewAsyncPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...OptionFunc) *PollingProjectConfigManager {
 
 	pollingProjectConfigManager := newConfigManager(sdkKey, logging.GetLogger(sdkKey, "PollingProjectConfigManager"), pollingMangerOptions...)
-	pollingProjectConfigManager.setInitialDatafile(pollingProjectConfigManager.initDatafile)
-
+	if len(pollingProjectConfigManager.initDatafile) > 0 {
+		pollingProjectConfigManager.setInitialDatafile(pollingProjectConfigManager.initDatafile)
+	}
 	return pollingProjectConfigManager
 }
 

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -105,7 +105,6 @@ func WithInitialDatafile(datafile []byte) OptionFunc {
 func WithAuthDatafileToken(authDatafileToken string) OptionFunc {
 	return func(p *PollingProjectConfigManager) {
 		p.authDatafileToken = authDatafileToken
-		p.datafileURLTemplate = AuthDatafileURLTemplate
 	}
 }
 
@@ -206,17 +205,25 @@ func (cm *PollingProjectConfigManager) setAuthDatafileRequest() {
 func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...OptionFunc) *PollingProjectConfigManager {
 
 	pollingProjectConfigManager := PollingProjectConfigManager{
-		notificationCenter:  registry.GetNotificationCenter(sdkKey),
-		pollingInterval:     DefaultPollingInterval,
-		requester:           utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester")),
-		datafileURLTemplate: DatafileURLTemplate,
-		sdkKey:              sdkKey,
-		logger:              logging.GetLogger(sdkKey, "PollingProjectConfigManager"),
+		notificationCenter: registry.GetNotificationCenter(sdkKey),
+		pollingInterval:    DefaultPollingInterval,
+		requester:          utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester")),
+		sdkKey:             sdkKey,
+		logger:             logging.GetLogger(sdkKey, "PollingProjectConfigManager"),
 	}
 
 	for _, opt := range pollingMangerOptions {
 		opt(&pollingProjectConfigManager)
 	}
+
+	if pollingProjectConfigManager.datafileURLTemplate == "" {
+		if pollingProjectConfigManager.authDatafileToken != "" {
+			pollingProjectConfigManager.datafileURLTemplate = AuthDatafileURLTemplate
+		} else {
+			pollingProjectConfigManager.datafileURLTemplate = DatafileURLTemplate
+		}
+	}
+
 	pollingProjectConfigManager.setAuthDatafileRequest()
 	if len(pollingProjectConfigManager.initDatafile) > 0 {
 		pollingProjectConfigManager.setInitialDatafile(pollingProjectConfigManager.initDatafile)
@@ -230,16 +237,23 @@ func NewPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...Optio
 func NewAsyncPollingProjectConfigManager(sdkKey string, pollingMangerOptions ...OptionFunc) *PollingProjectConfigManager {
 
 	pollingProjectConfigManager := PollingProjectConfigManager{
-		notificationCenter:  registry.GetNotificationCenter(sdkKey),
-		pollingInterval:     DefaultPollingInterval,
-		requester:           utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester")),
-		datafileURLTemplate: DatafileURLTemplate,
-		sdkKey:              sdkKey,
-		logger:              logging.GetLogger(sdkKey, "PollingProjectConfigManager"),
+		notificationCenter: registry.GetNotificationCenter(sdkKey),
+		pollingInterval:    DefaultPollingInterval,
+		requester:          utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester")),
+		sdkKey:             sdkKey,
+		logger:             logging.GetLogger(sdkKey, "PollingProjectConfigManager"),
 	}
 
 	for _, opt := range pollingMangerOptions {
 		opt(&pollingProjectConfigManager)
+	}
+
+	if pollingProjectConfigManager.datafileURLTemplate == "" {
+		if pollingProjectConfigManager.authDatafileToken != "" {
+			pollingProjectConfigManager.datafileURLTemplate = AuthDatafileURLTemplate
+		} else {
+			pollingProjectConfigManager.datafileURLTemplate = DatafileURLTemplate
+		}
 	}
 
 	pollingProjectConfigManager.setAuthDatafileRequest()

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -101,7 +101,7 @@ func WithInitialDatafile(datafile []byte) OptionFunc {
 	}
 }
 
-// WithDatafileAccessToken is an optional function, sets a passed datafile
+// WithDatafileAccessToken is an optional function, sets a passed datafile access token
 func WithDatafileAccessToken(datafileAccessToken string) OptionFunc {
 	return func(p *PollingProjectConfigManager) {
 		p.datafileAccessToken = datafileAccessToken

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -63,7 +63,6 @@ type PollingProjectConfigManager struct {
 	sdkKey              string
 	logger              logging.OptimizelyLogProducer
 	authDatafileToken   string
-	UUID                string
 
 	configLock       sync.RWMutex
 	err              error

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -670,8 +670,8 @@ func TestSetDatafileAccessTokenRequest(t *testing.T) {
 	assert.Equal(t, configManagerRequester, configManager.requester)
 	assert.Equal(t, asyncConfigManagerRequester, asyncConfigManager.requester)
 
-	configManager.setDatafileAccessTokenRequest()
-	asyncConfigManager.setDatafileAccessTokenRequest()
+	configManager.setAuthHeaderIfDatafileAccessTokenPresent()
+	asyncConfigManager.setAuthHeaderIfDatafileAccessTokenPresent()
 
 	// modified requester check
 	assert.NotEqual(t, configManagerRequester, configManager.requester)

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -626,3 +626,54 @@ func TestWithRequester(t *testing.T) {
 	assert.Equal(t, mockRequester, configManager.requester)
 	assert.Equal(t, mockRequester, asyncConfigManager.requester)
 }
+
+func TestWithDatafileAccessToken(t *testing.T) {
+
+	sdkKey := "test_sdk_key"
+	datafileAccessToken := "some_token"
+	configManager := NewPollingProjectConfigManager(sdkKey, WithDatafileAccessToken(datafileAccessToken))
+	asyncConfigManager := NewAsyncPollingProjectConfigManager(sdkKey, WithDatafileAccessToken(datafileAccessToken))
+
+	assert.Equal(t, datafileAccessToken, configManager.datafileAccessToken)
+	assert.Equal(t, datafileAccessToken, asyncConfigManager.datafileAccessToken)
+	assert.Equal(t, AuthDatafileURLTemplate, configManager.datafileURLTemplate)
+	assert.Equal(t, AuthDatafileURLTemplate, asyncConfigManager.datafileURLTemplate)
+}
+
+func TestWithDatafileAccessTokenCustomURLTemplate(t *testing.T) {
+
+	sdkKey := "test_sdk_key"
+	datafileAccessToken := "some_token"
+	datafileTemplate := "https://localhost/v1/%s.json"
+	configManager := NewPollingProjectConfigManager(sdkKey, WithDatafileURLTemplate(datafileTemplate), WithDatafileAccessToken(datafileAccessToken))
+	asyncConfigManager := NewAsyncPollingProjectConfigManager(sdkKey, WithDatafileURLTemplate(datafileTemplate), WithDatafileAccessToken(datafileAccessToken))
+
+	assert.Equal(t, datafileAccessToken, configManager.datafileAccessToken)
+	assert.Equal(t, datafileAccessToken, asyncConfigManager.datafileAccessToken)
+	assert.Equal(t, datafileTemplate, configManager.datafileURLTemplate)
+	assert.Equal(t, datafileTemplate, asyncConfigManager.datafileURLTemplate)
+}
+
+func TestSetDatafileAccessTokenRequest(t *testing.T) {
+
+	sdkKey := "test_sdk_key"
+	datafileAccessToken := "some_token"
+	configManager := NewPollingProjectConfigManager(sdkKey)
+	asyncConfigManager := NewAsyncPollingProjectConfigManager(sdkKey)
+
+	configManagerRequester := configManager.requester
+	asyncConfigManagerRequester := asyncConfigManager.requester
+
+	configManager.datafileAccessToken = datafileAccessToken
+	asyncConfigManager.datafileAccessToken = datafileAccessToken
+
+	assert.Equal(t, configManagerRequester, configManager.requester)
+	assert.Equal(t, asyncConfigManagerRequester, asyncConfigManager.requester)
+
+	configManager.setDatafileAccessTokenRequest()
+	asyncConfigManager.setDatafileAccessTokenRequest()
+
+	// modified requester check
+	assert.NotEqual(t, configManagerRequester, configManager.requester)
+	assert.NotEqual(t, asyncConfigManagerRequester, asyncConfigManager.requester)
+}

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -25,14 +25,14 @@ import (
 	"github.com/optimizely/go-sdk/pkg/notification"
 )
 
-// StaticProjectConfigManager maintains a static copy of the project configs
+// StaticProjectConfigManager maintains a static copy of the project config
 type StaticProjectConfigManager struct {
 	projectConfig    ProjectConfig
 	optimizelyConfig *OptimizelyConfig
 	configLock       sync.Mutex
 }
 
-// NewStaticProjectConfigManager creates a new instance of the manager with the given project config
+// NewStaticProjectConfigManager creates a new instance of the manager with the given sdk key and some options
 func NewStaticProjectConfigManager(sdkKey string, configMangerOptions ...OptionFunc) *StaticProjectConfigManager {
 
 	logger := logging.GetLogger(sdkKey, "StaticProjectConfigManager")

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -53,6 +53,29 @@ func NewStaticProjectConfigManagerFromURL(sdkKey string) (*StaticProjectConfigMa
 	return NewStaticProjectConfigManagerFromPayload(datafile, logger)
 }
 
+// NewAuthDatafileStaticProjectConfigManagerFromURL returns new instance of StaticProjectConfigManager for URL with auth datafile token
+func NewAuthDatafileStaticProjectConfigManagerFromURL(sdkKey, authDatafiletoken string) (*StaticProjectConfigManager, error) {
+
+	headers := []utils.Header{{Name: "Content-Type", Value: "application/json"}, {Name: "Accept", Value: "application/json"}}
+	dataFileTemplate := DatafileURLTemplate
+	if authDatafiletoken != "" {
+		headers = append(headers, utils.Header{Name: "Authorization", Value: "Bearer " + authDatafiletoken})
+		dataFileTemplate = AuthDatafileURLTemplate
+	}
+	requester := utils.NewHTTPRequester(logging.GetLogger(sdkKey, "HTTPRequester"), utils.Headers(headers...))
+
+	logger := logging.GetLogger(sdkKey, "StaticProjectConfigManager")
+
+	url := fmt.Sprintf(dataFileTemplate, sdkKey)
+	datafile, _, code, e := requester.Get(url)
+	if e != nil {
+		logger.Error(fmt.Sprintf("request returned with http code=%d", code), e)
+		return nil, e
+	}
+
+	return NewStaticProjectConfigManagerFromPayload(datafile, logger)
+}
+
 // NewStaticProjectConfigManagerFromPayload returns new instance of StaticProjectConfigManager for payload
 func NewStaticProjectConfigManagerFromPayload(payload []byte, logger logging.OptimizelyLogProducer) (*StaticProjectConfigManager, error) {
 	projectConfig, err := datafileprojectconfig.NewDatafileProjectConfig(payload, logger)
@@ -68,7 +91,7 @@ func NewStaticProjectConfigManagerFromPayload(payload []byte, logger logging.Opt
 func NewStaticProjectConfigManager(config ProjectConfig, logger logging.OptimizelyLogProducer) *StaticProjectConfigManager {
 	return &StaticProjectConfigManager{
 		projectConfig: config,
-		logger: logger,
+		logger:        logger,
 	}
 }
 

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -20,36 +20,22 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
-
 	"github.com/stretchr/testify/assert"
 )
-
-var tlogger = logging.GetLogger("", "staticManager")
-
-func TestNewStaticProjectConfigManager(t *testing.T) {
-	projectConfig := datafileprojectconfig.DatafileProjectConfig{}
-	configManager := NewStaticProjectConfigManager(projectConfig, tlogger)
-
-	actual, _ := configManager.GetConfig()
-	assert.Equal(t, projectConfig, actual)
-}
 
 func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123""}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
-	assert.Error(t, err)
-
+	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	assert.Nil(t, configManager)
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123",}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
-	assert.Error(t, err)
+	configManager = NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	assert.Nil(t, configManager)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err = NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
-	assert.Nil(t, err)
+	configManager = NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	assert.NotNil(t, configManager)
 
 	assert.Nil(t, configManager.optimizelyConfig)
 
@@ -60,8 +46,7 @@ func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 func TestStaticGetOptimizelyConfig(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
-	assert.Nil(t, err)
+	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
 
 	assert.Nil(t, configManager.optimizelyConfig)
 
@@ -72,15 +57,14 @@ func TestStaticGetOptimizelyConfig(t *testing.T) {
 }
 func TestNewStaticProjectConfigManagerFromURL(t *testing.T) {
 
-	configManager, err := NewStaticProjectConfigManagerFromURL("no_key_exists")
-	assert.Error(t, err)
+	configManager := NewStaticProjectConfigManager("no_key_exists")
 	assert.Nil(t, configManager)
 }
 
 func TestNewStaticProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager, err := NewStaticProjectConfigManagerFromPayload(mockDatafile, tlogger)
-	assert.Nil(t, err)
+	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	assert.NotNil(t, configManager)
 
 	callback := func(notification notification.ProjectConfigUpdateNotification) {
 


### PR DESCRIPTION
## Summary
- added support for authenticated datafiles
- refactored static config manager  to look more like polling config manager
- fixing a bug for polling interval set to 0 or below.
- here are different ways of initializing authenticated datafiles:
```
/************* default client  polling mgr ********************/
optimizelyClient, _ := optimizely.Client(sdkKey, client.WithDatafileAccessToken(token))
optimizelyClient.IsFeatureEnabled("EVENT_BATCHING", user)

/*********** custom polling mgr *****************/
pcm := config.NewPollingProjectConfigManager(sdkKey, config.WithDatafileAccessToken(token))
optimizelyClient, _ = optimizely.Client(sdkKey, client.WithConfigManager(pcm))
optimizelyClient.IsFeatureEnabled("EVENT_BATCHING", user)

/*************** custome polling mgr , setting polling interval *********/
optimizelyClient, _ = optimizely.Client(sdkKey, client.WithPollingConfigManagerDatafileAccessToken(time.Second, nil, token),
client.WithBatchEventProcessor(event.DefaultBatchSize, event.DefaultEventQueueSize, event.DefaultEventFlushInterval))
optimizelyClient.IsFeatureEnabled("EVENT_BATCHING", user)

/*************** static client *********/
optimizelyFactory := &client.OptimizelyFactory{
	SDKKey:              sdkKey,
	DatafileAccessToken: token,
}

optimizelyClient, _ = optimizelyFactory.StaticClient()
optimizelyClient.IsFeatureEnabled("EVENT_BATCHING", user)

/******** custom static client init ***************/
cm := config.NewStaticProjectConfigManager(sdkKey, config.WithDatafileAccessToken(token))
optimizelyClient, _ = optimizely.Client(sdkKey, client.WithConfigManager(cm))
optimizelyClient.IsFeatureEnabled("EVENT_BATCHING", user)

```