### PR TITLE
fix: provide synchronization for Notification Center Cache

### DIFF
--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -24,12 +24,12 @@ import (
 )
 
 var notificationCenterCache = make(map[string]notification.Center)
-var notificationLock sync.RWMutex
+var notificationLock sync.Mutex
 
 // GetNotificationCenter returns the notification center instance associated with the given SDK Key or creates a new one if not found
 func GetNotificationCenter(sdkKey string) notification.Center {
-	notificationLock.RLock()
-	defer notificationLock.RUnlock()
+	notificationLock.Lock()
+	defer notificationLock.Unlock()
 
 	notificationCenter, ok := notificationCenterCache[sdkKey]
 	if !ok {

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -18,16 +18,21 @@
 package registry
 
 import (
+	"sync"
+
 	"github.com/optimizely/go-sdk/pkg/notification"
 )
 
 var notificationCenterCache = make(map[string]notification.Center)
+var notificationLock sync.RWMutex
 
 // GetNotificationCenter returns the notification center instance associated with the given SDK Key or creates a new one if not found
 func GetNotificationCenter(sdkKey string) notification.Center {
-	var notificationCenter notification.Center
-	var ok bool
-	if notificationCenter, ok = notificationCenterCache[sdkKey]; !ok {
+	notificationLock.RLock()
+	defer notificationLock.RUnlock()
+
+	notificationCenter, ok := notificationCenterCache[sdkKey]
+	if !ok {
 		notificationCenter = notification.NewNotificationCenter()
 		notificationCenterCache[sdkKey] = notificationCenter
 	}

--- a/pkg/registry/service_test.go
+++ b/pkg/registry/service_test.go
@@ -28,11 +28,19 @@ type ServiceRegistryTestSuite struct {
 
 func (s *ServiceRegistryTestSuite) TestGetNotificationCenter() {
 	// empty state, make sure we get a new notification center
-	sdkKey := "sdk_key_1"
-	notificationCenter := GetNotificationCenter(sdkKey)
+	sdkKey1 := "sdk_key_1"
+	sdkKey2 := "sdk_key_2"
+	notificationCenter := GetNotificationCenter(sdkKey1)
 	s.NotNil(notificationCenter)
 
-	notificationCenter2 := GetNotificationCenter(sdkKey)
+	notificationCenter2 := GetNotificationCenter(sdkKey1)
+	s.Equal(notificationCenter, notificationCenter2)
+
+	// make sure sdkKey2 does not cause race condition
+	notificationCenter = GetNotificationCenter(sdkKey2)
+	s.NotNil(notificationCenter)
+
+	notificationCenter2 = GetNotificationCenter(sdkKey2)
 	s.Equal(notificationCenter, notificationCenter2)
 }
 


### PR DESCRIPTION
## Summary
- provide synchronization for Notification Center Cache
- this fix is for a case when many clients are initialized with different sdk keys ( Agent scenario) 