### PR TITLE
refact(decide-options): Added translate options method to be used by testapp and agent.

### DIFF
--- a/pkg/decide/decide_options.go
+++ b/pkg/decide/decide_options.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2020-2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -14,8 +14,10 @@
  * limitations under the License.                                           *
  ***************************************************************************/
 
-// Package decide has option definitions for decide api
+// Package decide has option definitions and helper methods for decide api
 package decide
+
+import "errors"
 
 // OptimizelyDecideOptions controlling flag decisions.
 type OptimizelyDecideOptions int
@@ -40,4 +42,26 @@ type Options struct {
 	IgnoreUserProfileService bool
 	IncludeReasons           bool
 	ExcludeVariables         bool
+}
+
+// TranslateOptions converts string options array to array of OptimizelyDecideOptions
+func TranslateOptions(options []string) ([]OptimizelyDecideOptions, error) {
+	decideOptions := []OptimizelyDecideOptions{}
+	for _, val := range options {
+		switch val {
+		case "DISABLE_DECISION_EVENT":
+			decideOptions = append(decideOptions, DisableDecisionEvent)
+		case "ENABLED_FLAGS_ONLY":
+			decideOptions = append(decideOptions, EnabledFlagsOnly)
+		case "IGNORE_USER_PROFILE_SERVICE":
+			decideOptions = append(decideOptions, IgnoreUserProfileService)
+		case "EXCLUDE_VARIABLES":
+			decideOptions = append(decideOptions, ExcludeVariables)
+		case "INCLUDE_REASONS":
+			decideOptions = append(decideOptions, IncludeReasons)
+		default:
+			return []OptimizelyDecideOptions{}, errors.New("invalid option: " + val)
+		}
+	}
+	return decideOptions, nil
 }

--- a/pkg/decide/decide_options_test.go
+++ b/pkg/decide/decide_options_test.go
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * Copyright 2021, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package decide
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateOptions(t *testing.T) {
+	options := []string{"DISABLE_DECISION_EVENT", "ENABLED_FLAGS_ONLY"}
+	translatedOptions, err := TranslateOptions(options)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 2)
+	assert.Equal(t, DisableDecisionEvent, translatedOptions[0])
+	assert.Equal(t, EnabledFlagsOnly, translatedOptions[1])
+
+	options = append(options, "IGNORE_USER_PROFILE_SERVICE", "EXCLUDE_VARIABLES", "INCLUDE_REASONS")
+	translatedOptions, err = TranslateOptions(options)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 5)
+	assert.Equal(t, IgnoreUserProfileService, translatedOptions[2])
+	assert.Equal(t, ExcludeVariables, translatedOptions[3])
+	assert.Equal(t, IncludeReasons, translatedOptions[4])
+
+	options[2] = "INVALID"
+	translatedOptions, err = TranslateOptions(options)
+	assert.Error(t, err)
+	assert.Len(t, translatedOptions, 0)
+}


### PR DESCRIPTION
 ## Summary
- Added `TranslateOptions` method to remove redundant declaration from test-app and agent.

## Test plan
- Added unit test.