### PR TITLE
ci: Run source clear only on cron and  before linting and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ jobs:
         FULLSTACK_TEST_REPO=ProdTesting
     
     - stage: 'Source clear'
+      if: type = cron
       env: GIMME_GO_VERSION=master GIMME_OS=linux GIMME_ARCH=amd64
       language: go
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ git:
 install:
   - eval "$(gimme)"
 stages:
+  - 'Source clear'
   - 'Lint markdown files'
   - 'Lint'
   - 'Unit test'
   - 'Benchmark test'  
   - 'Integration tests'
   - 'Production tests'
-  - 'Source clear'
   - 'Readme-sync'
 jobs:
   include:


### PR DESCRIPTION
Summary
-------
Stages run sequentially on Travis. If a stage fails, all the following stages are not executed. We execute source clear only on cron, and if due to any reason unit or integration tests fail, the source clear is not executed. Hence, moving source clear stage before tests. 


Test plan
---------
All unit tests must be passed. 
FSC must be passed.