### PR TITLE
feat: bring back old static manager constructor

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -220,7 +220,7 @@ func WithMetricsRegistry(metricsRegistry metrics.Registry) OptionFunc {
 // StaticClient returns a client initialized with a static project config.
 func (f *OptimizelyFactory) StaticClient() (optlyClient *OptimizelyClient, err error) {
 
-	staticManager := config.NewStaticProjectConfigManager(f.SDKKey, config.WithInitialDatafile(f.Datafile), config.WithDatafileAccessToken(f.DatafileAccessToken))
+	staticManager := config.NewStaticProjectConfigManagerWithOptions(f.SDKKey, config.WithInitialDatafile(f.Datafile), config.WithDatafileAccessToken(f.DatafileAccessToken))
 
 	if staticManager == nil {
 		return nil, errors.New("unable to initiate config manager")

--- a/pkg/client/factory_test.go
+++ b/pkg/client/factory_test.go
@@ -95,7 +95,7 @@ func TestClientWithPollingConfigManagerDatafileAccessToken(t *testing.T) {
 func TestClientWithProjectConfigManagerInOptions(t *testing.T) {
 	factory := OptimizelyFactory{}
 	mockDatafile := []byte(`{"version":"4"}`)
-	configManager := config.NewStaticProjectConfigManager("", config.WithInitialDatafile(mockDatafile))
+	configManager := config.NewStaticProjectConfigManagerWithOptions("", config.WithInitialDatafile(mockDatafile))
 
 	optimizelyClient, err := factory.Client(WithConfigManager(configManager))
 	assert.NoError(t, err)
@@ -107,7 +107,7 @@ func TestClientWithProjectConfigManagerInOptions(t *testing.T) {
 func TestClientWithDecisionServiceAndEventProcessorInOptions(t *testing.T) {
 	factory := OptimizelyFactory{}
 	mockDatafile := []byte(`{"version":"4"}`)
-	configManager := config.NewStaticProjectConfigManager("", config.WithInitialDatafile(mockDatafile))
+	configManager := config.NewStaticProjectConfigManagerWithOptions("", config.WithInitialDatafile(mockDatafile))
 	decisionService := new(MockDecisionService)
 	processor := event.NewBatchEventProcessor(event.WithQueueSize(100), event.WithFlushInterval(100),
 		event.WithQueue(event.NewInMemoryQueue(100)), event.WithEventDispatcher(&MockDispatcher{Events: []event.LogEvent{}}))

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -50,7 +50,7 @@ func (s *OptimizelyConfigTestSuite) SetupTest() {
 		s.Fail("error opening file " + dataFileName)
 	}
 
-	projectMgr := NewStaticProjectConfigManager("", WithInitialDatafile(dataFile))
+	projectMgr := NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(dataFile))
 
 	s.projectConfig = projectMgr.projectConfig
 

--- a/pkg/config/static_manager.go
+++ b/pkg/config/static_manager.go
@@ -30,10 +30,11 @@ type StaticProjectConfigManager struct {
 	projectConfig    ProjectConfig
 	optimizelyConfig *OptimizelyConfig
 	configLock       sync.Mutex
+	logger           logging.OptimizelyLogProducer
 }
 
-// NewStaticProjectConfigManager creates a new instance of the manager with the given sdk key and some options
-func NewStaticProjectConfigManager(sdkKey string, configMangerOptions ...OptionFunc) *StaticProjectConfigManager {
+// NewStaticProjectConfigManagerWithOptions creates a new instance of the manager with the given sdk key and some options
+func NewStaticProjectConfigManagerWithOptions(sdkKey string, configMangerOptions ...OptionFunc) *StaticProjectConfigManager {
 
 	logger := logging.GetLogger(sdkKey, "StaticProjectConfigManager")
 	staticProjectConfigManager := newConfigManager(sdkKey, logger, configMangerOptions...)
@@ -50,6 +51,15 @@ func NewStaticProjectConfigManager(sdkKey string, configMangerOptions ...OptionF
 
 	return &StaticProjectConfigManager{
 		projectConfig: projectConfig,
+		logger:        logger,
+	}
+}
+
+// NewStaticProjectConfigManager creates a new instance of the manager with the given project config
+func NewStaticProjectConfigManager(config ProjectConfig, logger logging.OptimizelyLogProducer) *StaticProjectConfigManager {
+	return &StaticProjectConfigManager{
+		projectConfig: config,
+		logger:        logger,
 	}
 }
 

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -20,21 +20,24 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/optimizely/go-sdk/pkg/config/datafileprojectconfig"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/notification"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123""}`)
-	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	configManager := NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(mockDatafile))
 	assert.Nil(t, configManager)
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123",}`)
-	configManager = NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	configManager = NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(mockDatafile))
 	assert.Nil(t, configManager)
 
 	mockDatafile = []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager = NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	configManager = NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(mockDatafile))
 	assert.NotNil(t, configManager)
 
 	assert.Nil(t, configManager.optimizelyConfig)
@@ -46,7 +49,9 @@ func TestNewStaticProjectConfigManagerFromPayload(t *testing.T) {
 func TestStaticGetOptimizelyConfig(t *testing.T) {
 
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	logger := logging.GetLogger("", "DatafileProjectConfig")
+	projectConfig, _ := datafileprojectconfig.NewDatafileProjectConfig([]byte(mockDatafile), logger)
+	configManager := NewStaticProjectConfigManager(projectConfig, logger)
 
 	assert.Nil(t, configManager.optimizelyConfig)
 
@@ -57,13 +62,13 @@ func TestStaticGetOptimizelyConfig(t *testing.T) {
 }
 func TestNewStaticProjectConfigManagerFromURL(t *testing.T) {
 
-	configManager := NewStaticProjectConfigManager("no_key_exists")
+	configManager := NewStaticProjectConfigManagerWithOptions("no_key_exists")
 	assert.Nil(t, configManager)
 }
 
 func TestNewStaticProjectConfigManagerOnDecision(t *testing.T) {
 	mockDatafile := []byte(`{"accountId":"42","projectId":"123","version":"4"}`)
-	configManager := NewStaticProjectConfigManager("", WithInitialDatafile(mockDatafile))
+	configManager := NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(mockDatafile))
 	assert.NotNil(t, configManager)
 
 	callback := func(notification notification.ProjectConfigUpdateNotification) {


### PR DESCRIPTION
 ## Summary
- bringing back old NewStaticProjectConfigManager that takes project config as a parameter
- renaming NewStaticProjectConfigManager to NewStaticProjectConfigManagerWithOptions
- changes are required for agent tests 