### PR TITLE
Add support for sending flag decisions along with decision metadata.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -460,17 +460,22 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 	if featureDecision.Variation != nil {
 		decisionInfo.Enabled = featureDecision.Variation.FeatureEnabled
 
+		var experiment = entities.Experiment{}
+		var variation = entities.Variation{}
+
 		// This information is only necessary for feature tests.
 		// For rollouts experiments and variations are an implementation detail only.
 		if featureDecision.Source == decision.FeatureTest {
 			decisionInfo.VariationKey = featureDecision.Variation.Key
 			decisionInfo.ExperimentKey = featureDecision.Experiment.Key
+			experiment = featureDecision.Experiment
+			variation = *featureDecision.Variation
 		}
 
 		// Triggers impression events when applicable
 		if !disableTracking {
 			// send impression event for feature tests
-			impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment, *featureDecision.Variation, userContext)
+			impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, experiment, variation, userContext)
 			o.EventProcessor.ProcessEvent(impressionEvent)
 		}
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -460,8 +460,13 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 	if featureDecision.Variation != nil {
 		decisionInfo.Enabled = featureDecision.Variation.FeatureEnabled
 
-		decisionInfo.VariationKey = featureDecision.Variation.Key
-		decisionInfo.ExperimentKey = featureDecision.Experiment.Key
+		// This information is only necessary for feature tests.
+		// For rollouts experiments and variations are an implementation detail only.
+		if featureDecision.Source == decision.FeatureTest {
+			decisionInfo.VariationKey = featureDecision.Variation.Key
+			decisionInfo.ExperimentKey = featureDecision.Experiment.Key
+		}
+
 		// Triggers impression events when applicable
 		if !disableTracking {
 			// send impression event for feature tests

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -460,15 +460,13 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 	if featureDecision.Variation != nil {
 		decisionInfo.Enabled = featureDecision.Variation.FeatureEnabled
 
-		if featureDecision.Source == decision.FeatureTest {
-			decisionInfo.VariationKey = featureDecision.Variation.Key
-			decisionInfo.ExperimentKey = featureDecision.Experiment.Key
-			// Triggers impression events when applicable
-			if !disableTracking {
-				// send impression event for feature tests
-				impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment, *featureDecision.Variation, userContext)
-				o.EventProcessor.ProcessEvent(impressionEvent)
-			}
+		decisionInfo.VariationKey = featureDecision.Variation.Key
+		decisionInfo.ExperimentKey = featureDecision.Experiment.Key
+		// Triggers impression events when applicable
+		if !disableTracking {
+			// send impression event for feature tests
+			impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment, *featureDecision.Variation, userContext)
+			o.EventProcessor.ProcessEvent(impressionEvent)
 		}
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -129,11 +129,8 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 		}
 	}
 
-	if featureDecision.Source == decision.FeatureTest && featureDecision.Variation != nil {
-		// send impression event for feature tests
-		impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment, *featureDecision.Variation, userContext)
-		o.EventProcessor.ProcessEvent(impressionEvent)
-	}
+	impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment, *featureDecision.Variation, userContext)
+	o.EventProcessor.ProcessEvent(impressionEvent)
 	return result, err
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -47,6 +47,12 @@ type OptimizelyClient struct {
 	logger             logging.OptimizelyLogProducer
 }
 
+const (
+	flagTypeKey     = "FLAG_TYPE"
+	flagKeyKey      = "FLAG_KEY"
+	variationKeyKey = "VARIATION_KEY"
+)
+
 // Activate returns the key of the variation the user is bucketed into and queues up an impression event to be sent to
 // the Optimizely log endpoint for results processing.
 func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.UserContext) (result string, err error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -47,12 +47,6 @@ type OptimizelyClient struct {
 	logger             logging.OptimizelyLogProducer
 }
 
-const (
-	flagTypeKey     = "FLAG_TYPE"
-	flagKeyKey      = "FLAG_KEY"
-	variationKeyKey = "VARIATION_KEY"
-)
-
 // Activate returns the key of the variation the user is bucketed into and queues up an impression event to be sent to
 // the Optimizely log endpoint for results processing.
 func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.UserContext) (result string, err error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -76,9 +76,10 @@ func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.U
 	if experimentDecision.Variation != nil && decisionContext.Experiment != nil {
 		// send an impression event
 		result = experimentDecision.Variation.Key
-		impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, *decisionContext.Experiment,
-			experimentDecision.Variation, userContext, experimentKey, "experiment")
-		o.EventProcessor.ProcessEvent(impressionEvent)
+		if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, *decisionContext.Experiment,
+			experimentDecision.Variation, userContext, experimentKey, "experiment"); ok {
+			o.EventProcessor.ProcessEvent(ue)
+		}
 	}
 
 	return result, err
@@ -130,9 +131,11 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 		}
 	}
 
-	impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-		featureDecision.Variation, userContext, featureKey, featureDecision.Source)
-	o.EventProcessor.ProcessEvent(impressionEvent)
+	if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
+		featureDecision.Variation, userContext, featureKey, featureDecision.Source); ok {
+		o.EventProcessor.ProcessEvent(ue)
+	}
+
 	return result, err
 }
 
@@ -472,9 +475,10 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 		// Triggers impression events when applicable
 		if !disableTracking {
 			// send impression event for feature tests
-			impressionEvent := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-				featureDecision.Variation, userContext, featureKey, featureDecision.Source)
-			o.EventProcessor.ProcessEvent(impressionEvent)
+			if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
+				featureDecision.Variation, userContext, featureKey, featureDecision.Source); ok {
+				o.EventProcessor.ProcessEvent(ue)
+			}
 		}
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -77,7 +77,7 @@ func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.U
 		// send an impression event
 		result = experimentDecision.Variation.Key
 		if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, *decisionContext.Experiment,
-			experimentDecision.Variation, userContext, experimentKey, "experiment"); ok {
+			experimentDecision.Variation, userContext, "", experimentKey, "experiment"); ok {
 			o.EventProcessor.ProcessEvent(ue)
 		}
 	}
@@ -132,7 +132,7 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 	}
 
 	if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-		featureDecision.Variation, userContext, featureKey, featureDecision.Source); ok {
+		featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source); ok {
 		o.EventProcessor.ProcessEvent(ue)
 	}
 
@@ -476,7 +476,7 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 		if !disableTracking {
 			// send impression event for feature tests
 			if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-				featureDecision.Variation, userContext, featureKey, featureDecision.Source); ok {
+				featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source); ok {
 				o.EventProcessor.ProcessEvent(ue)
 			}
 		}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2813,9 +2813,18 @@ func (s *ClientTestSuiteTrackNotification) TestRemoveOnTrackThrowsErrorWhenRemov
 	mockNotificationCenter.AssertExpectations(s.T())
 }
 
-func TestClientTestSuite(t *testing.T) {
+func TestClientTestSuiteAB(t *testing.T) {
 	suite.Run(t, new(ClientTestSuiteAB))
+}
+
+func TestClientTestSuiteFM(t *testing.T) {
 	suite.Run(t, new(ClientTestSuiteFM))
+}
+
+func TestClientTestSuiteTrackEvent(t *testing.T) {
 	suite.Run(t, new(ClientTestSuiteTrackEvent))
+}
+
+func TestClientTestSuiteTrackNotification(t *testing.T) {
 	suite.Run(t, new(ClientTestSuiteTrackNotification))
 }

--- a/pkg/client/fixtures_test.go
+++ b/pkg/client/fixtures_test.go
@@ -77,6 +77,9 @@ func (c *MockProjectConfig) GetAnonymizeIP() bool {
 func (c *MockProjectConfig) GetBotFiltering() bool {
 	return false
 }
+func (c *MockProjectConfig) SendFlagDecisions() bool {
+	return false
+}
 
 type MockProjectConfigManager struct {
 	projectConfig config.ProjectConfig

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -47,6 +47,7 @@ type DatafileProjectConfig struct {
 	rolloutMap           map[string]entities.Rollout
 	anonymizeIP          bool
 	botFiltering         bool
+	sendFlagDecisions    bool
 }
 
 // GetDatafile returns a string representation of the environment's datafile
@@ -178,6 +179,11 @@ func (c DatafileProjectConfig) GetGroupByID(groupID string) (entities.Group, err
 	return entities.Group{}, fmt.Errorf(`group with ID "%s" not found`, groupID)
 }
 
+// SendFlagDecisions determines whether impressions events are sent for ALL decision types
+func (c DatafileProjectConfig) SendFlagDecisions() bool {
+	return c.sendFlagDecisions
+}
+
 // NewDatafileProjectConfig initializes a new datafile from a json byte array using the default JSON datafile parser
 func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogProducer) (*DatafileProjectConfig, error) {
 	datafile, err := Parse(jsonDatafile)
@@ -217,6 +223,7 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 		projectID:            datafile.ProjectID,
 		revision:             datafile.Revision,
 		rolloutMap:           rolloutMap,
+		sendFlagDecisions:    datafile.SendFlagDecisions,
 	}
 
 	logger.Info("Datafile is valid.")

--- a/pkg/config/datafileprojectconfig/entities/entities.go
+++ b/pkg/config/datafileprojectconfig/entities/entities.go
@@ -106,19 +106,20 @@ type Rollout struct {
 
 // Datafile represents the datafile we get from Optimizely
 type Datafile struct {
-	Attributes     []Attribute   `json:"attributes"`
-	Audiences      []Audience    `json:"audiences"`
-	Experiments    []Experiment  `json:"experiments"`
-	Groups         []Group       `json:"groups"`
-	FeatureFlags   []FeatureFlag `json:"featureFlags"`
-	Events         []Event       `json:"events"`
-	Rollouts       []Rollout     `json:"rollouts"`
-	TypedAudiences []Audience    `json:"typedAudiences"`
-	Variables      []string      `json:"variables"`
-	AccountID      string        `json:"accountId"`
-	ProjectID      string        `json:"projectId"`
-	Revision       string        `json:"revision"`
-	Version        string        `json:"version"`
-	AnonymizeIP    bool          `json:"anonymizeIP"`
-	BotFiltering   bool          `json:"botFiltering"`
+	Attributes        []Attribute   `json:"attributes"`
+	Audiences         []Audience    `json:"audiences"`
+	Experiments       []Experiment  `json:"experiments"`
+	Groups            []Group       `json:"groups"`
+	FeatureFlags      []FeatureFlag `json:"featureFlags"`
+	Events            []Event       `json:"events"`
+	Rollouts          []Rollout     `json:"rollouts"`
+	TypedAudiences    []Audience    `json:"typedAudiences"`
+	Variables         []string      `json:"variables"`
+	AccountID         string        `json:"accountId"`
+	ProjectID         string        `json:"projectId"`
+	Revision          string        `json:"revision"`
+	Version           string        `json:"version"`
+	AnonymizeIP       bool          `json:"anonymizeIP"`
+	BotFiltering      bool          `json:"botFiltering"`
+	SendFlagDecisions bool          `json:"sendFlagDecisions"`
 }

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -41,6 +41,7 @@ type ProjectConfig interface {
 	GetGroupByID(string) (entities.Group, error)
 	GetProjectID() string
 	GetRevision() string
+	SendFlagDecisions() bool
 }
 
 // ProjectConfigManager maintains an instance of the ProjectConfig

--- a/pkg/decision/entities.go
+++ b/pkg/decision/entities.go
@@ -45,7 +45,7 @@ type UnsafeFeatureDecisionInfo struct {
 }
 
 // Source is where the decision came from
-type Source string
+type Source = string
 
 const (
 	// Rollout - the decision came from a rollout

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -41,12 +41,19 @@ type UserEvent struct {
 // ImpressionEvent represents an impression event
 type ImpressionEvent struct {
 	Attributes   []VisitorAttribute
-	CampaignID   string            `json:"campaign_id"`
-	EntityID     string            `json:"entity_id"`
-	ExperimentID string            `json:"experiment_id"`
-	Key          string            `json:"key"`
-	Metadata     map[string]string `json:"metadata"`
-	VariationID  string            `json:"variation_id"`
+	CampaignID   string           `json:"campaign_id"`
+	EntityID     string           `json:"entity_id"`
+	ExperimentID string           `json:"experiment_id"`
+	Key          string           `json:"key"`
+	Metadata     DecisionMetadata `json:"metadata"`
+	VariationID  string           `json:"variation_id"`
+}
+
+// DecisionMetadata captures additional information regarding the decision
+type DecisionMetadata struct {
+	FlagType     string `json:"flag_type"`
+	FlagKey      string `json:"flag_key"`
+	VariationKey string `json:"variation_key"`
 }
 
 // ConversionEvent represents a conversion event
@@ -102,10 +109,10 @@ type Snapshot struct {
 
 // Decision represents a decision of a snapshot
 type Decision struct {
-	VariationID  string            `json:"variation_id"`
-	CampaignID   string            `json:"campaign_id"`
-	ExperimentID string            `json:"experiment_id"`
-	Metadata     map[string]string `json:"metadata"`
+	VariationID  string           `json:"variation_id"`
+	CampaignID   string           `json:"campaign_id"`
+	ExperimentID string           `json:"experiment_id"`
+	Metadata     DecisionMetadata `json:"metadata"`
 }
 
 // SnapshotEvent represents an event of a snapshot

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -51,8 +51,9 @@ type ImpressionEvent struct {
 
 // DecisionMetadata captures additional information regarding the decision
 type DecisionMetadata struct {
-	FlagType     string `json:"flag_type"`
 	FlagKey      string `json:"flag_key"`
+	RuleKey      string `json:"rule_key"`
+	RuleType     string `json:"rule_type"`
 	VariationKey string `json:"variation_key"`
 }
 

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -41,14 +41,12 @@ type UserEvent struct {
 // ImpressionEvent represents an impression event
 type ImpressionEvent struct {
 	Attributes   []VisitorAttribute
-	CampaignID   string `json:"campaign_id"`
-	EntityID     string `json:"entity_id"`
-	ExperimentID string `json:"experiment_id"`
-	FlagKey      string `json:"flag_key"`
-	FlagType     string `json:"flag_type"`
-	Key          string `json:"key"`
-	VariationID  string `json:"variation_id"`
-	VariationKey string `json:"variation_key"`
+	CampaignID   string            `json:"campaign_id"`
+	EntityID     string            `json:"entity_id"`
+	ExperimentID string            `json:"experiment_id"`
+	Key          string            `json:"key"`
+	Metadata     map[string]string `json:"metadata"`
+	VariationID  string            `json:"variation_id"`
 }
 
 // ConversionEvent represents a conversion event
@@ -104,12 +102,10 @@ type Snapshot struct {
 
 // Decision represents a decision of a snapshot
 type Decision struct {
-	VariationID  string `json:"variation_id"`
-	CampaignID   string `json:"campaign_id"`
-	ExperimentID string `json:"experiment_id"`
-	FlagKey      string `json:"flag_key"`
-	FlagType     string `json:"flag_type"`
-	VariationKey string `json:"variation_key"`
+	VariationID  string            `json:"variation_id"`
+	CampaignID   string            `json:"campaign_id"`
+	ExperimentID string            `json:"experiment_id"`
+	Metadata     map[string]string `json:"metadata"`
 }
 
 // SnapshotEvent represents an event of a snapshot

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -40,12 +40,14 @@ type UserEvent struct {
 
 // ImpressionEvent represents an impression event
 type ImpressionEvent struct {
-	EntityID     string `json:"entity_id"`
-	Key          string `json:"key"`
 	Attributes   []VisitorAttribute
-	VariationID  string `json:"variation_id"`
 	CampaignID   string `json:"campaign_id"`
+	EntityID     string `json:"entity_id"`
 	ExperimentID string `json:"experiment_id"`
+	FlagKey      string `json:"flag_key"`
+	FlagType     string `json:"flag_type"`
+	Key          string `json:"key"`
+	VariationID  string `json:"variation_id"`
 }
 
 // ConversionEvent represents a conversion event

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -48,6 +48,7 @@ type ImpressionEvent struct {
 	FlagType     string `json:"flag_type"`
 	Key          string `json:"key"`
 	VariationID  string `json:"variation_id"`
+	VariationKey string `json:"variation_key"`
 }
 
 // ConversionEvent represents a conversion event
@@ -106,6 +107,9 @@ type Decision struct {
 	VariationID  string `json:"variation_id"`
 	CampaignID   string `json:"campaign_id"`
 	ExperimentID string `json:"experiment_id"`
+	FlagKey      string `json:"flag_key"`
+	FlagType     string `json:"flag_type"`
+	VariationKey string `json:"variation_key"`
 }
 
 // SnapshotEvent represents an event of a snapshot

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -82,6 +82,7 @@ func createImpressionEvent(
 		CampaignID:   experiment.LayerID,
 		EntityID:     experiment.LayerID,
 		ExperimentID: experiment.ID,
+		Key:          impressionKey,
 		Metadata:     metadata,
 		VariationID:  variationID,
 	}

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -61,12 +61,12 @@ func CreateEventContext(projectConfig config.ProjectConfig) Context {
 func createImpressionEvent(
 	projectConfig config.ProjectConfig,
 	experiment entities.Experiment,
-	variation entities.Variation,
+	variation *entities.Variation,
 	attributes map[string]interface{},
 	flagKey, flagType string,
 ) ImpressionEvent {
 
-	return ImpressionEvent{
+	event := ImpressionEvent{
 		Attributes:   getEventAttributes(projectConfig, attributes),
 		CampaignID:   experiment.LayerID,
 		EntityID:     experiment.LayerID,
@@ -74,14 +74,19 @@ func createImpressionEvent(
 		FlagKey:      flagKey,
 		FlagType:     flagType,
 		Key:          impressionKey,
-		VariationID:  variation.ID,
-		VariationKey: variation.Key,
 	}
+
+	if variation != nil {
+		event.VariationKey = variation.Key
+		event.VariationID = variation.ID
+	}
+
+	return event
 }
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation entities.Variation, userContext entities.UserContext, flagKey, flagType string) UserEvent {
+	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) UserEvent {
 
 	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, flagType)
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -25,6 +25,7 @@ import (
 	guuid "github.com/google/uuid"
 
 	"github.com/optimizely/go-sdk/pkg/config"
+	decisionPkg "github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/utils"
 )
@@ -92,7 +93,11 @@ func createImpressionEvent(
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) UserEvent {
+	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) (UserEvent, bool) {
+
+	if flagType == decisionPkg.Rollout || variation == nil {
+		return UserEvent{}, false
+	}
 
 	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, flagType)
 
@@ -103,7 +108,7 @@ func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment en
 	userEvent.Impression = &impression
 	userEvent.EventContext = CreateEventContext(projectConfig)
 
-	return userEvent
+	return userEvent, true
 }
 
 // create an impression visitor

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -95,7 +95,7 @@ func createImpressionEvent(
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
 	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) (UserEvent, bool) {
 
-	if projectConfig.SendFlagDecisions() || flagType == decisionPkg.Rollout || variation == nil {
+	if (flagType == decisionPkg.Rollout || variation == nil) && !projectConfig.SendFlagDecisions() {
 		return UserEvent{}, false
 	}
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -67,14 +67,14 @@ func createImpressionEvent(
 	flagKey, flagType string,
 ) ImpressionEvent {
 
-	metadata := map[string]string{
-		"FLAG_KEY":  flagKey,
-		"FLAG_TYPE": flagType,
+	metadata := DecisionMetadata{
+		FlagType: flagType,
+		FlagKey:  flagKey,
 	}
 
 	var variationID string
 	if variation != nil {
-		metadata["VARIAITON_KEY"] = variation.Key
+		metadata.VariationKey = variation.Key
 		variationID = variation.ID
 	}
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -75,6 +75,7 @@ func createImpressionEvent(
 		FlagType:     flagType,
 		Key:          impressionKey,
 		VariationID:  variation.ID,
+		VariationKey: variation.Key,
 	}
 }
 
@@ -100,6 +101,9 @@ func createImpressionVisitor(userEvent UserEvent) Visitor {
 	decision.CampaignID = userEvent.Impression.CampaignID
 	decision.ExperimentID = userEvent.Impression.ExperimentID
 	decision.VariationID = userEvent.Impression.VariationID
+	decision.FlagKey = userEvent.Impression.FlagKey
+	decision.FlagType = userEvent.Impression.FlagType
+	decision.VariationKey = userEvent.Impression.VariationKey
 
 	dispatchEvent := SnapshotEvent{}
 	dispatchEvent.Timestamp = makeTimestamp()

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -95,7 +95,7 @@ func createImpressionEvent(
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
 	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) (UserEvent, bool) {
 
-	if flagType == decisionPkg.Rollout || variation == nil {
+	if projectConfig.SendFlagDecisions() || flagType == decisionPkg.Rollout || variation == nil {
 		return UserEvent{}, false
 	}
 

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -66,19 +66,24 @@ func createImpressionEvent(
 	flagKey, flagType string,
 ) ImpressionEvent {
 
+	metadata := map[string]string{
+		"FLAG_KEY":  flagKey,
+		"FLAG_TYPE": flagType,
+	}
+
+	var variationID string
+	if variation != nil {
+		metadata["VARIAITON_KEY"] = variation.Key
+		variationID = variation.ID
+	}
+
 	event := ImpressionEvent{
 		Attributes:   getEventAttributes(projectConfig, attributes),
 		CampaignID:   experiment.LayerID,
 		EntityID:     experiment.LayerID,
 		ExperimentID: experiment.ID,
-		FlagKey:      flagKey,
-		FlagType:     flagType,
-		Key:          impressionKey,
-	}
-
-	if variation != nil {
-		event.VariationKey = variation.Key
-		event.VariationID = variation.ID
+		Metadata:     metadata,
+		VariationID:  variationID,
 	}
 
 	return event
@@ -106,9 +111,7 @@ func createImpressionVisitor(userEvent UserEvent) Visitor {
 	decision.CampaignID = userEvent.Impression.CampaignID
 	decision.ExperimentID = userEvent.Impression.ExperimentID
 	decision.VariationID = userEvent.Impression.VariationID
-	decision.FlagKey = userEvent.Impression.FlagKey
-	decision.FlagType = userEvent.Impression.FlagType
-	decision.VariationKey = userEvent.Impression.VariationKey
+	decision.Metadata = userEvent.Impression.Metadata
 
 	dispatchEvent := SnapshotEvent{}
 	dispatchEvent.Timestamp = makeTimestamp()

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -64,12 +64,13 @@ func createImpressionEvent(
 	experiment entities.Experiment,
 	variation *entities.Variation,
 	attributes map[string]interface{},
-	flagKey, flagType string,
+	flagKey, ruleKey, ruleType string,
 ) ImpressionEvent {
 
 	metadata := DecisionMetadata{
-		FlagType: flagType,
 		FlagKey:  flagKey,
+		RuleKey:  ruleKey,
+		RuleType: ruleType,
 	}
 
 	var variationID string
@@ -93,13 +94,13 @@ func createImpressionEvent(
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation *entities.Variation, userContext entities.UserContext, flagKey, flagType string) (UserEvent, bool) {
+	variation *entities.Variation, userContext entities.UserContext, flagKey, ruleKey, ruleType string) (UserEvent, bool) {
 
-	if (flagType == decisionPkg.Rollout || variation == nil) && !projectConfig.SendFlagDecisions() {
+	if (ruleType == decisionPkg.Rollout || variation == nil) && !projectConfig.SendFlagDecisions() {
 		return UserEvent{}, false
 	}
 
-	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, flagType)
+	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, ruleKey, ruleType)
 
 	userEvent := UserEvent{}
 	userEvent.Timestamp = makeTimestamp()

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	guuid "github.com/google/uuid"
+
 	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/utils"
@@ -57,26 +58,31 @@ func CreateEventContext(projectConfig config.ProjectConfig) Context {
 	return context
 }
 
-func createImpressionEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation entities.Variation, attributes map[string]interface{}) ImpressionEvent {
+func createImpressionEvent(
+	projectConfig config.ProjectConfig,
+	experiment entities.Experiment,
+	variation entities.Variation,
+	attributes map[string]interface{},
+	flagKey, flagType string,
+) ImpressionEvent {
 
-	impression := ImpressionEvent{}
-	impression.Key = impressionKey
-	impression.EntityID = experiment.LayerID
-	impression.Attributes = getEventAttributes(projectConfig, attributes)
-	impression.VariationID = variation.ID
-	impression.ExperimentID = experiment.ID
-	impression.CampaignID = experiment.LayerID
-
-	return impression
+	return ImpressionEvent{
+		Attributes:   getEventAttributes(projectConfig, attributes),
+		CampaignID:   experiment.LayerID,
+		EntityID:     experiment.LayerID,
+		ExperimentID: experiment.ID,
+		FlagKey:      flagKey,
+		FlagType:     flagType,
+		Key:          impressionKey,
+		VariationID:  variation.ID,
+	}
 }
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation entities.Variation,
-	userContext entities.UserContext) UserEvent {
+	variation entities.Variation, userContext entities.UserContext, flagKey, flagType string) UserEvent {
 
-	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes)
+	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, flagType)
 
 	userEvent := UserEvent{}
 	userEvent.Timestamp = makeTimestamp()

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -128,6 +128,10 @@ func TestCreateEmptyEvent(t *testing.T) {
 
 func TestCreateAndSendImpressionEvent(t *testing.T) {
 	impressionUserEvent := BuildTestImpressionEvent()
+	assert.Equal(t, userContext.ID, impressionUserEvent.VisitorID)
+	assert.Equal(t, "experiment", impressionUserEvent.Impression.Metadata.FlagType)
+	assert.Equal(t, testVariation.Key, impressionUserEvent.Impression.Metadata.VariationKey)
+	assert.Equal(t, testExperiment.Key, impressionUserEvent.Impression.Metadata.FlagKey)
 
 	processor := NewBatchEventProcessor(WithBatchSize(10), WithQueueSize(100),
 		WithFlushInterval(10),

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/optimizely/go-sdk/pkg/config"
+	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/stretchr/testify/assert"
 )
@@ -87,16 +88,21 @@ var userContext = entities.UserContext{
 func BuildTestImpressionEvent() UserEvent {
 	config := TestConfig{}
 
-	experiment := entities.Experiment{}
-	experiment.Key = "background_experiment"
-	experiment.LayerID = "15399420423"
-	experiment.ID = "15402980349"
+	fd := decision.FeatureDecision{
+		Decision: decision.Decision{},
+		Source:   "test",
+		Experiment: entities.Experiment{
+			ID:      "15402980349",
+			LayerID: "15399420423",
+			Key:     "background_experiment",
+		},
+		Variation: &entities.Variation{
+			ID:  "15410990633",
+			Key: "variation_a",
+		},
+	}
 
-	variation := entities.Variation{}
-	variation.Key = "variation_a"
-	variation.ID = "15410990633"
-
-	impressionUserEvent := CreateImpressionUserEvent(config, experiment, variation, userContext)
+	impressionUserEvent := CreateImpressionUserEvent(config, fd, userContext)
 
 	return impressionUserEvent
 }
@@ -127,7 +133,7 @@ func TestCreateAndSendImpressionEvent(t *testing.T) {
 
 	processor := NewBatchEventProcessor(WithBatchSize(10), WithQueueSize(100),
 		WithFlushInterval(10),
-		WithEventDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+		WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	go processor.Start(context.Background())
 
@@ -145,7 +151,7 @@ func TestCreateAndSendConversionEvent(t *testing.T) {
 	conversionUserEvent := BuildTestConversionEvent()
 
 	processor := NewBatchEventProcessor(WithFlushInterval(10),
-		WithEventDispatcher(&MockDispatcher{Events:NewInMemoryQueue(100)}))
+		WithEventDispatcher(&MockDispatcher{Events: NewInMemoryQueue(100)}))
 
 	go processor.Start(context.Background())
 

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -103,7 +103,7 @@ var userContext = entities.UserContext{
 
 func BuildTestImpressionEvent() UserEvent {
 	tc := TestConfig{}
-	impressionUserEvent, _ := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, testExperiment.Key, "experiment")
+	impressionUserEvent, _ := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, "experiment")
 	return impressionUserEvent
 }
 
@@ -129,9 +129,9 @@ func TestCreateEmptyEvent(t *testing.T) {
 func TestCreateAndSendImpressionEvent(t *testing.T) {
 	impressionUserEvent := BuildTestImpressionEvent()
 	assert.Equal(t, userContext.ID, impressionUserEvent.VisitorID)
-	assert.Equal(t, "experiment", impressionUserEvent.Impression.Metadata.FlagType)
+	assert.Equal(t, "experiment", impressionUserEvent.Impression.Metadata.RuleType)
 	assert.Equal(t, testVariation.Key, impressionUserEvent.Impression.Metadata.VariationKey)
-	assert.Equal(t, testExperiment.Key, impressionUserEvent.Impression.Metadata.FlagKey)
+	assert.Equal(t, testExperiment.Key, impressionUserEvent.Impression.Metadata.RuleKey)
 
 	processor := NewBatchEventProcessor(WithBatchSize(10), WithQueueSize(100),
 		WithFlushInterval(10),
@@ -195,20 +195,20 @@ func TestCreateImpressionUserEvent(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, scenario.flagType)
 		assert.Equal(t, ok, scenario.expected)
 	}
 
 	// nil variation should _always_ return false
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType)
 		assert.False(t, ok)
 	}
 
 	// should _always_ return true if sendFlagDecisions is set
 	tc.sendFlagDecisions = true
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType)
 		assert.True(t, ok)
 	}
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -97,7 +97,7 @@ func BuildTestImpressionEvent() UserEvent {
 	variation.Key = "variation_a"
 	variation.ID = "15410990633"
 
-	impressionUserEvent := CreateImpressionUserEvent(config, experiment, variation, userContext, experiment.Key, "experiment")
+	impressionUserEvent := CreateImpressionUserEvent(config, experiment, &variation, userContext, experiment.Key, "experiment")
 
 	return impressionUserEvent
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -97,7 +97,7 @@ func BuildTestImpressionEvent() UserEvent {
 	variation.Key = "variation_a"
 	variation.ID = "15410990633"
 
-	impressionUserEvent := CreateImpressionUserEvent(config, experiment, &variation, userContext, experiment.Key, "experiment")
+	impressionUserEvent, _ := CreateImpressionUserEvent(config, experiment, &variation, userContext, experiment.Key, "experiment")
 
 	return impressionUserEvent
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/optimizely/go-sdk/pkg/config"
-	"github.com/optimizely/go-sdk/pkg/decision"
-	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/optimizely/go-sdk/pkg/config"
+	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
 type TestConfig struct {
@@ -88,21 +88,16 @@ var userContext = entities.UserContext{
 func BuildTestImpressionEvent() UserEvent {
 	config := TestConfig{}
 
-	fd := decision.FeatureDecision{
-		Decision: decision.Decision{},
-		Source:   "test",
-		Experiment: entities.Experiment{
-			ID:      "15402980349",
-			LayerID: "15399420423",
-			Key:     "background_experiment",
-		},
-		Variation: &entities.Variation{
-			ID:  "15410990633",
-			Key: "variation_a",
-		},
-	}
+	experiment := entities.Experiment{}
+	experiment.Key = "background_experiment"
+	experiment.LayerID = "15399420423"
+	experiment.ID = "15402980349"
 
-	impressionUserEvent := CreateImpressionUserEvent(config, fd, userContext)
+	variation := entities.Variation{}
+	variation.Key = "variation_a"
+	variation.ID = "15410990633"
+
+	impressionUserEvent := CreateImpressionUserEvent(config, experiment, variation, userContext, experiment.Key, "experiment")
 
 	return impressionUserEvent
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -69,6 +69,9 @@ func (TestConfig) GetClientName() string {
 func (TestConfig) GetClientVersion() string {
 	return "1.0.0"
 }
+func (TestConfig) SendFlagDecisions() bool {
+	return false
+}
 
 func RandomString(len int) string {
 	bytes := make([]byte, len)


### PR DESCRIPTION
## Summary
* Add experiment/feature flag key, variation key and type to impression events.
* Send events for **ALL** decision types.
* Add `Metadata` field to EventBatch.Decisions to capture flag type, key and variation key.

This change outline the proposed logical and structural changes required to support capturing all decision instances. The new eventbatch field is backwards compatible with the current pipeline.