### PR TITLE
refact(decision-reasons): Refactoring reasons for decide api

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -302,7 +302,7 @@ func TestGetFeatureVariableBool(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		client := OptimizelyClient{
 			ConfigManager:   mockConfigManager,
@@ -380,7 +380,7 @@ func TestGetFeatureVariableBoolWithNotification(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		notificationCenter := notification.NewNotificationCenter()
 		client := OptimizelyClient{
@@ -487,7 +487,7 @@ func TestGetFeatureVariableDouble(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		client := OptimizelyClient{
 			ConfigManager:   mockConfigManager,
@@ -565,7 +565,7 @@ func TestGetFeatureVariableDoubleWithNotification(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		notificationCenter := notification.NewNotificationCenter()
 		client := OptimizelyClient{
@@ -672,7 +672,7 @@ func TestGetFeatureVariableInteger(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		client := OptimizelyClient{
 			ConfigManager:   mockConfigManager,
@@ -750,7 +750,7 @@ func TestGetFeatureVariableIntegerWithNotification(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		notificationCenter := notification.NewNotificationCenter()
 		client := OptimizelyClient{
@@ -855,7 +855,7 @@ func TestGetFeatureVariableSting(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		client := OptimizelyClient{
 			ConfigManager:   mockConfigManager,
@@ -931,7 +931,7 @@ func TestGetFeatureVariableStringWithNotification(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		notificationCenter := notification.NewNotificationCenter()
 		client := OptimizelyClient{
@@ -1038,7 +1038,7 @@ func TestGetFeatureVariableJSON(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		client := OptimizelyClient{
 			ConfigManager:   mockConfigManager,
@@ -1122,7 +1122,7 @@ func TestGetFeatureVariableJSONWithNotification(t *testing.T) {
 
 		expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 		mockDecisionService := new(MockDecisionService)
-		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+		mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 		notificationCenter := notification.NewNotificationCenter()
 		client := OptimizelyClient{
@@ -1271,7 +1271,7 @@ func TestGetFeatureDecisionValid(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1317,7 +1317,7 @@ func TestGetFeatureDecisionErrProjectConfig(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1361,7 +1361,7 @@ func TestGetFeatureDecisionPanicProjectConfig(t *testing.T) {
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
 
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   &PanickingConfigManager{},
@@ -1442,7 +1442,7 @@ func TestGetFeatureDecisionErrFeatureDecision(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, errors.New("error feature"))
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), errors.New("error feature"))
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1497,7 +1497,7 @@ func TestGetAllFeatureVariablesWithDecision(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1554,7 +1554,7 @@ func TestGetAllFeatureVariablesWithDecisionWithNotification(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	notificationCenter := notification.NewNotificationCenter()
 	client := OptimizelyClient{
@@ -1616,7 +1616,7 @@ func TestGetAllFeatureVariablesWithDecisionWithError(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, errors.New(""))
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), errors.New(""))
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1696,7 +1696,7 @@ func TestGetDetailedFeatureDecisionUnsafeWithNotification(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	notificationCenter := notification.NewNotificationCenter()
 	client := OptimizelyClient{
@@ -1767,7 +1767,7 @@ func TestGetDetailedFeatureDecisionUnsafeWithTrackingDisabled(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1827,7 +1827,7 @@ func TestGetDetailedFeatureDecisionUnsafeWithError(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, errors.New(""))
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), errors.New(""))
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1867,7 +1867,7 @@ func TestGetDetailedFeatureDecisionUnsafeWithFeatureTestAndTrackingEnabled(t *te
 		Source:     decision.FeatureTest,
 	}
 
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -1928,7 +1928,7 @@ func TestGetAllFeatureVariables(t *testing.T) {
 
 	expectedFeatureDecision := getTestFeatureDecision(testExperiment, testVariation)
 	mockDecisionService := new(MockDecisionService)
-	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   mockConfigManager,
@@ -2044,7 +2044,7 @@ func (s *ClientTestSuiteAB) TestActivate() {
 	expectedExperimentDecision := decision.ExperimentDecision{
 		Variation: &expectedVariation,
 	}
-	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedExperimentDecision, nil)
+	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedExperimentDecision, decide.NewDecisionReasons(nil), nil)
 	s.mockEventProcessor.On("ProcessEvent", mock.AnythingOfType("event.UserEvent"))
 
 	testClient := OptimizelyClient{
@@ -2113,7 +2113,7 @@ func (s *ClientTestSuiteAB) TestGetVariation() {
 	expectedExperimentDecision := decision.ExperimentDecision{
 		Variation: &expectedVariation,
 	}
-	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedExperimentDecision, nil)
+	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedExperimentDecision, decide.NewDecisionReasons(nil), nil)
 
 	testClient := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
@@ -2143,7 +2143,7 @@ func (s *ClientTestSuiteAB) TestGetVariationWithDecisionError() {
 	expectedExperimentDecision := decision.ExperimentDecision{
 		Variation: &expectedVariation,
 	}
-	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedExperimentDecision, errors.New(""))
+	s.mockDecisionService.On("GetExperimentDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedExperimentDecision, decide.NewDecisionReasons(nil), errors.New(""))
 
 	testClient := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
@@ -2211,7 +2211,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabled() {
 		Source:     decision.FeatureTest,
 	}
 
-	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,
@@ -2248,7 +2248,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledWithNotification() {
 		Source:     decision.FeatureTest,
 	}
 
-	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, nil)
+	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), nil)
 
 	notificationCenter := notification.NewNotificationCenter()
 	client := OptimizelyClient{
@@ -2302,7 +2302,7 @@ func (s *ClientTestSuiteFM) TestIsFeatureEnabledWithDecisionError() {
 		Source:     decision.FeatureTest,
 	}
 
-	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecision, errors.New(""))
+	s.mockDecisionService.On("GetFeatureDecision", testDecisionContext, testUserContext, &decide.Options{}).Return(expectedFeatureDecision, decide.NewDecisionReasons(nil), errors.New(""))
 	s.mockEventProcessor.On("ProcessEvent", mock.AnythingOfType("event.UserEvent"))
 
 	client := OptimizelyClient{
@@ -2411,8 +2411,8 @@ func (s *ClientTestSuiteFM) TestGetEnabledFeatures() {
 		Variation:  &testVariationDisabled,
 	}
 
-	s.mockDecisionService.On("GetFeatureDecision", testDecisionContextEnabled, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecisionEnabled, nil)
-	s.mockDecisionService.On("GetFeatureDecision", testDecisionContextDisabled, testUserContext, &decide.Options{}, decide.NewDecisionReasons(&decide.Options{})).Return(expectedFeatureDecisionDisabled, nil)
+	s.mockDecisionService.On("GetFeatureDecision", testDecisionContextEnabled, testUserContext, &decide.Options{}).Return(expectedFeatureDecisionEnabled, decide.NewDecisionReasons(nil), nil)
+	s.mockDecisionService.On("GetFeatureDecision", testDecisionContextDisabled, testUserContext, &decide.Options{}).Return(expectedFeatureDecisionDisabled, decide.NewDecisionReasons(nil), nil)
 
 	client := OptimizelyClient{
 		ConfigManager:   s.mockConfigManager,

--- a/pkg/client/fixtures_test.go
+++ b/pkg/client/fixtures_test.go
@@ -117,14 +117,14 @@ type MockDecisionService struct {
 	mock.Mock
 }
 
-func (m *MockDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (decision.FeatureDecision, error) {
-	args := m.Called(decisionContext, userContext, options, reasons)
-	return args.Get(0).(decision.FeatureDecision), args.Error(1)
+func (m *MockDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (decision.FeatureDecision, decide.DecisionReasons, error) {
+	args := m.Called(decisionContext, userContext, options)
+	return args.Get(0).(decision.FeatureDecision), args.Get(1).(decide.DecisionReasons), args.Error(2)
 }
 
-func (m *MockDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (decision.ExperimentDecision, error) {
-	args := m.Called(decisionContext, userContext, options, reasons)
-	return args.Get(0).(decision.ExperimentDecision), args.Error(1)
+func (m *MockDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options) (decision.ExperimentDecision, decide.DecisionReasons, error) {
+	args := m.Called(decisionContext, userContext, options)
+	return args.Get(0).(decision.ExperimentDecision), args.Get(1).(decide.DecisionReasons), args.Error(2)
 }
 
 func (m *MockDecisionService) OnDecision(callback func(note notification.DecisionNotification)) (int, error) {
@@ -160,11 +160,11 @@ func (m *PanickingConfigManager) GetConfig() (config.ProjectConfig, error) {
 type PanickingDecisionService struct {
 }
 
-func (m *PanickingDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (decision.FeatureDecision, error) {
+func (m *PanickingDecisionService) GetFeatureDecision(decisionContext decision.FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (decision.FeatureDecision, decide.DecisionReasons, error) {
 	panic("I'm panicking")
 }
 
-func (m *PanickingDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (decision.ExperimentDecision, error) {
+func (m *PanickingDecisionService) GetExperimentDecision(decisionContext decision.ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options) (decision.ExperimentDecision, decide.DecisionReasons, error) {
 	panic("I'm panicking")
 }
 

--- a/pkg/decide/decision_reasons.go
+++ b/pkg/decide/decision_reasons.go
@@ -21,5 +21,6 @@ package decide
 type DecisionReasons interface {
 	AddError(format string, arguments ...interface{})
 	AddInfo(format string, arguments ...interface{}) string
+	Append(reasons DecisionReasons)
 	ToReport() []string
 }

--- a/pkg/decide/decision_reasons_test.go
+++ b/pkg/decide/decision_reasons_test.go
@@ -75,3 +75,37 @@ func TestInfoLogsAreOnlyReportedWhenIncludeReasonsOptionIsSet(t *testing.T) {
 	assert.Equal(t, "info message", reportedReasons[2])
 	assert.Equal(t, "info message: unexpected string", reportedReasons[3])
 }
+
+func TestAppend(t *testing.T) {
+	options := &Options{
+		DisableDecisionEvent:     true,
+		EnabledFlagsOnly:         true,
+		IgnoreUserProfileService: true,
+		ExcludeVariables:         true,
+		IncludeReasons:           true,
+	}
+	reasons1 := NewDecisionReasons(options)
+	reasons1.AddError("error message")
+	reasons1.AddError("error message: code %d", 121)
+	reasons1.AddInfo("info message")
+	reasons1.AddInfo("info message: %s", "unexpected string")
+
+	// Shouldn't append info logs if include reasons is set to false
+	reasons2 := NewDecisionReasons(nil)
+	reasons2.Append(reasons1)
+	reportedReasons := reasons2.ToReport()
+	assert.Equal(t, 2, len(reportedReasons))
+	assert.Equal(t, "error message", reportedReasons[0])
+	assert.Equal(t, "error message: code 121", reportedReasons[1])
+
+	// Should append info logs if include reasons is set to true
+	options.IncludeReasons = true
+	reasons2 = NewDecisionReasons(options)
+	reasons2.Append(reasons1)
+	reportedReasons = reasons2.ToReport()
+	assert.Equal(t, 4, len(reportedReasons))
+	assert.Equal(t, "error message", reportedReasons[0])
+	assert.Equal(t, "error message: code 121", reportedReasons[1])
+	assert.Equal(t, "info message", reportedReasons[2])
+	assert.Equal(t, "info message: unexpected string", reportedReasons[3])
+}

--- a/pkg/decide/default_decision_reasons.go
+++ b/pkg/decide/default_decision_reasons.go
@@ -29,10 +29,14 @@ type DefaultDecisionReasons struct {
 
 // NewDecisionReasons returns a new instance of DecisionReasons.
 func NewDecisionReasons(options *Options) *DefaultDecisionReasons {
+	includeReasons := false
+	if options != nil {
+		includeReasons = options.IncludeReasons
+	}
 	return &DefaultDecisionReasons{
 		errors:         []string{},
 		logs:           []string{},
-		includeReasons: options.IncludeReasons,
+		includeReasons: includeReasons,
 	}
 }
 
@@ -49,6 +53,16 @@ func (o *DefaultDecisionReasons) AddInfo(format string, arguments ...interface{}
 	}
 	o.logs = append(o.logs, message)
 	return message
+}
+
+// Append appends given reasons.
+func (o *DefaultDecisionReasons) Append(reasons DecisionReasons) {
+	if decisionReasons, ok := reasons.(*DefaultDecisionReasons); ok {
+		o.errors = append(o.errors, decisionReasons.errors...)
+		if o.includeReasons {
+			o.logs = append(o.logs, decisionReasons.logs...)
+		}
+	}
 }
 
 // ToReport returns reasons to be reported.

--- a/pkg/decision/composite_experiment_service_test.go
+++ b/pkg/decision/composite_experiment_service_test.go
@@ -61,13 +61,13 @@ func (s *CompositeExperimentTestSuite) TestGetDecision() {
 	expectedExperimentDecision := ExperimentDecision{
 		Variation: &expectedVariation,
 	}
-	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedExperimentDecision, nil)
+	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(expectedExperimentDecision, s.reasons, nil)
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
 		logger:             logging.GetLogger("sdkKey", "ExperimentService"),
 	}
-	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 	s.Equal(expectedExperimentDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())
@@ -83,18 +83,18 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionFallthrough() {
 
 	expectedVariation := testExp1111.Variations["2222"]
 	expectedExperimentDecision := ExperimentDecision{}
-	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedExperimentDecision, nil)
+	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(expectedExperimentDecision, s.reasons, nil)
 
 	expectedExperimentDecision2 := ExperimentDecision{
 		Variation: &expectedVariation,
 	}
-	s.mockExperimentService2.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedExperimentDecision2, nil)
+	s.mockExperimentService2.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(expectedExperimentDecision2, s.reasons, nil)
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
 		logger:             logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
-	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(expectedExperimentDecision2, decision)
@@ -108,16 +108,16 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionNoDecisionsMade() {
 		ID: "test_user_1",
 	}
 	expectedExperimentDecision := ExperimentDecision{}
-	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedExperimentDecision, nil)
+	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(expectedExperimentDecision, s.reasons, nil)
 
 	expectedExperimentDecision2 := ExperimentDecision{}
-	s.mockExperimentService2.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedExperimentDecision2, nil)
+	s.mockExperimentService2.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(expectedExperimentDecision2, s.reasons, nil)
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{s.mockExperimentService, s.mockExperimentService2},
 		logger:             logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
-	decision, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(expectedExperimentDecision2, decision)
@@ -139,12 +139,12 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionReturnsError() {
 	shouldBeIgnoredDecision := ExperimentDecision{
 		Variation: &testExp1114Var2225,
 	}
-	s.mockExperimentService.On("GetDecision", testDecisionContext, testUserContext, s.options, s.reasons).Return(shouldBeIgnoredDecision, errors.New("Error making decision"))
+	s.mockExperimentService.On("GetDecision", testDecisionContext, testUserContext, s.options).Return(shouldBeIgnoredDecision, s.reasons, errors.New("Error making decision"))
 
 	expectedDecision := ExperimentDecision{
 		Variation: &testExp1114Var2226,
 	}
-	s.mockExperimentService2.On("GetDecision", testDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, nil)
+	s.mockExperimentService2.On("GetDecision", testDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, nil)
 
 	compositeExperimentService := &CompositeExperimentService{
 		experimentServices: []ExperimentService{
@@ -153,7 +153,7 @@ func (s *CompositeExperimentTestSuite) TestGetDecisionReturnsError() {
 		},
 		logger: logging.GetLogger("sdkKey", "CompositeExperimentService"),
 	}
-	decision, err := compositeExperimentService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeExperimentService.GetDecision(testDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -64,7 +64,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecision() {
 		Experiment: testExp1113,
 		Variation:  &testExp1113Var2223,
 	}
-	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, nil)
+	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, nil)
 
 	compositeFeatureService := &CompositeFeatureService{
 		featureServices: []FeatureService{
@@ -73,7 +73,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecision() {
 		},
 		logger: logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
-	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockFeatureService.AssertExpectations(s.T())
@@ -87,12 +87,12 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionFallthrough() {
 	}
 
 	nilDecision := FeatureDecision{}
-	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(nilDecision, nil)
+	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(nilDecision, s.reasons, nil)
 
 	expectedDecision := FeatureDecision{
 		Variation: &testExp1113Var2223,
 	}
-	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, nil)
+	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, nil)
 
 	compositeFeatureService := &CompositeFeatureService{
 		featureServices: []FeatureService{
@@ -101,7 +101,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionFallthrough() {
 		},
 		logger: logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
-	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockFeatureService.AssertExpectations(s.T())
@@ -117,12 +117,12 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsError() {
 	shouldBeIgnoredDecision := FeatureDecision{
 		Variation: &testExp1113Var2223,
 	}
-	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(shouldBeIgnoredDecision, errors.New("Error making decision"))
+	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(shouldBeIgnoredDecision, s.reasons, errors.New("Error making decision"))
 
 	expectedDecision := FeatureDecision{
 		Variation: &testExp1113Var2224,
 	}
-	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, nil)
+	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, nil)
 
 	compositeFeatureService := &CompositeFeatureService{
 		featureServices: []FeatureService{
@@ -131,7 +131,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsError() {
 		},
 		logger: logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
-	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockFeatureService.AssertExpectations(s.T())
@@ -147,8 +147,8 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 	expectedDecision := FeatureDecision{
 		Variation: &testExp1113Var2223,
 	}
-	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, errors.New("Error making decision"))
-	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options, s.reasons).Return(expectedDecision, errors.New("test error"))
+	s.mockFeatureService.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, errors.New("Error making decision"))
+	s.mockFeatureService2.On("GetDecision", s.testFeatureDecisionContext, testUserContext, s.options).Return(expectedDecision, s.reasons, errors.New("test error"))
 
 	compositeFeatureService := &CompositeFeatureService{
 		featureServices: []FeatureService{
@@ -157,7 +157,7 @@ func (s *CompositeFeatureServiceTestSuite) TestGetDecisionReturnsLastDecisionWit
 		},
 		logger: logging.GetLogger("sdkKey", "CompositeFeatureService"),
 	}
-	decision, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := compositeFeatureService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.Error(err)
 	s.Equal(err.Error(), "test error")

--- a/pkg/decision/composite_service_test.go
+++ b/pkg/decision/composite_service_test.go
@@ -58,8 +58,8 @@ func (s *CompositeServiceFeatureTestSuite) TestGetFeatureDecision() {
 	decisionService := &CompositeService{
 		compositeFeatureService: s.mockFeatureService,
 	}
-	s.mockFeatureService.On("GetDecision", s.decisionContext, s.testUserContext, s.options, s.reasons).Return(expectedFeatureDecision, nil)
-	featureDecision, err := decisionService.GetFeatureDecision(s.decisionContext, s.testUserContext, s.options, s.reasons)
+	s.mockFeatureService.On("GetDecision", s.decisionContext, s.testUserContext, s.options).Return(expectedFeatureDecision, s.reasons, nil)
+	featureDecision, _, err := decisionService.GetFeatureDecision(s.decisionContext, s.testUserContext, s.options)
 
 	// Test assertions
 	s.Equal(expectedFeatureDecision, featureDecision)
@@ -112,8 +112,8 @@ func (s *CompositeServiceExperimentTestSuite) TestGetExperimentDecision() {
 	decisionService := &CompositeService{
 		compositeExperimentService: s.mockExperimentService,
 	}
-	s.mockExperimentService.On("GetDecision", s.decisionContext, s.testUserContext, s.options, s.reasons).Return(expectedExperimentDecision, nil)
-	experimentDecision, err := decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options, s.reasons)
+	s.mockExperimentService.On("GetDecision", s.decisionContext, s.testUserContext, s.options).Return(expectedExperimentDecision, s.reasons, nil)
+	experimentDecision, _, err := decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options)
 
 	// Test assertions
 	s.Equal(expectedExperimentDecision, experimentDecision)
@@ -130,8 +130,8 @@ func (s *CompositeServiceExperimentTestSuite) TestDecisionListeners() {
 		compositeExperimentService: s.mockExperimentService,
 		notificationCenter:         notificationCenter,
 	}
-	s.mockExperimentService.On("GetDecision", s.decisionContext, s.testUserContext, s.options, s.reasons).Return(expectedExperimentDecision, nil)
-	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options, s.reasons)
+	s.mockExperimentService.On("GetDecision", s.decisionContext, s.testUserContext, s.options).Return(expectedExperimentDecision, s.reasons, nil)
+	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options)
 
 	var numberOfCalls = 0
 
@@ -142,13 +142,13 @@ func (s *CompositeServiceExperimentTestSuite) TestDecisionListeners() {
 	id, _ := decisionService.OnDecision(callback)
 
 	s.NotEqual(0, id)
-	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options, s.reasons)
+	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options)
 
 	s.Equal(numberOfCalls, 1)
 
 	err := decisionService.RemoveOnDecision(id)
 	s.NoError(err)
-	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options, s.reasons)
+	decisionService.GetExperimentDecision(s.decisionContext, s.testUserContext, s.options)
 	s.Equal(numberOfCalls, 1)
 }
 

--- a/pkg/decision/evaluator/condition_test.go
+++ b/pkg/decision/evaluator/condition_test.go
@@ -36,7 +36,7 @@ type ConditionTestSuite struct {
 func (s *ConditionTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
 	s.conditionEvaluator = NewCustomAttributeConditionEvaluator(s.mockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
+	s.reasons = decide.NewDecisionReasons(nil)
 }
 
 func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluator() {
@@ -55,7 +55,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluator() {
 	}
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
-	result, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, true)
 
 	// Test condition fails
@@ -64,7 +64,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluator() {
 			"string_foo": "not_foo",
 		},
 	}
-	result, _ = s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ = s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, false)
 }
 
@@ -83,7 +83,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorWithoutMatchTy
 	}
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
-	result, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, true)
 
 	// Test condition fails
@@ -92,7 +92,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorWithoutMatchTy
 			"string_foo": "not_foo",
 		},
 	}
-	result, _ = s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ = s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, false)
 }
 
@@ -113,7 +113,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorWithInvalidMat
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnknownMatchType.String(), ""))
-	result, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, false)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -134,7 +134,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorWithUnknownTyp
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnknownConditionType.String(), ""))
-	result, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := s.conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, false)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -156,7 +156,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorForGeSemver() 
 	}
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
-	result, _ := conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(result, true)
 }
 
@@ -177,7 +177,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorForGeSemverBet
 	}
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
-	result, _ := conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	result, _, _ := conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.Equal(true, result)
 }
 
@@ -198,7 +198,7 @@ func (s *ConditionTestSuite) TestCustomAttributeConditionEvaluatorForGeSemverInv
 	}
 
 	condTreeParams := entities.NewTreeParameters(&user, map[string]entities.Audience{})
-	_, err := conditionEvaluator.Evaluate(condition, condTreeParams, s.reasons)
+	_, _, err := conditionEvaluator.Evaluate(condition, condTreeParams)
 	s.NotNil(err)
 }
 

--- a/pkg/decision/evaluator/condition_tree_test.go
+++ b/pkg/decision/evaluator/condition_tree_test.go
@@ -78,7 +78,7 @@ type ConditionTreeTestSuite struct {
 
 func (s *ConditionTreeTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
+	s.reasons = decide.NewDecisionReasons(nil)
 	s.conditionTreeEvaluator = NewMixedTreeEvaluator(s.mockLogger)
 }
 
@@ -99,7 +99,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateSimpleCondition() {
 		},
 	}
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
-	result, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test no match
@@ -108,7 +108,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateSimpleCondition() {
 			"string_foo": "not foo",
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 }
 
@@ -133,7 +133,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleOrConditions()
 	}
 
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
-	result, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test match bool
@@ -143,7 +143,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleOrConditions()
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "string_foo"))
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 
 	s.True(result)
 
@@ -154,7 +154,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleOrConditions()
 			"bool_true":  true,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test no match
@@ -164,7 +164,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleOrConditions()
 			"bool_true":  false,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -191,7 +191,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleAndConditions(
 
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "bool_true"))
-	result, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 
 	// Test only bool match with NULL bubbling
@@ -202,7 +202,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleAndConditions(
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "string_foo"))
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 
 	// Test match both
@@ -212,7 +212,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleAndConditions(
 			"bool_true":  true,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test no match
@@ -222,7 +222,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleAndConditions(
 			"bool_true":  false,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -259,7 +259,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateNotCondition() {
 	}
 
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
-	result, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test match bool
@@ -269,7 +269,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateNotCondition() {
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "string_foo"))
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test match both
@@ -279,7 +279,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateNotCondition() {
 			"bool_true":  false,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test no match
@@ -289,7 +289,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateNotCondition() {
 			"bool_true":  true,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -339,7 +339,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleMixedCondition
 	}
 
 	condTreeParams := e.NewTreeParameters(&user, map[string]e.Audience{})
-	result, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test only match the NOT condition
@@ -350,7 +350,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleMixedCondition
 			"int_42":     43,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test only match the int condition
@@ -361,7 +361,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleMixedCondition
 			"int_42":     42,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.True(result)
 
 	// Test no match
@@ -372,7 +372,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateMultipleMixedCondition
 			"int_42":     43,
 		},
 	}
-	result, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(conditionTree, condTreeParams)
 	s.False(result)
 }
 
@@ -441,7 +441,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateAnAudienceTreeSingleAu
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluationStarted.String(), "11111"))
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluatedTo.String(), "11111", true))
-	result, _ := s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams)
 	s.True(result)
 	s.mockLogger.AssertExpectations(s.T())
 }
@@ -471,7 +471,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateAnAudienceTreeMultiple
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluationStarted.String(), "11111"))
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluatedTo.String(), "11111", true))
-	result, _ := s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams, s.reasons)
+	result, _, _ := s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams)
 	s.True(result)
 
 	// Test only matches audience 11112
@@ -490,7 +490,7 @@ func (s *ConditionTreeTestSuite) TestConditionTreeEvaluateAnAudienceTreeMultiple
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluationStarted.String(), "11112"))
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.AudienceEvaluatedTo.String(), "11112", true))
 
-	result, _ = s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams, s.reasons)
+	result, _, _ = s.conditionTreeEvaluator.Evaluate(audienceTree, treeParams)
 	s.True(result)
 	s.mockLogger.AssertExpectations(s.T())
 }

--- a/pkg/decision/evaluator/matchers/exact_test.go
+++ b/pkg/decision/evaluator/matchers/exact_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
@@ -51,13 +50,11 @@ func (m *MockLogger) Error(message string, err interface{}) {
 type ExactTestSuite struct {
 	suite.Suite
 	mockLogger *MockLogger
-	reasons    decide.DecisionReasons
 	matcher    Matcher
 }
 
 func (s *ExactTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
 	s.matcher, _ = Get(ExactMatchType)
 }
 
@@ -74,7 +71,7 @@ func (s *ExactTestSuite) TestExactMatcherString() {
 			"string_foo": "foo",
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -85,7 +82,7 @@ func (s *ExactTestSuite) TestExactMatcherString() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -96,7 +93,7 @@ func (s *ExactTestSuite) TestExactMatcherString() {
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "string_foo"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -106,7 +103,7 @@ func (s *ExactTestSuite) TestExactMatcherString() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", 121, "string_foo"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(false)
 	s.mockLogger.AssertExpectations(s.T())
@@ -125,7 +122,7 @@ func (s *ExactTestSuite) TestExactMatcherBool() {
 			"bool_true": true,
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -136,7 +133,7 @@ func (s *ExactTestSuite) TestExactMatcherBool() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -148,7 +145,7 @@ func (s *ExactTestSuite) TestExactMatcherBool() {
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "bool_true"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -158,7 +155,7 @@ func (s *ExactTestSuite) TestExactMatcherBool() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", 121, "bool_true"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -177,7 +174,7 @@ func (s *ExactTestSuite) TestExactMatcherInt() {
 			"int_42": 42,
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -188,7 +185,7 @@ func (s *ExactTestSuite) TestExactMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -199,7 +196,7 @@ func (s *ExactTestSuite) TestExactMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -210,7 +207,7 @@ func (s *ExactTestSuite) TestExactMatcherInt() {
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "int_42"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -220,7 +217,7 @@ func (s *ExactTestSuite) TestExactMatcherInt() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", "test", "int_42"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -239,7 +236,7 @@ func (s *ExactTestSuite) TestExactMatcherFloat() {
 			"float_4_2": 4.2,
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -250,7 +247,7 @@ func (s *ExactTestSuite) TestExactMatcherFloat() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -261,7 +258,7 @@ func (s *ExactTestSuite) TestExactMatcherFloat() {
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "float_4_2"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -271,7 +268,7 @@ func (s *ExactTestSuite) TestExactMatcherFloat() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", "test", "float_4_2"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -291,7 +288,7 @@ func (s *ExactTestSuite) TestExactMatcherUnsupportedConditionValue() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnsupportedConditionValue.String(), ""))
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())

--- a/pkg/decision/evaluator/matchers/exists.go
+++ b/pkg/decision/evaluator/matchers/exists.go
@@ -24,6 +24,6 @@ import (
 )
 
 // ExistsMatcher matches against the "exists" match type
-func ExistsMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, reasons decide.DecisionReasons) (bool, error) {
-	return user.CheckAttributeExists(condition.Name), nil
+func ExistsMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	return user.CheckAttributeExists(condition.Name), decide.NewDecisionReasons(nil), nil
 }

--- a/pkg/decision/evaluator/matchers/exists_test.go
+++ b/pkg/decision/evaluator/matchers/exists_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
@@ -40,7 +39,7 @@ func TestExistsMatcher(t *testing.T) {
 		},
 	}
 
-	result, err := existsMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err := existsMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -51,7 +50,7 @@ func TestExistsMatcher(t *testing.T) {
 		},
 	}
 
-	result, err = existsMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = existsMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
@@ -59,7 +58,7 @@ func TestExistsMatcher(t *testing.T) {
 	user = entities.UserContext{
 		Attributes: map[string]interface{}{},
 	}
-	result, err = ExistsMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = ExistsMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 }

--- a/pkg/decision/evaluator/matchers/ge.go
+++ b/pkg/decision/evaluator/matchers/ge.go
@@ -28,15 +28,15 @@ import (
 )
 
 // GeMatcher matches against the "ge" match type
-func GeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, reasons decide.DecisionReasons) (bool, error) {
-
+func GeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	if floatValue, ok := utils.ToFloat(condition.Value); ok {
 		attributeValue, err := user.GetFloatAttribute(condition.Name)
 		if err != nil {
-			return false, err
+			return false, reasons, err
 		}
-		return floatValue <= attributeValue, nil
+		return floatValue <= attributeValue, reasons, nil
 	}
 
-	return false, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
+	return false, reasons, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
 }

--- a/pkg/decision/evaluator/matchers/ge_test.go
+++ b/pkg/decision/evaluator/matchers/ge_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
@@ -40,7 +39,7 @@ func TestGeMatcherInt(t *testing.T) {
 			"int_42": 43,
 		},
 	}
-	result, err := geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err := geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -51,7 +50,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -62,7 +61,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -73,7 +72,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
@@ -84,7 +83,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	_, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = geMatcher(condition, user, nil)
 	assert.Error(t, err)
 
 	// Test wrong int
@@ -94,7 +93,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	_, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = geMatcher(condition, user, nil)
 	assert.Error(t, err)
 
 	// Test bad condition
@@ -109,7 +108,7 @@ func TestGeMatcherInt(t *testing.T) {
 		},
 	}
 
-	_, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = geMatcher(condition, user, nil)
 	assert.Error(t, err)
 }
 
@@ -126,7 +125,7 @@ func TestGeMatcherFloat(t *testing.T) {
 			"float_4_2": 5,
 		},
 	}
-	result, err := geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err := geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -136,7 +135,7 @@ func TestGeMatcherFloat(t *testing.T) {
 			"float_4_2": 4.29999,
 		},
 	}
-	result, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -147,7 +146,7 @@ func TestGeMatcherFloat(t *testing.T) {
 		},
 	}
 
-	result, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = geMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -158,6 +157,6 @@ func TestGeMatcherFloat(t *testing.T) {
 		},
 	}
 
-	_, err = geMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = geMatcher(condition, user, nil)
 	assert.Error(t, err)
 }

--- a/pkg/decision/evaluator/matchers/gt_test.go
+++ b/pkg/decision/evaluator/matchers/gt_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
@@ -30,13 +29,11 @@ import (
 type GtTestSuite struct {
 	suite.Suite
 	mockLogger *MockLogger
-	reasons    decide.DecisionReasons
 	matcher    Matcher
 }
 
 func (s *GtTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
 	s.matcher, _ = Get(GtMatchType)
 }
 
@@ -53,7 +50,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 			"int_42": 43,
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -64,7 +61,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -75,7 +72,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -86,7 +83,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -97,7 +94,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 		},
 	}
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "int_42"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -107,7 +104,7 @@ func (s *GtTestSuite) TestGtMatcherInt() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", true, "int_42"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -126,7 +123,7 @@ func (s *GtTestSuite) TestGtMatcherFloat() {
 			"float_4_2": 5,
 		},
 	}
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -136,7 +133,7 @@ func (s *GtTestSuite) TestGtMatcherFloat() {
 			"float_4_2": 4.29999,
 		},
 	}
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -147,7 +144,7 @@ func (s *GtTestSuite) TestGtMatcherFloat() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -159,7 +156,7 @@ func (s *GtTestSuite) TestGtMatcherFloat() {
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "float_4_2"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -169,7 +166,7 @@ func (s *GtTestSuite) TestGtMatcherFloat() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", true, "float_4_2"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -189,7 +186,7 @@ func (s *GtTestSuite) TestGtMatcherUnsupportedConditionValue() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnsupportedConditionValue.String(), ""))
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())

--- a/pkg/decision/evaluator/matchers/le.go
+++ b/pkg/decision/evaluator/matchers/le.go
@@ -28,15 +28,15 @@ import (
 )
 
 // LeMatcher matches against the "le" match type
-func LeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, reasons decide.DecisionReasons) (bool, error) {
-
+func LeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	if floatValue, ok := utils.ToFloat(condition.Value); ok {
 		attributeValue, err := user.GetFloatAttribute(condition.Name)
 		if err != nil {
-			return false, err
+			return false, reasons, err
 		}
-		return floatValue >= attributeValue, nil
+		return floatValue >= attributeValue, reasons, nil
 	}
 
-	return false, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
+	return false, reasons, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
 }

--- a/pkg/decision/evaluator/matchers/le_test.go
+++ b/pkg/decision/evaluator/matchers/le_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
@@ -40,7 +39,7 @@ func TestLeMatcherInt(t *testing.T) {
 			"int_42": 41,
 		},
 	}
-	result, err := leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err := leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -50,7 +49,7 @@ func TestLeMatcherInt(t *testing.T) {
 			"int_42": 42,
 		},
 	}
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 	// Test match int to float
@@ -60,7 +59,7 @@ func TestLeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -71,7 +70,7 @@ func TestLeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
@@ -82,7 +81,7 @@ func TestLeMatcherInt(t *testing.T) {
 		},
 	}
 
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
@@ -93,7 +92,7 @@ func TestLeMatcherInt(t *testing.T) {
 		},
 	}
 
-	_, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = leMatcher(condition, user, nil)
 	assert.Error(t, err)
 
 	// Test bad condition
@@ -108,7 +107,7 @@ func TestLeMatcherInt(t *testing.T) {
 		},
 	}
 
-	_, err = LeMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = LeMatcher(condition, user, nil)
 	assert.Error(t, err)
 }
 
@@ -125,7 +124,7 @@ func TestLeMatcherFloat(t *testing.T) {
 			"float_4_2": 4,
 		},
 	}
-	result, err := leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err := leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -135,7 +134,7 @@ func TestLeMatcherFloat(t *testing.T) {
 			"float_4_2": 4.19999,
 		},
 	}
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -145,7 +144,7 @@ func TestLeMatcherFloat(t *testing.T) {
 			"float_4_2": 4.200000,
 		},
 	}
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
@@ -156,7 +155,7 @@ func TestLeMatcherFloat(t *testing.T) {
 		},
 	}
 
-	result, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	result, _, err = leMatcher(condition, user, nil)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
@@ -167,6 +166,6 @@ func TestLeMatcherFloat(t *testing.T) {
 		},
 	}
 
-	_, err = leMatcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+	_, _, err = leMatcher(condition, user, nil)
 	assert.Error(t, err)
 }

--- a/pkg/decision/evaluator/matchers/lt.go
+++ b/pkg/decision/evaluator/matchers/lt.go
@@ -24,10 +24,12 @@ import (
 )
 
 // LtMatcher matches against the "lt" match type
-func LtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, reasons decide.DecisionReasons) (bool, error) {
-	res, err := compare(condition, user, logger, reasons)
+func LtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
+	res, decideReasons, err := compare(condition, user, logger)
+	reasons.Append(decideReasons)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return res < 0, nil
+	return res < 0, reasons, nil
 }

--- a/pkg/decision/evaluator/matchers/lt_test.go
+++ b/pkg/decision/evaluator/matchers/lt_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
@@ -30,13 +29,11 @@ import (
 type LtTestSuite struct {
 	suite.Suite
 	mockLogger *MockLogger
-	reasons    decide.DecisionReasons
 	matcher    Matcher
 }
 
 func (s *LtTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
 	s.matcher, _ = Get(LtMatchType)
 }
 
@@ -54,7 +51,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 		},
 	}
 
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -65,7 +62,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -76,7 +73,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -87,7 +84,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -99,7 +96,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "int_42"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -109,7 +106,7 @@ func (s *LtTestSuite) TestLtMatcherInt() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", true, "int_42"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -129,7 +126,7 @@ func (s *LtTestSuite) TestLtMatcherFloat() {
 		},
 	}
 
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -140,7 +137,7 @@ func (s *LtTestSuite) TestLtMatcherFloat() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -151,7 +148,7 @@ func (s *LtTestSuite) TestLtMatcherFloat() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -163,7 +160,7 @@ func (s *LtTestSuite) TestLtMatcherFloat() {
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "float_4_2"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -173,7 +170,7 @@ func (s *LtTestSuite) TestLtMatcherFloat() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", true, "float_4_2"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -193,7 +190,7 @@ func (s *LtTestSuite) TestLtMatcherUnsupportedConditionValue() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnsupportedConditionValue.String(), ""))
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())

--- a/pkg/decision/evaluator/matchers/registry.go
+++ b/pkg/decision/evaluator/matchers/registry.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Matcher type is used to evaluate audience conditional primitives
-type Matcher func(entities.Condition, entities.UserContext, logging.OptimizelyLogProducer, decide.DecisionReasons) (bool, error)
+type Matcher func(entities.Condition, entities.UserContext, logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error)
 
 const (
 	// ExactMatchType name for the "exact" matcher

--- a/pkg/decision/evaluator/matchers/registry_test.go
+++ b/pkg/decision/evaluator/matchers/registry_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	expected := func(entities.Condition, entities.UserContext, logging.OptimizelyLogProducer, decide.DecisionReasons) (bool, error) {
-		return false, nil
+	expected := func(entities.Condition, entities.UserContext, logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+		return false, decide.DecisionReasons(nil), nil
 	}
 	Register("test", expected)
 	actual := assertMatcher(t, "test")
-	matches, err := actual(entities.Condition{}, entities.UserContext{}, nil, decide.NewDecisionReasons(&decide.Options{}))
+	matches, _, err := actual(entities.Condition{}, entities.UserContext{}, nil)
 	assert.False(t, matches)
 	assert.NoError(t, err)
 }

--- a/pkg/decision/evaluator/matchers/semver.go
+++ b/pkg/decision/evaluator/matchers/semver.go
@@ -26,7 +26,7 @@ import (
 	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/logging"
 
-	"github.com/optimizely/go-sdk/pkg/decision/reasons"
+	pkgReasons "github.com/optimizely/go-sdk/pkg/decision/reasons"
 	"github.com/optimizely/go-sdk/pkg/entities"
 
 	"github.com/pkg/errors"
@@ -89,7 +89,7 @@ func (sv SemanticVersion) compareVersion(attribute string) (int, error) {
 func (sv SemanticVersion) splitSemanticVersion(targetedVersion string) ([]string, error) {
 
 	if sv.hasWhiteSpace(targetedVersion) {
-		return []string{}, errors.New(string(reasons.AttributeFormatInvalid))
+		return []string{}, errors.New(string(pkgReasons.AttributeFormatInvalid))
 	}
 
 	targetPrefix := targetedVersion
@@ -105,7 +105,7 @@ func (sv SemanticVersion) splitSemanticVersion(targetedVersion string) ([]string
 		// in the case it is neither a build or pre release it will return the
 		// original string as the first element in the array
 		if len(targetParts) == 0 {
-			return []string{}, errors.New(string(reasons.AttributeFormatInvalid))
+			return []string{}, errors.New(string(pkgReasons.AttributeFormatInvalid))
 		}
 
 		targetPrefix = targetParts[0]
@@ -118,16 +118,16 @@ func (sv SemanticVersion) splitSemanticVersion(targetedVersion string) ([]string
 	targetedVersionParts := strings.Split(targetPrefix, ".")
 
 	if len(targetedVersionParts) > 3 {
-		return []string{}, errors.New(string(reasons.AttributeFormatInvalid))
+		return []string{}, errors.New(string(pkgReasons.AttributeFormatInvalid))
 	}
 
 	if len(targetedVersionParts) == 0 {
-		return []string{}, errors.New(string(reasons.AttributeFormatInvalid))
+		return []string{}, errors.New(string(pkgReasons.AttributeFormatInvalid))
 	}
 
 	for i := 0; i < len(targetedVersionParts); i++ {
 		if !sv.isNumber(targetedVersionParts[i]) {
-			return []string{}, errors.New(string(reasons.AttributeFormatInvalid))
+			return []string{}, errors.New(string(pkgReasons.AttributeFormatInvalid))
 		}
 	}
 

--- a/pkg/decision/evaluator/matchers/semver.go
+++ b/pkg/decision/evaluator/matchers/semver.go
@@ -216,46 +216,51 @@ func SemverEvaluator(cond entities.Condition, user entities.UserContext) (int, e
 }
 
 // SemverEqMatcher returns true if the user's semver attribute is equal to the semver condition value
-func SemverEqMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, _ decide.DecisionReasons) (bool, error) {
+func SemverEqMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	comparison, err := SemverEvaluator(condition, user)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return comparison == 0, nil
+	return comparison == 0, reasons, nil
 }
 
 // SemverGeMatcher returns true if the user's semver attribute is greater or equal to the semver condition value
-func SemverGeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, _ decide.DecisionReasons) (bool, error) {
+func SemverGeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	comparison, err := SemverEvaluator(condition, user)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return comparison >= 0, nil
+	return comparison >= 0, reasons, nil
 }
 
 // SemverGtMatcher returns true if the user's semver attribute is greater than the semver condition value
-func SemverGtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, _ decide.DecisionReasons) (bool, error) {
+func SemverGtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	comparison, err := SemverEvaluator(condition, user)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return comparison > 0, nil
+	return comparison > 0, reasons, nil
 }
 
 // SemverLeMatcher returns true if the user's semver attribute is less than or equal to the semver condition value
-func SemverLeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, _ decide.DecisionReasons) (bool, error) {
+func SemverLeMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	comparison, err := SemverEvaluator(condition, user)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return comparison <= 0, nil
+	return comparison <= 0, reasons, nil
 }
 
 // SemverLtMatcher returns true if the user's semver attribute is less than the semver condition value
-func SemverLtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, _ decide.DecisionReasons) (bool, error) {
+func SemverLtMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	comparison, err := SemverEvaluator(condition, user)
 	if err != nil {
-		return false, err
+		return false, reasons, err
 	}
-	return comparison < 0, nil
+	return comparison < 0, reasons, nil
 }

--- a/pkg/decision/evaluator/matchers/semver_test.go
+++ b/pkg/decision/evaluator/matchers/semver_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 )
 
@@ -70,7 +69,7 @@ func TestValidAttributes(t *testing.T) {
 		matcher, ok := Get(scenario.matchType)
 		assert.True(t, ok, messageAndArgs...)
 
-		actual, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		actual, _, err := matcher(condition, user, nil)
 		assert.NoError(t, err, messageAndArgs...)
 
 		assert.Equal(t, scenario.expected, actual, messageAndArgs...)
@@ -121,7 +120,7 @@ func TestValidAttributesReleaseToBeta(t *testing.T) {
 		matcher, ok := Get(scenario.matchType)
 		assert.True(t, ok, messageAndArgs...)
 
-		actual, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		actual, _, err := matcher(condition, user, nil)
 		assert.NoError(t, err, messageAndArgs...)
 
 		assert.Equal(t, scenario.expected, actual, messageAndArgs...)
@@ -172,7 +171,7 @@ func TestValidAttributesBetaToRelease(t *testing.T) {
 		matcher, ok := Get(scenario.matchType)
 		assert.True(t, ok, messageAndArgs...)
 
-		actual, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		actual, _, err := matcher(condition, user, nil)
 		assert.NoError(t, err, messageAndArgs...)
 
 		assert.Equal(t, scenario.expected, actual, messageAndArgs...)
@@ -220,7 +219,7 @@ func TestTargetBetaAndBetaComplex(t *testing.T) {
 		matcher, ok := Get(scenario.matchType)
 		assert.True(t, ok, messageAndArgs...)
 
-		actual, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		actual, _, err := matcher(condition, user, nil)
 		assert.NoError(t, err, messageAndArgs...)
 
 		assert.Equal(t, scenario.expected, actual, messageAndArgs...)
@@ -278,7 +277,7 @@ func TestDifferentAttributeAgainstBuildAndPrerelease(t *testing.T) {
 		matcher, ok := Get(scenario.matchType)
 		assert.True(t, ok, messageAndArgs...)
 
-		actual, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		actual, _, err := matcher(condition, user, nil)
 		assert.NoError(t, err, messageAndArgs...)
 
 		assert.Equal(t, scenario.expected, actual, messageAndArgs...)
@@ -330,7 +329,7 @@ func TestInvalidAttributes(t *testing.T) {
 					"version": attribute,
 				},
 			}
-			_, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+			_, _, err := matcher(condition, user, nil)
 			assert.Error(t, err, "matchType: %s, value: %v", matchType, attribute)
 		}
 	}
@@ -358,7 +357,7 @@ func TestInvalidConditions(t *testing.T) {
 				"version": "12.2.3",
 			},
 		}
-		_, err := matcher(condition, user, nil, decide.NewDecisionReasons(&decide.Options{}))
+		_, _, err := matcher(condition, user, nil)
 		assert.Error(t, err, "matchType: semver_eq, value: 12.2.3")
 
 	}

--- a/pkg/decision/evaluator/matchers/substring.go
+++ b/pkg/decision/evaluator/matchers/substring.go
@@ -27,11 +27,11 @@ import (
 )
 
 // SubstringMatcher matches against the "substring" match type
-func SubstringMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer, reasons decide.DecisionReasons) (bool, error) {
-
+func SubstringMatcher(condition entities.Condition, user entities.UserContext, logger logging.OptimizelyLogProducer) (bool, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(nil)
 	if !user.CheckAttributeExists(condition.Name) {
 		logger.Debug(fmt.Sprintf(logging.NullUserAttribute.String(), condition.StringRepresentation, condition.Name))
-		return false, fmt.Errorf(`no attribute named "%s"`, condition.Name)
+		return false, reasons, fmt.Errorf(`no attribute named "%s"`, condition.Name)
 	}
 
 	if stringValue, ok := condition.Value.(string); ok {
@@ -39,11 +39,11 @@ func SubstringMatcher(condition entities.Condition, user entities.UserContext, l
 		if err != nil {
 			val, _ := user.GetAttribute(condition.Name)
 			logger.Warning(fmt.Sprintf(logging.InvalidAttributeValueType.String(), condition.StringRepresentation, val, condition.Name))
-			return false, err
+			return false, reasons, err
 		}
-		return strings.Contains(attributeValue, stringValue), nil
+		return strings.Contains(attributeValue, stringValue), reasons, nil
 	}
 
 	logger.Warning(fmt.Sprintf(logging.UnsupportedConditionValue.String(), condition.StringRepresentation))
-	return false, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
+	return false, reasons, fmt.Errorf("audience condition %s evaluated to NULL because the condition value type is not supported", condition.Name)
 }

--- a/pkg/decision/evaluator/matchers/substring_test.go
+++ b/pkg/decision/evaluator/matchers/substring_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/optimizely/go-sdk/pkg/decide"
 	"github.com/optimizely/go-sdk/pkg/entities"
 	"github.com/optimizely/go-sdk/pkg/logging"
 )
@@ -30,13 +29,11 @@ import (
 type SubstringTestSuite struct {
 	suite.Suite
 	mockLogger *MockLogger
-	reasons    decide.DecisionReasons
 	matcher    Matcher
 }
 
 func (s *SubstringTestSuite) SetupTest() {
 	s.mockLogger = new(MockLogger)
-	s.reasons = decide.NewDecisionReasons(&decide.Options{})
 	s.matcher, _ = Get(SubstringMatchType)
 }
 
@@ -54,7 +51,7 @@ func (s *SubstringTestSuite) TestSubstringMatcher() {
 		},
 	}
 
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.True(result)
 
@@ -65,7 +62,7 @@ func (s *SubstringTestSuite) TestSubstringMatcher() {
 		},
 	}
 
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.NoError(err)
 	s.False(result)
 
@@ -77,7 +74,7 @@ func (s *SubstringTestSuite) TestSubstringMatcher() {
 	}
 
 	s.mockLogger.On("Debug", fmt.Sprintf(logging.NullUserAttribute.String(), "", "string_foo"))
-	_, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	_, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 
 	// Test attribute of different type
@@ -87,7 +84,7 @@ func (s *SubstringTestSuite) TestSubstringMatcher() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.InvalidAttributeValueType.String(), "", true, "string_foo"))
-	result, err = s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err = s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())
@@ -107,7 +104,7 @@ func (s *SubstringTestSuite) TestSubstringMatcherUnsupportedConditionValue() {
 		},
 	}
 	s.mockLogger.On("Warning", fmt.Sprintf(logging.UnsupportedConditionValue.String(), ""))
-	result, err := s.matcher(condition, user, s.mockLogger, s.reasons)
+	result, _, err := s.matcher(condition, user, s.mockLogger)
 	s.Error(err)
 	s.False(result)
 	s.mockLogger.AssertExpectations(s.T())

--- a/pkg/decision/experiment_bucketer_service_test.go
+++ b/pkg/decision/experiment_bucketer_service_test.go
@@ -97,7 +97,7 @@ func (s *ExperimentBucketerTestSuite) TestGetDecisionNoTargeting() {
 		bucketer: s.mockBucketer,
 		logger:   s.mockLogger,
 	}
-	decision, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockLogger.AssertExpectations(s.T())
@@ -117,7 +117,7 @@ func (s *ExperimentBucketerTestSuite) TestGetDecisionWithTargetingPasses() {
 	s.mockBucketer.On("Bucket", testUserContext.ID, testTargetedExp1116, entities.Group{}).Return(&testTargetedExp1116Var2228, reasons.BucketedIntoVariation, nil)
 
 	mockAudienceTreeEvaluator := new(MockAudienceTreeEvaluator)
-	mockAudienceTreeEvaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, true)
+	mockAudienceTreeEvaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, true, s.reasons)
 	experimentBucketerService := ExperimentBucketerService{
 		audienceTreeEvaluator: mockAudienceTreeEvaluator,
 		logger:                s.mockLogger,
@@ -131,7 +131,7 @@ func (s *ExperimentBucketerTestSuite) TestGetDecisionWithTargetingPasses() {
 		Experiment:    &testTargetedExp1116,
 		ProjectConfig: s.mockConfig,
 	}
-	decision, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockLogger.AssertExpectations(s.T())
@@ -148,7 +148,7 @@ func (s *ExperimentBucketerTestSuite) TestGetDecisionWithTargetingFails() {
 		},
 	}
 	mockAudienceTreeEvaluator := new(MockAudienceTreeEvaluator)
-	mockAudienceTreeEvaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, true)
+	mockAudienceTreeEvaluator.On("Evaluate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, true, s.reasons)
 	experimentBucketerService := ExperimentBucketerService{
 		audienceTreeEvaluator: mockAudienceTreeEvaluator,
 		logger:                s.mockLogger,
@@ -163,7 +163,7 @@ func (s *ExperimentBucketerTestSuite) TestGetDecisionWithTargetingFails() {
 		Experiment:    &testTargetedExp1116,
 		ProjectConfig: s.mockConfig,
 	}
-	decision, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := experimentBucketerService.GetDecision(testDecisionContext, testUserContext, s.options)
 	s.Equal(expectedDecision, decision)
 	s.NoError(err)
 	s.mockBucketer.AssertNotCalled(s.T(), "Bucket")

--- a/pkg/decision/experiment_whitelist_service.go
+++ b/pkg/decision/experiment_whitelist_service.go
@@ -35,27 +35,28 @@ func NewExperimentWhitelistService() *ExperimentWhitelistService {
 }
 
 // GetDecision returns a decision with a variation when a variation assignment is found in the experiment whitelist for the given user and experiment
-func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (ExperimentDecision, error) {
+func (s ExperimentWhitelistService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options) (ExperimentDecision, decide.DecisionReasons, error) {
 	decision := ExperimentDecision{}
+	reasons := decide.NewDecisionReasons(options)
 
 	if decisionContext.Experiment == nil {
-		return decision, errors.New("decisionContext Experiment is nil")
+		return decision, reasons, errors.New("decisionContext Experiment is nil")
 	}
 
 	variationKey, ok := decisionContext.Experiment.Whitelist[userContext.ID]
 	if !ok {
 		decision.Reason = pkgReasons.NoWhitelistVariationAssignment
-		return decision, nil
+		return decision, reasons, nil
 	}
 
 	if id, ok := decisionContext.Experiment.VariationKeyToIDMap[variationKey]; ok {
 		if variation, ok := decisionContext.Experiment.Variations[id]; ok {
 			decision.Reason = pkgReasons.WhitelistVariationAssignmentFound
 			decision.Variation = &variation
-			return decision, nil
+			return decision, reasons, nil
 		}
 	}
 
 	decision.Reason = pkgReasons.InvalidWhitelistVariationAssignment
-	return decision, nil
+	return decision, reasons, nil
 }

--- a/pkg/decision/experiment_whitelist_service_test.go
+++ b/pkg/decision/experiment_whitelist_service_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -31,14 +31,12 @@ type ExperimentWhitelistServiceTestSuite struct {
 	mockConfig       *mockProjectConfig
 	whitelistService *ExperimentWhitelistService
 	options          *decide.Options
-	reasons          decide.DecisionReasons
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) SetupTest() {
 	s.mockConfig = new(mockProjectConfig)
 	s.whitelistService = NewExperimentWhitelistService()
 	s.options = &decide.Options{}
-	s.reasons = decide.NewDecisionReasons(s.options)
 }
 
 func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
@@ -51,7 +49,7 @@ func (s *ExperimentWhitelistServiceTestSuite) TestWhitelistIncludesDecision() {
 		ID: "test_user_1",
 	}
 
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.NotNil(decision.Variation)
@@ -68,7 +66,7 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoUserEntryInWhitelist() {
 		ID: "test_user_3",
 	}
 
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.Nil(decision.Variation)
@@ -86,7 +84,7 @@ func (s *ExperimentWhitelistServiceTestSuite) TestEmptyWhitelist() {
 		ID: "test_user_1",
 	}
 
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.Nil(decision.Variation)
@@ -104,7 +102,7 @@ func (s *ExperimentWhitelistServiceTestSuite) TestInvalidVariationInUserEntry() 
 		ID: "test_user_2",
 	}
 
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options)
 
 	s.NoError(err)
 	s.Nil(decision.Variation)
@@ -121,7 +119,7 @@ func (s *ExperimentWhitelistServiceTestSuite) TestNoExperimentInDecisionContext(
 		ID: "test_user_1",
 	}
 
-	decision, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := s.whitelistService.GetDecision(testDecisionContext, testUserContext, s.options)
 
 	s.Error(err)
 	s.Nil(decision.Variation)

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -60,7 +60,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecision() {
 		Experiment:    &testExp1113,
 		ProjectConfig: s.mockConfig,
 	}
-	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext, testUserContext, s.options, s.reasons).Return(returnExperimentDecision, nil)
+	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext, testUserContext, s.options).Return(returnExperimentDecision, s.reasons, nil)
 
 	featureExperimentService := &FeatureExperimentService{
 		compositeExperimentService: s.mockExperimentService,
@@ -72,7 +72,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecision() {
 		Variation:  &expectedVariation,
 		Source:     FeatureTest,
 	}
-	decision, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedFeatureDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())
@@ -89,7 +89,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 		Experiment:    &testExp1113,
 		ProjectConfig: s.mockConfig,
 	}
-	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext1, testUserContext, s.options, s.reasons).Return(nilDecision, nil)
+	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext1, testUserContext, s.options).Return(nilDecision, s.reasons, nil)
 
 	// second experiment returns a valid decision to simulate user being bucketed into this experiment in the group
 	expectedVariation := testExp1114.Variations["2225"]
@@ -100,7 +100,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 		Experiment:    &testExp1114,
 		ProjectConfig: s.mockConfig,
 	}
-	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext2, testUserContext, s.options, s.reasons).Return(returnExperimentDecision, nil)
+	s.mockExperimentService.On("GetDecision", testExperimentDecisionContext2, testUserContext, s.options).Return(returnExperimentDecision, s.reasons, nil)
 
 	expectedFeatureDecision := FeatureDecision{
 		Experiment: *testExperimentDecisionContext2.Experiment,
@@ -111,7 +111,7 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 		compositeExperimentService: s.mockExperimentService,
 		logger:                     logging.GetLogger("sdkKey", "FeatureExperimentService"),
 	}
-	decision, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
 	s.Equal(expectedFeatureDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -58,18 +58,18 @@ type MockExperimentDecisionService struct {
 	mock.Mock
 }
 
-func (m *MockExperimentDecisionService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (ExperimentDecision, error) {
-	args := m.Called(decisionContext, userContext, options, reasons)
-	return args.Get(0).(ExperimentDecision), args.Error(1)
+func (m *MockExperimentDecisionService) GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options) (ExperimentDecision, decide.DecisionReasons, error) {
+	args := m.Called(decisionContext, userContext, options)
+	return args.Get(0).(ExperimentDecision), args.Get(1).(decide.DecisionReasons), args.Error(2)
 }
 
 type MockFeatureDecisionService struct {
 	mock.Mock
 }
 
-func (m *MockFeatureDecisionService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (FeatureDecision, error) {
-	args := m.Called(decisionContext, userContext, options, reasons)
-	return args.Get(0).(FeatureDecision), args.Error(1)
+func (m *MockFeatureDecisionService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
+	args := m.Called(decisionContext, userContext, options)
+	return args.Get(0).(FeatureDecision), args.Get(1).(decide.DecisionReasons), args.Error(2)
 }
 
 type MockAudienceTreeEvaluator struct {
@@ -90,9 +90,9 @@ func (m *MockUserProfileService) Save(userProfile UserProfile) {
 	m.Called(userProfile)
 }
 
-func (m *MockAudienceTreeEvaluator) Evaluate(node *entities.TreeNode, condTreeParams *entities.TreeParameters, reasons decide.DecisionReasons) (evalResult, isValid bool) {
+func (m *MockAudienceTreeEvaluator) Evaluate(node *entities.TreeNode, condTreeParams *entities.TreeParameters) (evalResult, isValid bool, reasons decide.DecisionReasons) {
 	args := m.Called(node, condTreeParams, reasons)
-	return args.Bool(0), args.Bool(1)
+	return args.Bool(0), args.Bool(1), args.Get(2).(decide.DecisionReasons)
 }
 
 // Single variation experiment

--- a/pkg/decision/interface.go
+++ b/pkg/decision/interface.go
@@ -25,20 +25,20 @@ import (
 
 // Service interface is used to make a decision for a given feature or experiment
 type Service interface {
-	GetFeatureDecision(FeatureDecisionContext, entities.UserContext, *decide.Options, decide.DecisionReasons) (FeatureDecision, error)
-	GetExperimentDecision(ExperimentDecisionContext, entities.UserContext, *decide.Options, decide.DecisionReasons) (ExperimentDecision, error)
+	GetFeatureDecision(FeatureDecisionContext, entities.UserContext, *decide.Options) (FeatureDecision, decide.DecisionReasons, error)
+	GetExperimentDecision(ExperimentDecisionContext, entities.UserContext, *decide.Options) (ExperimentDecision, decide.DecisionReasons, error)
 	OnDecision(func(notification.DecisionNotification)) (int, error)
 	RemoveOnDecision(id int) error
 }
 
 // ExperimentService can make a decision about an experiment
 type ExperimentService interface {
-	GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (ExperimentDecision, error)
+	GetDecision(decisionContext ExperimentDecisionContext, userContext entities.UserContext, options *decide.Options) (ExperimentDecision, decide.DecisionReasons, error)
 }
 
 // FeatureService can make a decision about a Feature Flag (can be feature test or rollout)
 type FeatureService interface {
-	GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (FeatureDecision, error)
+	GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error)
 }
 
 // UserProfileService is used to save and retrieve past bucketing decisions for users

--- a/pkg/decision/persisting_experiment_service_test.go
+++ b/pkg/decision/persisting_experiment_service_test.go
@@ -58,12 +58,12 @@ func (s *PersistingExperimentServiceTestSuite) SetupTest() {
 	}
 	s.options = &decide.Options{}
 	s.reasons = decide.NewDecisionReasons(s.options)
-	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options, s.reasons).Return(s.testComputedDecision, nil)
+	s.mockExperimentService.On("GetDecision", s.testDecisionContext, testUserContext, s.options).Return(s.testComputedDecision, s.reasons, nil)
 }
 
 func (s *PersistingExperimentServiceTestSuite) TestNilUserProfileService() {
 	persistingExperimentService := NewPersistingExperimentService(nil, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
-	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())
@@ -79,7 +79,7 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationFound() {
 	s.mockUserProfileService.On("Save", mock.Anything)
 
 	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
-	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 	savedDecision := ExperimentDecision{
 		Variation: &testExp1113Var2224,
 	}
@@ -99,7 +99,7 @@ func (s *PersistingExperimentServiceTestSuite) TestNoSavedVariation() {
 
 	s.mockUserProfileService.On("Save", updatedUserProfile)
 	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
-	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())
@@ -120,7 +120,7 @@ func (s *PersistingExperimentServiceTestSuite) TestSavedVariationNoLongerValid()
 	}
 	s.mockUserProfileService.On("Save", updatedUserProfile)
 	persistingExperimentService := NewPersistingExperimentService(s.mockUserProfileService, s.mockExperimentService, logging.GetLogger("", "NewPersistingExperimentService"))
-	decision, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options, s.reasons)
+	decision, _, err := persistingExperimentService.GetDecision(s.testDecisionContext, testUserContext, s.options)
 	s.Equal(s.testComputedDecision, decision)
 	s.NoError(err)
 	s.mockExperimentService.AssertExpectations(s.T())

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -65,7 +65,7 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		return evalResult
 	}
 
-	getFeatureDecision := func(experiment *entities.Experiment, decision *ExperimentDecision) (FeatureDecision, error) {
+	getFeatureDecision := func(experiment *entities.Experiment, decision *ExperimentDecision) FeatureDecision {
 		// translate the experiment reason into a more rollouts-appropriate reason
 		switch decision.Reason {
 		case pkgReasons.NotBucketedIntoVariation:
@@ -81,7 +81,7 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 			featureDecision.Experiment = *experiment
 		}
 		r.logger.Debug(fmt.Sprintf(`Decision made for user "%s" for feature rollout with key "%s": %s.`, userContext.ID, feature.Key, featureDecision.Reason))
-		return featureDecision, nil
+		return featureDecision
 	}
 
 	getExperimentDecisionContext := func(experiment *entities.Experiment) ExperimentDecisionContext {
@@ -122,8 +122,7 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 			// Evaluate fall back rule / last rule now
 			break
 		}
-		// error is always nil in this case
-		finalFeatureDecision, _ := getFeatureDecision(experiment, &decision)
+		finalFeatureDecision := getFeatureDecision(experiment, &decision)
 		return finalFeatureDecision, reasons, nil
 	}
 
@@ -140,8 +139,8 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		if err == nil {
 			r.logger.Debug(fmt.Sprintf(logging.UserInEveryoneElse.String(), userContext.ID))
 		}
-		finalFeatureDecision, err := getFeatureDecision(experiment, &decision)
-		return finalFeatureDecision, reasons, err
+		finalFeatureDecision := getFeatureDecision(experiment, &decision)
+		return finalFeatureDecision, reasons, nil
 	}
 
 	return featureDecision, reasons, nil

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -46,17 +46,19 @@ func NewRolloutService(sdkKey string) *RolloutService {
 }
 
 // GetDecision returns a decision for the given feature and user context
-func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options, reasons decide.DecisionReasons) (FeatureDecision, error) {
+func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
 	featureDecision := FeatureDecision{
 		Source: Rollout,
 	}
 	feature := decisionContext.Feature
 	rollout := feature.Rollout
+	reasons := decide.NewDecisionReasons(options)
 
 	evaluateConditionTree := func(experiment *entities.Experiment, loggingKey string) bool {
 		condTreeParams := entities.NewTreeParameters(&userContext, decisionContext.ProjectConfig.GetAudienceMap())
 		r.logger.Debug(fmt.Sprintf(logging.EvaluatingAudiencesForRollout.String(), loggingKey))
-		evalResult, _ := r.audienceTreeEvaluator.Evaluate(experiment.AudienceConditionTree, condTreeParams, reasons)
+		evalResult, _, decisionReasons := r.audienceTreeEvaluator.Evaluate(experiment.AudienceConditionTree, condTreeParams)
+		reasons.Append(decisionReasons)
 		if !evalResult {
 			featureDecision.Reason = pkgReasons.FailedRolloutTargeting
 		}
@@ -91,13 +93,13 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 
 	if rollout.ID == "" {
 		featureDecision.Reason = pkgReasons.NoRolloutForFeature
-		return featureDecision, nil
+		return featureDecision, reasons, nil
 	}
 
 	numberOfExperiments := len(rollout.Experiments)
 	if numberOfExperiments == 0 {
 		featureDecision.Reason = pkgReasons.RolloutHasNoExperiments
-		return featureDecision, nil
+		return featureDecision, reasons, nil
 	}
 
 	for index := 0; index < numberOfExperiments-1; index++ {
@@ -114,12 +116,14 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 			continue
 		}
 
-		decision, _ := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext, options, reasons)
+		decision, decisionReasons, _ := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext, options)
+		reasons.Append(decisionReasons)
 		if decision.Variation == nil {
 			// Evaluate fall back rule / last rule now
 			break
 		}
-		return getFeatureDecision(experiment, &decision)
+		featureDecision, err := getFeatureDecision(experiment, &decision)
+		return featureDecision, reasons, err
 	}
 
 	// fall back rule / last rule
@@ -130,12 +134,14 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 	r.logger.Debug(fmt.Sprintf(logging.RolloutAudiencesEvaluatedTo.String(), "Everyone Else", evaluationResult))
 
 	if evaluationResult {
-		decision, err := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext, options, reasons)
+		decision, decisionReasons, err := r.experimentBucketerService.GetDecision(experimentDecisionContext, userContext, options)
+		reasons.Append(decisionReasons)
 		if err == nil {
 			r.logger.Debug(fmt.Sprintf(logging.UserInEveryoneElse.String(), userContext.ID))
 		}
-		return getFeatureDecision(experiment, &decision)
+		featureDecision, err := getFeatureDecision(experiment, &decision)
+		return featureDecision, reasons, err
 	}
 
-	return featureDecision, nil
+	return featureDecision, reasons, nil
 }

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -122,8 +122,9 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 			// Evaluate fall back rule / last rule now
 			break
 		}
-		featureDecision, err := getFeatureDecision(experiment, &decision)
-		return featureDecision, reasons, err
+		// error is always nil in this case
+		finalFeatureDecision, _ := getFeatureDecision(experiment, &decision)
+		return finalFeatureDecision, reasons, nil
 	}
 
 	// fall back rule / last rule
@@ -139,8 +140,8 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		if err == nil {
 			r.logger.Debug(fmt.Sprintf(logging.UserInEveryoneElse.String(), userContext.ID))
 		}
-		featureDecision, err := getFeatureDecision(experiment, &decision)
-		return featureDecision, reasons, err
+		finalFeatureDecision, err := getFeatureDecision(experiment, &decision)
+		return finalFeatureDecision, reasons, err
 	}
 
 	return featureDecision, reasons, nil


### PR DESCRIPTION
## Summary
Reasons were previously being collected by sending a reasons object down the stack to all the related functions which would mutate it by pushing their own reasons. This is now changed. Every related function now returns the reasons array along with the actual value.

## Test plan
- Manually tested thoroughly.
- Fixed all the affected unit test.
- FSC passing