### PR TITLE
Enforce go fmt in CI (errors are present).

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,8 @@ linters-settings:
      - wrapperFunc
      - hugeParam
      - rangeValCopy
+ gofmt:
+   simplify: false
 
 linters:
  disable-all: true
@@ -54,6 +56,7 @@ linters:
    - gosimple
    - prealloc 
    - maligned
+   - gofmt
  fast: false
 
 run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,9 @@ jobs:
       script:
         - make install lint
 
-
     - stage: 'Fmt'
       script:
-        - if [ -z "$(go fmt ./...)" ]; then true; esle false; fi
+        - if [ -z "$(go fmt ./...)" ]; then true; else false; fi
 
     - &test
       stage: 'Unit test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ stages:
   - 'Source clear'
   - 'Lint markdown files'
   - 'Lint'
+  - 'Fmt'
   - 'Unit test'
   - 'Benchmark test'  
   - 'Integration tests'
@@ -26,6 +27,11 @@ jobs:
       env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
       script:
         - make install lint
+
+
+    - stage: 'Fmt'
+      script:
+        - if [ -z "$(go fmt ./...)" ]; then true; esle false; fi
 
     - &test
       stage: 'Unit test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ stages:
   - 'Source clear'
   - 'Lint markdown files'
   - 'Lint'
-  - 'Fmt'
   - 'Unit test'
   - 'Benchmark test'  
   - 'Integration tests'
@@ -27,10 +26,6 @@ jobs:
       env: GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
       script:
         - make install lint
-
-    - stage: 'Fmt'
-      script:
-        - if [ -z "$(go fmt ./...)" ]; then true; else false; fi
 
     - &test
       stage: 'Unit test'

--- a/optimizely.go
+++ b/optimizely.go
@@ -32,7 +32,7 @@ func Client(sdkKey string, options ...client.OptionFunc) (*client.OptimizelyClie
 // UserContext is a helper method for creating a user context
 func UserContext(userID string, attributes map[string]interface{}) entities.UserContext {
 	return entities.UserContext{
-		ID: userID,
+		ID:         userID,
 		Attributes: attributes,
 	}
 }

--- a/optimizely.go
+++ b/optimizely.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/decision/bucketer/experiment_bucketer_test.go
+++ b/pkg/decision/bucketer/experiment_bucketer_test.go
@@ -47,7 +47,7 @@ func TestBucketExclusionGroups(t *testing.T) {
 		},
 	}
 
-	bucketer := NewMurmurhashExperimentBucketer(logging.GetLogger("","TestBucketExclusionGroups" ), DefaultHashSeed)
+	bucketer := NewMurmurhashExperimentBucketer(logging.GetLogger("", "TestBucketExclusionGroups"), DefaultHashSeed)
 	// ppid2 + 1886780722 (groupId) will generate bucket value of 2434 which maps to experiment 1
 	bucketedVariation, reason, _ := bucketer.Bucket("ppid2", experiment1, exclusionGroup)
 	assert.Equal(t, experiment1.Variations["22222"], *bucketedVariation)

--- a/pkg/decision/bucketer/murmurhashbucketer.go
+++ b/pkg/decision/bucketer/murmurhashbucketer.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/decision/bucketer/murmurhashbucketer.go
+++ b/pkg/decision/bucketer/murmurhashbucketer.go
@@ -49,7 +49,7 @@ type MurmurhashBucketer struct {
 func NewMurmurhashBucketer(logger logging.OptimizelyLogProducer, hashSeed uint32) *MurmurhashBucketer {
 	return &MurmurhashBucketer{
 		hashSeed: hashSeed,
-		logger: logger,
+		logger:   logger,
 	}
 }
 

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -46,7 +46,7 @@ func (l *FilteredLevelLogConsumer) Log(level LogLevel, message string, fields ma
 		sort.Strings(keys)
 
 		for _, k := range keys {
-			if s, ok := fields[k].(string);ok && s != "" {
+			if s, ok := fields[k].(string); ok && s != "" {
 				fmt.Fprintf(&messBuilder, "[%s]", s)
 			}
 		}

--- a/pkg/logging/level_log_consumer.go
+++ b/pkg/logging/level_log_consumer.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/notification/manager.go
+++ b/pkg/notification/manager.go
@@ -43,7 +43,7 @@ type AtomicManager struct {
 // NewAtomicManager creates a new instance of the atomic manager
 func NewAtomicManager(logger logging.OptimizelyLogProducer) *AtomicManager {
 	return &AtomicManager{
-		logger: logger,
+		logger:   logger,
 		handlers: make(map[uint32]func(interface{})),
 	}
 }

--- a/pkg/utils/execgroup.go
+++ b/pkg/utils/execgroup.go
@@ -36,7 +36,7 @@ func NewExecGroup(ctx context.Context, logger logging.OptimizelyLogProducer) *Ex
 	nctx, cancelFn := context.WithCancel(ctx)
 	wg := sync.WaitGroup{}
 
-	return &ExecGroup{wg: &wg, ctx: nctx, cancelFunc: cancelFn, logger:logger}
+	return &ExecGroup{wg: &wg, ctx: nctx, cancelFunc: cancelFn, logger: logger}
 }
 
 // Go initiates a goroutine with the inputted function. Each invocation increments a shared WaitGroup

--- a/pkg/utils/execgroup.go
+++ b/pkg/utils/execgroup.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/utils/requester_test.go
+++ b/pkg/utils/requester_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/utils/requester_test.go
+++ b/pkg/utils/requester_test.go
@@ -40,7 +40,7 @@ func TestHeaders(t *testing.T) {
 func TestAddHeaders(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "", nil)
-	requester := &HTTPRequester{logger:logging.GetLogger("", "")}
+	requester := &HTTPRequester{logger: logging.GetLogger("", "")}
 	headers := []Header{{"one", "1"}}
 
 	fn := Headers(Header{"two", "2"})


### PR DESCRIPTION
## Summary
- Fix and enforce Go formatting according to the integrated Go tool without simplify.
## Test plan
- All unit tests and new lint fmt test must pass.