### PR TITLE
feat: added "enabled" field to decision metadata structure

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -77,7 +77,7 @@ func (o *OptimizelyClient) Activate(experimentKey string, userContext entities.U
 		// send an impression event
 		result = experimentDecision.Variation.Key
 		if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, *decisionContext.Experiment,
-			experimentDecision.Variation, userContext, "", experimentKey, "experiment"); ok {
+			experimentDecision.Variation, userContext, "", experimentKey, "experiment", true); ok {
 			o.EventProcessor.ProcessEvent(ue)
 		}
 	}
@@ -132,7 +132,7 @@ func (o *OptimizelyClient) IsFeatureEnabled(featureKey string, userContext entit
 	}
 
 	if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-		featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source); ok {
+		featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source, result); ok && featureDecision.Source != "" {
 		o.EventProcessor.ProcessEvent(ue)
 	}
 
@@ -476,7 +476,7 @@ func (o *OptimizelyClient) GetDetailedFeatureDecisionUnsafe(featureKey string, u
 		if !disableTracking {
 			// send impression event for feature tests
 			if ue, ok := event.CreateImpressionUserEvent(decisionContext.ProjectConfig, featureDecision.Experiment,
-				featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source); ok {
+				featureDecision.Variation, userContext, featureKey, featureDecision.Experiment.Key, featureDecision.Source, decisionInfo.Enabled); ok {
 				o.EventProcessor.ProcessEvent(ue)
 			}
 		}

--- a/pkg/event/events.go
+++ b/pkg/event/events.go
@@ -55,6 +55,7 @@ type DecisionMetadata struct {
 	RuleKey      string `json:"rule_key"`
 	RuleType     string `json:"rule_type"`
 	VariationKey string `json:"variation_key"`
+	Enabled      bool   `json:"enabled"`
 }
 
 // ConversionEvent represents a conversion event

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -64,13 +64,14 @@ func createImpressionEvent(
 	experiment entities.Experiment,
 	variation *entities.Variation,
 	attributes map[string]interface{},
-	flagKey, ruleKey, ruleType string,
+	flagKey, ruleKey, ruleType string, enabled bool,
 ) ImpressionEvent {
 
 	metadata := DecisionMetadata{
 		FlagKey:  flagKey,
 		RuleKey:  ruleKey,
 		RuleType: ruleType,
+		Enabled:  enabled,
 	}
 
 	var variationID string
@@ -94,13 +95,13 @@ func createImpressionEvent(
 
 // CreateImpressionUserEvent creates and returns ImpressionEvent for user
 func CreateImpressionUserEvent(projectConfig config.ProjectConfig, experiment entities.Experiment,
-	variation *entities.Variation, userContext entities.UserContext, flagKey, ruleKey, ruleType string) (UserEvent, bool) {
+	variation *entities.Variation, userContext entities.UserContext, flagKey, ruleKey, ruleType string, enabled bool) (UserEvent, bool) {
 
 	if (ruleType == decisionPkg.Rollout || variation == nil) && !projectConfig.SendFlagDecisions() {
 		return UserEvent{}, false
 	}
 
-	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, ruleKey, ruleType)
+	impression := createImpressionEvent(projectConfig, experiment, variation, userContext.Attributes, flagKey, ruleKey, ruleType, enabled)
 
 	userEvent := UserEvent{}
 	userEvent.Timestamp = makeTimestamp()

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -103,7 +103,7 @@ var userContext = entities.UserContext{
 
 func BuildTestImpressionEvent() UserEvent {
 	tc := TestConfig{}
-	impressionUserEvent, _ := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, "experiment")
+	impressionUserEvent, _ := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, "experiment", true)
 	return impressionUserEvent
 }
 
@@ -195,20 +195,20 @@ func TestCreateImpressionUserEvent(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, scenario.flagType, true)
 		assert.Equal(t, ok, scenario.expected)
 	}
 
 	// nil variation should _always_ return false
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, true)
 		assert.False(t, ok)
 	}
 
 	// should _always_ return true if sendFlagDecisions is set
 	tc.sendFlagDecisions = true
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType)
+		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, true)
 		assert.True(t, ok)
 	}
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -195,20 +195,42 @@ func TestCreateImpressionUserEvent(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, scenario.flagType, true)
+		userEvent, ok := CreateImpressionUserEvent(tc, testExperiment, &testVariation, userContext, "", testExperiment.Key, scenario.flagType, true)
 		assert.Equal(t, ok, scenario.expected)
+
+		if ok {
+			metaData := userEvent.Impression.Metadata
+			assert.Equal(t, "", metaData.FlagKey)
+			assert.Equal(t, testExperiment.Key, metaData.RuleKey)
+			assert.Equal(t, scenario.flagType, metaData.RuleType)
+			assert.Equal(t, true, metaData.Enabled)
+		}
 	}
 
 	// nil variation should _always_ return false
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, true)
+		userEvent, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, false)
 		assert.False(t, ok)
+		if ok {
+			metaData := userEvent.Impression.Metadata
+			assert.Equal(t, "", metaData.FlagKey)
+			assert.Equal(t, testExperiment.Key, metaData.RuleKey)
+			assert.Equal(t, scenario.flagType, metaData.RuleType)
+			assert.Equal(t, false, metaData.Enabled)
+		}
 	}
 
 	// should _always_ return true if sendFlagDecisions is set
 	tc.sendFlagDecisions = true
 	for _, scenario := range scenarios {
-		_, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, true)
+		userEvent, ok := CreateImpressionUserEvent(tc, testExperiment, nil, userContext, "", testExperiment.Key, scenario.flagType, true)
 		assert.True(t, ok)
+		if ok {
+			metaData := userEvent.Impression.Metadata
+			assert.Equal(t, "", metaData.FlagKey)
+			assert.Equal(t, testExperiment.Key, metaData.RuleKey)
+			assert.Equal(t, scenario.flagType, metaData.RuleType)
+			assert.Equal(t, true, metaData.Enabled)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- added "enabled" field to decision metadata structure
- setting "enabled" to true for activate() since we check for non nil variation. 

