### PR TITLE
fix: corrected logic for rollout services

### DIFF
--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -74,8 +74,10 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 			featureDecision.Decision = decision.Decision
 		}
 
-		featureDecision.Experiment = *experiment
 		featureDecision.Variation = decision.Variation
+		if featureDecision.Variation != nil {
+			featureDecision.Experiment = *experiment
+		}
 		r.logger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))
 		return featureDecision, nil
 	}

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -199,7 +199,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionWhenFallbackBucketingFails() {
 		logger:                    s.mockLogger,
 	}
 	expectedFeatureDecision := FeatureDecision{
-		Experiment: testExp1118,
+		Experiment: entities.Experiment{}, // should not populate good experiment on nil variation
 		Source:     Rollout,
 		Decision:   Decision{Reason: reasons.FailedRolloutBucketing},
 	}


### PR DESCRIPTION
## Summary 
- corrected logic for rollout services: don't populate experiment when variation is null 
- that should be safe and won't break notification center since 
```
if featureDecision.Source == FeatureTest {
		sourceInfo["experimentKey"] = featureDecision.Experiment.Key
		sourceInfo["variationKey"] = featureDecision.Variation.Key
	}
```
is the only logic accessing  featureDecision.Experiment directly. And our change is happening on the rollout only
