### PR TITLE
feat(OptimizelyConfig): Add new fields to OptimizelyConfig 

### DIFF
--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -38,18 +38,18 @@ type DatafileProjectConfig struct {
 	projectID            string
 	revision             string
 	experimentKeyToIDMap map[string]string
-	audienceList         []entities.Audience
+	audiences            []entities.Audience
 	audienceMap          map[string]entities.Audience
 	attributeMap         map[string]entities.Attribute
 	events               []entities.Event
 	eventMap             map[string]entities.Event
 	attributeKeyToIDMap  map[string]string
-	experimentList       []entities.Experiment
+	experiments          []entities.Experiment
 	experimentMap        map[string]entities.Experiment
-	featureList          []entities.Feature
+	features             []entities.Feature
 	featureMap           map[string]entities.Feature
 	groupMap             map[string]entities.Group
-	rolloutList          []entities.Rollout
+	rollouts             []entities.Rollout
 	rolloutMap           map[string]entities.Rollout
 	anonymizeIP          bool
 	botFiltering         bool
@@ -159,22 +159,22 @@ func (c DatafileProjectConfig) GetAttributeByKey(key string) (entities.Attribute
 
 // GetFeatureList returns an array of all the features
 func (c DatafileProjectConfig) GetFeatureList() (featureList []entities.Feature) {
-	return c.featureList
+	return c.features
 }
 
 // GetExperimentList returns an array of all the experiments
 func (c DatafileProjectConfig) GetExperimentList() (experimentList []entities.Experiment) {
-	return c.experimentList
+	return c.experiments
 }
 
 // GetRolloutList returns an array of all the rollouts
 func (c DatafileProjectConfig) GetRolloutList() (rolloutList []entities.Rollout) {
-	return c.rolloutList
+	return c.rollouts
 }
 
 // GetAudienceList returns an array of all the audiences
 func (c DatafileProjectConfig) GetAudienceList() (audienceList []entities.Audience) {
-	return c.audienceList
+	return c.audiences
 }
 
 // GetAudienceByID returns the audience with the given ID
@@ -235,19 +235,19 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 	groupMap, experimentGroupMap := mappers.MapGroups(datafile.Groups)
 	experiments, experimentMap, experimentKeyMap := mappers.MapExperiments(allExperiments, experimentGroupMap)
 
-	rolloutList, rolloutMap := mappers.MapRollouts(datafile.Rollouts)
+	rollouts, rolloutMap := mappers.MapRollouts(datafile.Rollouts)
 	events := []entities.Event{}
 	for _, event := range datafile.Events {
 		events = append(events, entities.Event(event))
 	}
 	eventMap := mappers.MapEvents(datafile.Events)
 	mergedAudiences := append(datafile.TypedAudiences, datafile.Audiences...)
-	featureList, featureMap := mappers.MapFeatures(datafile.FeatureFlags, rolloutMap, experimentMap)
+	features, featureMap := mappers.MapFeatures(datafile.FeatureFlags, rolloutMap, experimentMap)
 	attributes := []entities.Attribute{}
 	for _, attribute := range datafile.Attributes {
 		attributes = append(attributes, entities.Attribute(attribute))
 	}
-	audienceList, audienceMap := mappers.MapAudiences(mergedAudiences)
+	audiences, audienceMap := mappers.MapAudiences(mergedAudiences)
 
 	config := &DatafileProjectConfig{
 		datafile:             string(jsonDatafile),
@@ -255,23 +255,23 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 		attributes:           attributes,
 		anonymizeIP:          datafile.AnonymizeIP,
 		attributeKeyToIDMap:  attributeKeyToIDMap,
-		audienceList:         audienceList,
+		audiences:            audiences,
 		audienceMap:          audienceMap,
 		attributeMap:         attributeMap,
 		botFiltering:         datafile.BotFiltering,
 		sdkKey:               datafile.SDKKey,
 		environmentKey:       datafile.EnvironmentKey,
-		experimentList:       experiments,
+		experiments:          experiments,
 		experimentKeyToIDMap: experimentKeyMap,
 		experimentMap:        experimentMap,
 		groupMap:             groupMap,
 		events:               events,
 		eventMap:             eventMap,
-		featureList:          featureList,
+		features:             features,
 		featureMap:           featureMap,
 		projectID:            datafile.ProjectID,
 		revision:             datafile.Revision,
-		rolloutList:          rolloutList,
+		rollouts:             rollouts,
 		rolloutMap:           rolloutMap,
 		sendFlagDecisions:    datafile.SendFlagDecisions,
 	}

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -278,7 +278,7 @@ func TestGetFeatureList(t *testing.T) {
 		Key: key,
 	}
 	config := &DatafileProjectConfig{
-		featureList: []entities.Feature{feature},
+		features: []entities.Feature{feature},
 	}
 
 	features := config.GetFeatureList()
@@ -295,7 +295,7 @@ func TestGetExperimentList(t *testing.T) {
 	}
 
 	config := &DatafileProjectConfig{
-		experimentList: []entities.Experiment{experiment},
+		experiments: []entities.Experiment{experiment},
 	}
 
 	experiments := config.GetExperimentList()

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -277,10 +277,8 @@ func TestGetFeatureList(t *testing.T) {
 	feature := entities.Feature{
 		Key: key,
 	}
-	featureMap := make(map[string]entities.Feature)
-	featureMap[key] = feature
 	config := &DatafileProjectConfig{
-		featureMap: featureMap,
+		featureList: []entities.Feature{feature},
 	}
 
 	features := config.GetFeatureList()
@@ -290,20 +288,14 @@ func TestGetFeatureList(t *testing.T) {
 }
 
 func TestGetExperimentList(t *testing.T) {
-	id := "id"
 	key := "key"
-	experimentKeyToIDMap := make(map[string]string)
-	experimentKeyToIDMap[key] = id
 
 	experiment := entities.Experiment{
 		Key: key,
 	}
-	experimentMap := make(map[string]entities.Experiment)
-	experimentMap[id] = experiment
 
 	config := &DatafileProjectConfig{
-		experimentKeyToIDMap: experimentKeyToIDMap,
-		experimentMap:        experimentMap,
+		experimentList: []entities.Experiment{experiment},
 	}
 
 	experiments := config.GetExperimentList()

--- a/pkg/config/datafileprojectconfig/mappers/audience.go
+++ b/pkg/config/datafileprojectconfig/mappers/audience.go
@@ -23,9 +23,10 @@ import (
 )
 
 // MapAudiences maps the raw datafile audience entities to SDK Audience entities
-func MapAudiences(audiences []datafileEntities.Audience) map[string]entities.Audience {
+func MapAudiences(audiences []datafileEntities.Audience) (audienceList []entities.Audience, audienceMap map[string]entities.Audience) {
 
-	audienceMap := make(map[string]entities.Audience)
+	audienceList = []entities.Audience{}
+	audienceMap = make(map[string]entities.Audience)
 	for _, audience := range audiences {
 		_, ok := audienceMap[audience.ID]
 		if !ok {
@@ -34,13 +35,15 @@ func MapAudiences(audiences []datafileEntities.Audience) map[string]entities.Aud
 				// @TODO: handle error
 				func() {}() // cheat the linters
 			}
-			audienceMap[audience.ID] = entities.Audience{
+			audience := entities.Audience{
 				ID:            audience.ID,
 				Name:          audience.Name,
 				ConditionTree: conditionTree,
 				Conditions:    audience.Conditions,
 			}
+			audienceMap[audience.ID] = audience
+			audienceList = append(audienceList, audience)
 		}
 	}
-	return audienceMap
+	return audienceList, audienceMap
 }

--- a/pkg/config/datafileprojectconfig/mappers/audience.go
+++ b/pkg/config/datafileprojectconfig/mappers/audience.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -38,6 +38,7 @@ func MapAudiences(audiences []datafileEntities.Audience) map[string]entities.Aud
 				ID:            audience.ID,
 				Name:          audience.Name,
 				ConditionTree: conditionTree,
+				Conditions:    audience.Conditions,
 			}
 		}
 	}

--- a/pkg/config/datafileprojectconfig/mappers/audience_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/audience_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -28,22 +28,26 @@ import (
 
 func TestMapAudiencesEmptyList(t *testing.T) {
 
-	audienceMap := MapAudiences(nil)
+	audienceList, audienceMap := MapAudiences(nil)
 
+	expectedAudienceList := []entities.Audience{}
 	expectedAudienceMap := map[string]entities.Audience{}
 
-	assert.Equal(t, audienceMap, expectedAudienceMap)
-
+	assert.Equal(t, expectedAudienceList, audienceList)
+	assert.Equal(t, expectedAudienceMap, audienceMap)
 }
 func TestMapAudiences(t *testing.T) {
 
 	audienceList := []datafileEntities.Audience{{ID: "1", Name: "one"}, {ID: "2", Name: "two"},
 		{ID: "3", Name: "three"}, {ID: "2", Name: "four"}, {ID: "5", Name: "one"}}
-
-	audienceMap := MapAudiences(audienceList)
+	audiences, audienceMap := MapAudiences(audienceList)
 
 	expectedAudienceMap := map[string]entities.Audience{"1": {ID: "1", Name: "one"}, "2": {ID: "2", Name: "two"},
 		"3": {ID: "3", Name: "three"}, "5": {ID: "5", Name: "one"}}
-
-	assert.Equal(t, audienceMap, expectedAudienceMap)
+	expectedAudienceList := []entities.Audience{}
+	for _, audience := range expectedAudienceMap {
+		expectedAudienceList = append(expectedAudienceList, audience)
+	}
+	assert.Equal(t, expectedAudienceList, audiences)
+	assert.Equal(t, expectedAudienceMap, audienceMap)
 }

--- a/pkg/config/datafileprojectconfig/mappers/audience_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/audience_test.go
@@ -36,17 +36,18 @@ func TestMapAudiencesEmptyList(t *testing.T) {
 	assert.Equal(t, expectedAudienceList, audienceList)
 	assert.Equal(t, expectedAudienceMap, audienceMap)
 }
+
 func TestMapAudiences(t *testing.T) {
 
 	audienceList := []datafileEntities.Audience{{ID: "1", Name: "one"}, {ID: "2", Name: "two"},
-		{ID: "3", Name: "three"}, {ID: "2", Name: "four"}, {ID: "5", Name: "one"}}
+		{ID: "3", Name: "three"}, {ID: "4", Name: "four"}, {ID: "5", Name: "one"}}
 	audiences, audienceMap := MapAudiences(audienceList)
 
 	expectedAudienceMap := map[string]entities.Audience{"1": {ID: "1", Name: "one"}, "2": {ID: "2", Name: "two"},
-		"3": {ID: "3", Name: "three"}, "5": {ID: "5", Name: "one"}}
+		"3": {ID: "3", Name: "three"}, "4": {ID: "4", Name: "four"}, "5": {ID: "5", Name: "one"}}
 	expectedAudienceList := []entities.Audience{}
-	for _, audience := range expectedAudienceMap {
-		expectedAudienceList = append(expectedAudienceList, audience)
+	for _, audience := range audienceList {
+		expectedAudienceList = append(expectedAudienceList, expectedAudienceMap[audience.ID])
 	}
 	assert.Equal(t, expectedAudienceList, audiences)
 	assert.Equal(t, expectedAudienceMap, audienceMap)

--- a/pkg/config/datafileprojectconfig/mappers/condition_trees.go
+++ b/pkg/config/datafileprojectconfig/mappers/condition_trees.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -27,6 +27,11 @@ import (
 
 var errEmptyTree = errors.New("empty tree")
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+// GetDefaultOperators returns default conditional operators
+func GetDefaultOperators() []string {
+	return []string{"and", "or", "not"}
+}
 
 // Takes the conditions array from the audience in the datafile and turns it into a condition tree
 func buildConditionTree(conditions interface{}) (conditionTree *entities.TreeNode, retErr error) {
@@ -135,7 +140,7 @@ func createLeafCondition(typedV map[string]interface{}, node *entities.TreeNode)
 // Takes the conditions array from the audience in the datafile and turns it into a condition tree
 func buildAudienceConditionTree(conditions interface{}) (conditionTree *entities.TreeNode, err error) {
 
-	var operators = []string{"or", "and", "not"} // any other operators?
+	var operators = GetDefaultOperators()
 	value := reflect.ValueOf(conditions)
 	visited := make(map[interface{}]bool)
 

--- a/pkg/config/datafileprojectconfig/mappers/experiment.go
+++ b/pkg/config/datafileprojectconfig/mappers/experiment.go
@@ -23,8 +23,9 @@ import (
 )
 
 // MapExperiments maps the raw experiments entities from the datafile to SDK Experiment entities and also returns a map of experiment key to experiment ID
-func MapExperiments(rawExperiments []datafileEntities.Experiment, experimentGroupMap map[string]string) (experimentMap map[string]entities.Experiment, experimentKeyMap map[string]string) {
+func MapExperiments(rawExperiments []datafileEntities.Experiment, experimentGroupMap map[string]string) (experiments []entities.Experiment, experimentMap map[string]entities.Experiment, experimentKeyMap map[string]string) {
 
+	allExperiments := []entities.Experiment{}
 	experimentMap = make(map[string]entities.Experiment)
 	experimentKeyMap = make(map[string]string)
 	for _, rawExperiment := range rawExperiments {
@@ -33,9 +34,10 @@ func MapExperiments(rawExperiments []datafileEntities.Experiment, experimentGrou
 		experiment.GroupID = experimentGroupMap[experiment.ID]
 		experimentMap[experiment.ID] = experiment
 		experimentKeyMap[experiment.Key] = experiment.ID
+		allExperiments = append(allExperiments, experiment)
 	}
 
-	return experimentMap, experimentKeyMap
+	return allExperiments, experimentMap, experimentKeyMap
 }
 
 // Maps the raw variation entity from the datafile to an SDK Variation entity

--- a/pkg/config/datafileprojectconfig/mappers/experiment.go
+++ b/pkg/config/datafileprojectconfig/mappers/experiment.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -81,6 +81,7 @@ func mapExperiment(rawExperiment datafileEntities.Experiment) entities.Experimen
 
 	experiment := entities.Experiment{
 		AudienceIds:           rawExperiment.AudienceIds,
+		AudienceConditions:    rawExperiment.AudienceConditions,
 		ID:                    rawExperiment.ID,
 		LayerID:               rawExperiment.LayerID,
 		Key:                   rawExperiment.Key,

--- a/pkg/config/datafileprojectconfig/mappers/feature.go
+++ b/pkg/config/datafileprojectconfig/mappers/feature.go
@@ -24,8 +24,9 @@ import (
 
 // MapFeatures maps the raw datafile feature flag entities to SDK Feature entities
 func MapFeatures(featureFlags []datafileEntities.FeatureFlag, rolloutMap map[string]entities.Rollout, experimentMap map[string]entities.Experiment,
-) (featureMap map[string]entities.Feature) {
+) (featureList []entities.Feature, featureMap map[string]entities.Feature) {
 
+	featureList = []entities.Feature{}
 	featureMap = make(map[string]entities.Feature)
 	for _, featureFlag := range featureFlags {
 		feature := entities.Feature{
@@ -62,7 +63,8 @@ func MapFeatures(featureFlags []datafileEntities.FeatureFlag, rolloutMap map[str
 		feature.ExperimentIDs = featureFlag.ExperimentIDs
 		feature.FeatureExperiments = featureExperiments
 		feature.VariableMap = variableMap
+		featureList = append(featureList, feature)
 		featureMap[featureFlag.Key] = feature
 	}
-	return featureMap
+	return featureList, featureMap
 }

--- a/pkg/config/datafileprojectconfig/mappers/feature.go
+++ b/pkg/config/datafileprojectconfig/mappers/feature.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -59,6 +59,7 @@ func MapFeatures(featureFlags []datafileEntities.FeatureFlag, rolloutMap map[str
 
 		}
 
+		feature.ExperimentIDs = featureFlag.ExperimentIDs
 		feature.FeatureExperiments = featureExperiments
 		feature.VariableMap = variableMap
 		featureMap[featureFlag.Key] = feature

--- a/pkg/config/datafileprojectconfig/mappers/feature_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/feature_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -49,7 +49,7 @@ func TestMapFeatures(t *testing.T) {
 		"31111": experiment31111,
 		"31112": experiment31112,
 	}
-	featureMap := MapFeatures(rawFeatureFlags, rolloutMap, experimentMap)
+	featuresList, featureMap := MapFeatures(rawFeatureFlags, rolloutMap, experimentMap)
 
 	// Test MapFeatures should only change IsFeatureExperiment to true for experiment31111 since it belongs to a featureflag
 	experiment31111.IsFeatureExperiment = true
@@ -63,6 +63,7 @@ func TestMapFeatures(t *testing.T) {
 		"test_feature_21111": entities.Feature{
 			ID:                 "21111",
 			Key:                "test_feature_21111",
+			ExperimentIDs:      []string{"31111"},
 			Rollout:            rollout,
 			FeatureExperiments: []entities.Experiment{experiment31111},
 			VariableMap:        map[string]entities.Variable{variable.Key: variable},
@@ -73,6 +74,7 @@ func TestMapFeatures(t *testing.T) {
 		"31112": experiment31112,
 	}
 
+	assert.Equal(t, []entities.Feature{featureMap["test_feature_21111"]}, featuresList)
 	assert.Equal(t, expectedFeatureMap, featureMap)
 	assert.Equal(t, expectedExperimentMap, experimentMap)
 }

--- a/pkg/config/datafileprojectconfig/mappers/rollout.go
+++ b/pkg/config/datafileprojectconfig/mappers/rollout.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -23,13 +23,16 @@ import (
 )
 
 // MapRollouts maps the raw datafile rollout entities to SDK Rollout entities
-func MapRollouts(rollouts []datafileEntities.Rollout) map[string]entities.Rollout {
-	rolloutMap := make(map[string]entities.Rollout)
+func MapRollouts(rollouts []datafileEntities.Rollout) (rolloutList []entities.Rollout, rolloutMap map[string]entities.Rollout) {
+	rolloutList = []entities.Rollout{}
+	rolloutMap = make(map[string]entities.Rollout)
 	for _, rollout := range rollouts {
-		rolloutMap[rollout.ID] = mapRollout(rollout)
+		mappedRollout := mapRollout(rollout)
+		rolloutList = append(rolloutList, mappedRollout)
+		rolloutMap[rollout.ID] = mappedRollout
 	}
 
-	return rolloutMap
+	return rolloutList, rolloutMap
 }
 
 func mapRollout(datafileRollout datafileEntities.Rollout) entities.Rollout {

--- a/pkg/config/datafileprojectconfig/mappers/rollout_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/rollout_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -37,16 +37,17 @@ func TestMapRollouts(t *testing.T) {
 	json.Unmarshal([]byte(testRolloutString), &rawRollout)
 
 	rawRollouts := []datafileEntities.Rollout{rawRollout}
-	rolloutMap := MapRollouts(rawRollouts)
+	rolloutList, rolloutMap := MapRollouts(rawRollouts)
 	expectedRolloutMap := map[string]entities.Rollout{
-		"21111": entities.Rollout{
+		"21111": {
 			ID: "21111",
 			Experiments: []entities.Experiment{
-				entities.Experiment{ID: "11111", Key: "exp_11111", Variations: map[string]entities.Variation{}, VariationKeyToIDMap: map[string]string{}, TrafficAllocation: []entities.Range{}},
-				entities.Experiment{ID: "11112", Key: "exp_11112", Variations: map[string]entities.Variation{}, VariationKeyToIDMap: map[string]string{}, TrafficAllocation: []entities.Range{}},
+				{ID: "11111", Key: "exp_11111", Variations: map[string]entities.Variation{}, VariationKeyToIDMap: map[string]string{}, TrafficAllocation: []entities.Range{}},
+				{ID: "11112", Key: "exp_11112", Variations: map[string]entities.Variation{}, VariationKeyToIDMap: map[string]string{}, TrafficAllocation: []entities.Range{}},
 			},
 		},
 	}
 
+	assert.Equal(t, []entities.Rollout{expectedRolloutMap["21111"]}, rolloutList)
 	assert.Equal(t, expectedRolloutMap, rolloutMap)
 }

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -29,6 +29,7 @@ type ProjectConfig interface {
 	GetAnonymizeIP() bool
 	GetAttributeID(id string) string // returns "" if there is no id
 	GetAttributeByKey(key string) (entities.Attribute, error)
+	GetAudienceList() (audienceList []entities.Audience)
 	GetAudienceByID(string) (entities.Audience, error)
 	GetAudienceMap() map[string]entities.Audience
 	GetBotFiltering() bool

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -32,11 +32,13 @@ type ProjectConfig interface {
 	GetAudienceByID(string) (entities.Audience, error)
 	GetAudienceMap() map[string]entities.Audience
 	GetBotFiltering() bool
+	GetEvents() []entities.Event
 	GetEventByKey(string) (entities.Event, error)
 	GetExperimentByKey(string) (entities.Experiment, error)
 	GetFeatureByKey(string) (entities.Feature, error)
 	GetVariableByKey(featureKey string, variableKey string) (entities.Variable, error)
 	GetExperimentList() []entities.Experiment
+	GetRolloutList() (rolloutList []entities.Rollout)
 	GetFeatureList() []entities.Feature
 	GetGroupByID(string) (entities.Group, error)
 	GetProjectID() string
@@ -44,6 +46,7 @@ type ProjectConfig interface {
 	SendFlagDecisions() bool
 	GetSdkKey() string
 	GetEnvironmentKey() string
+	GetAttributes() []entities.Attribute
 }
 
 // ProjectConfigManager maintains an instance of the ProjectConfig

--- a/pkg/config/optimizely_config.go
+++ b/pkg/config/optimizely_config.go
@@ -174,25 +174,30 @@ func getSerializedAudiences(conditions interface{}, audiencesByID map[string]ent
 					}
 				default:
 				}
-				// Checks if sub audience is empty or not
-				if subAudience != "" {
-					if serializedAudience != "" || cond == "NOT" {
-						if cond == "" {
-							cond = "OR"
-						}
-						if serializedAudience == "" {
-							serializedAudience = fmt.Sprintf(`%s %s`, cond, subAudience)
-						} else {
-							serializedAudience += fmt.Sprintf(` %s %s`, cond, subAudience)
-						}
-					} else {
-						serializedAudience += subAudience
-					}
-				}
+				// Had to create a different method to reduce cyclomatic complexity
+				evaluateSubAudience(&subAudience, &serializedAudience, &cond)
 			}
 		}
 	}
 	return serializedAudience
+}
+
+func evaluateSubAudience(subAudience, serializedAudience, cond *string) {
+	// Checks if sub audience is empty or not
+	if *subAudience != "" {
+		if *serializedAudience != "" || *cond == "NOT" {
+			if *cond == "" {
+				*cond = "OR"
+			}
+			if *serializedAudience == "" {
+				*serializedAudience = fmt.Sprintf(`%s %s`, *cond, *subAudience)
+			} else {
+				*serializedAudience += fmt.Sprintf(` %s %s`, *cond, *subAudience)
+			}
+		} else {
+			*serializedAudience += *subAudience
+		}
+	}
 }
 
 func getExperimentAudiences(experiment entities.Experiment, audiencesByID map[string]entities.Audience) string {

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -26,48 +26,108 @@ import (
 
 type OptimizelyConfigTestSuite struct {
 	suite.Suite
-	projectConfig            ProjectConfig
-	expectedOptimizelyConfig OptimizelyConfig
 }
 
-func (s *OptimizelyConfigTestSuite) SetupTest() {
+func (s *OptimizelyConfigTestSuite) TestOptlyConfig() {
 
-	// reading expected json file validates public access for OptimizelyConfig and its members
-	outputFileName := "testdata/optimizely_config_expected.json"
-	expectedOutput, err := ioutil.ReadFile(outputFileName)
-	if err != nil {
-		s.Fail("error opening file " + outputFileName)
+	test := func(datafileOne string, datafileTwo string) {
+		// Cleaned here due to linter warning
+		folder := "testdata/"
+		dataFile, err := ioutil.ReadFile(folder + datafileOne)
+		if err != nil {
+			s.Fail("error opening file " + datafileOne)
+		}
+
+		projectMgr := NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(dataFile))
+		projConfig, err := projectMgr.GetConfig()
+		if err != nil {
+			s.Fail(err.Error())
+		}
+		optimizelyConfig := NewOptimizelyConfig(projConfig)
+
+		dataFile2, err := ioutil.ReadFile(folder + datafileTwo)
+		if err != nil {
+			s.Fail("error opening file " + datafileTwo)
+		}
+		var expectedConfig OptimizelyConfig
+		err = json.Unmarshal(dataFile2, &expectedConfig)
+		if err != nil {
+			s.Fail("unable to parse expected file")
+		}
+		expectedConfig.datafile = string(dataFile)
+
+		s.Equal(expectedConfig.Attributes, optimizelyConfig.Attributes)
+		s.Equal(expectedConfig.Audiences, optimizelyConfig.Audiences)
+		s.Equal(expectedConfig.FeaturesMap, optimizelyConfig.FeaturesMap)
+		s.Equal(expectedConfig.ExperimentsMap, optimizelyConfig.ExperimentsMap)
+		s.Equal(expectedConfig.Revision, optimizelyConfig.Revision)
+		s.Equal(expectedConfig.datafile, optimizelyConfig.datafile)
+		s.Equal(expectedConfig.SdkKey, optimizelyConfig.SdkKey)
+		s.Equal(expectedConfig.EnvironmentKey, optimizelyConfig.EnvironmentKey)
+		s.Equal(expectedConfig.Events, optimizelyConfig.Events)
+
+		s.Equal(expectedConfig, *optimizelyConfig)
 	}
 
-	err = json.Unmarshal(expectedOutput, &s.expectedOptimizelyConfig)
-	if err != nil {
-		s.Fail("unable to parse expected file")
-	}
+	// Simple datafile
+	test("optimizely_config_datafile.json", "optimizely_config_expected.json")
+	// Similar keys datafile
+	test("similar_exp_keys_datafile.json", "similar_exp_keys_expected.json")
+	// Similar rule keys bucketing datafile
+	test("similar_rule_keys_bucketing_datafile.json", "similar_rule_keys_bucketing_expected.json")
+}
 
-	dataFileName := "testdata/optimizely_config_datafile.json"
+func (s *OptimizelyConfigTestSuite) TestSerializeAudiences() {
+
+	dataFileName := "testdata/typed_audience_datafile.json"
 	dataFile, err := ioutil.ReadFile(dataFileName)
 	if err != nil {
 		s.Fail("error opening file " + dataFileName)
 	}
-	s.expectedOptimizelyConfig.datafile = string(dataFile)
 
 	projectMgr := NewStaticProjectConfigManagerWithOptions("", WithInitialDatafile(dataFile))
+	projConfig, err := projectMgr.GetConfig()
+	if err != nil {
+		s.Fail(err.Error())
+	}
 
-	s.projectConfig = projectMgr.projectConfig
+	conditions := []interface{}{
+		[]interface{}{"or", "3468206642", "3988293898"},
+		[]interface{}{"or", "3468206642", "3988293898", "3468206646"},
+		[]interface{}{"not", "3468206642"},
+		[]interface{}{"or", "3468206642"},
+		[]interface{}{"and", "3468206642"},
+		[]interface{}{"3468206642"},
+		[]interface{}{"3468206642", "3988293898"},
+		[]interface{}{"and", []interface{}{"or", "3468206642", "3988293898"}, "3468206646"},
+		[]interface{}{"and", []interface{}{"or", "3468206642", []interface{}{"and", "3988293898", "3468206646"}}, []interface{}{"and", "3988293899", []interface{}{"or", "3468206647", "3468206643"}}},
+		[]interface{}{"and", "and"},
+		[]interface{}{"not", []interface{}{"and", "3468206642", "3988293898"}},
+		[]interface{}{},
+		[]interface{}{"or", "3468206642", "999999999"},
+	}
 
-}
+	expectedOutputs := []string{
+		"\"exactString\" OR \"substringString\"",
+		"\"exactString\" OR \"substringString\" OR \"exactNumber\"",
+		"NOT \"exactString\"",
+		"\"exactString\"",
+		"\"exactString\"",
+		"\"exactString\"",
+		"\"exactString\" OR \"substringString\"",
+		"(\"exactString\" OR \"substringString\") AND \"exactNumber\"",
+		"(\"exactString\" OR (\"substringString\" AND \"exactNumber\")) AND (\"exists\" AND (\"gtNumber\" OR \"exactBoolean\"))",
+		"",
+		"NOT (\"exactString\" AND \"substringString\")",
+		"",
+		"\"exactString\" OR \"999999999\"",
+	}
 
-func (s *OptimizelyConfigTestSuite) TestOptlyConfig() {
-	optimizelyConfig := NewOptimizelyConfig(s.projectConfig)
+	for i, condition := range conditions {
+		result := getSerializedAudiences(condition, projConfig.GetAudienceMap())
+		s.Equal(expectedOutputs[i], result)
+	}
 
-	s.Equal(s.expectedOptimizelyConfig.FeaturesMap, optimizelyConfig.FeaturesMap)
-	s.Equal(s.expectedOptimizelyConfig.ExperimentsMap, optimizelyConfig.ExperimentsMap)
-	s.Equal(s.expectedOptimizelyConfig.Revision, optimizelyConfig.Revision)
-	s.Equal(s.expectedOptimizelyConfig.datafile, optimizelyConfig.datafile)
-	s.Equal(s.expectedOptimizelyConfig.SdkKey, optimizelyConfig.SdkKey)
-	s.Equal(s.expectedOptimizelyConfig.EnvironmentKey, optimizelyConfig.EnvironmentKey)
-
-	s.Equal(s.expectedOptimizelyConfig, *optimizelyConfig)
 }
 
 func (s *OptimizelyConfigTestSuite) TestOptlyConfigUnMarshalEmptySDKKeyAndEnvironmentKey() {
@@ -81,11 +141,8 @@ func (s *OptimizelyConfigTestSuite) TestOptlyConfigUnMarshalEmptySDKKeyAndEnviro
 	bytesData, _ := json.Marshal(optimizelyConfig)
 	json.Unmarshal(bytesData, &jsonMap)
 
-	_, keyExists := jsonMap["sdkKey"]
-	s.False(keyExists)
-
-	_, keyExists = jsonMap["environmentKey"]
-	s.False(keyExists)
+	s.Equal("", jsonMap["sdkKey"])
+	s.Equal("", jsonMap["environmentKey"])
 }
 
 func (s *OptimizelyConfigTestSuite) TestOptlyConfigUnMarshalNonEmptySDKKeyAndEnvironmentKey() {

--- a/pkg/config/optimizely_config_test.go
+++ b/pkg/config/optimizely_config_test.go
@@ -30,10 +30,9 @@ type OptimizelyConfigTestSuite struct {
 
 func (s *OptimizelyConfigTestSuite) TestOptlyConfig() {
 
+	rootDirectory := "testdata/"
 	test := func(datafileOne string, datafileTwo string) {
-		// Cleaned here due to linter warning
-		folder := "testdata/"
-		dataFile, err := ioutil.ReadFile(folder + datafileOne)
+		dataFile, err := ioutil.ReadFile(rootDirectory + datafileOne)
 		if err != nil {
 			s.Fail("error opening file " + datafileOne)
 		}
@@ -45,7 +44,7 @@ func (s *OptimizelyConfigTestSuite) TestOptlyConfig() {
 		}
 		optimizelyConfig := NewOptimizelyConfig(projConfig)
 
-		dataFile2, err := ioutil.ReadFile(folder + datafileTwo)
+		dataFile2, err := ioutil.ReadFile(rootDirectory + datafileTwo)
 		if err != nil {
 			s.Fail("error opening file " + datafileTwo)
 		}

--- a/pkg/config/static_manager_test.go
+++ b/pkg/config/static_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -57,8 +57,9 @@ func TestStaticGetOptimizelyConfig(t *testing.T) {
 
 	optimizelyConfig := configManager.GetOptimizelyConfig()
 	assert.NotNil(t, configManager.optimizelyConfig)
+
 	assert.Equal(t, &OptimizelyConfig{ExperimentsMap: map[string]OptimizelyExperiment{},
-		FeaturesMap: map[string]OptimizelyFeature{}, datafile: "{\"accountId\":\"42\",\"projectId\":\"123\",\"version\":\"4\"}"}, optimizelyConfig)
+		FeaturesMap: map[string]OptimizelyFeature{}, Attributes: []OptimizelyAttribute{}, Audiences: []OptimizelyAudience{}, Events: []OptimizelyEvent{}, datafile: "{\"accountId\":\"42\",\"projectId\":\"123\",\"version\":\"4\"}"}, optimizelyConfig)
 }
 func TestNewStaticProjectConfigManagerFromURL(t *testing.T) {
 

--- a/pkg/config/testdata/optimizely_config_datafile.json
+++ b/pkg/config/testdata/optimizely_config_datafile.json
@@ -1,268 +1,111 @@
 {
   "version": "4",
   "rollouts": [],
-  "typedAudiences": [],
   "anonymizeIP": true,
-  "projectId": "12254210345",
+  "projectId": "10431130345",
   "variables": [],
   "featureFlags": [
     {
-      "_comment": "trafficAllocation: 4000 and 8000, respectively",
-      "experimentIds": ["12198292373", "12198292374"],
-      "id": "4482920077",
-      "key": "mutex_group_feature",
+      "experimentIds": ["10390977673"],
+      "key": "ab_running_exp_single_exact_match_string_untypedaudience",
       "rolloutId": "",
-      "variables": [
-        {
-          "defaultValue": "42",
-          "id": "2687470094",
-          "key": "i_42",
-          "type": "integer"
-        },
-        {
-          "defaultValue": "42.2",
-          "id": "2687470095",
-          "key": "d_4_2",
-          "type": "double"
-        },
-        {
-          "defaultValue": "true",
-          "id": "2687470096",
-          "key": "b_true",
-          "type": "boolean"
-        },
-        {
-          "defaultValue": "foo",
-          "id": "2687470097",
-          "key": "s_foo",
-          "type": "string"
-        }
-      ]
+      "variables": [],
+      "id": "1000000016"
     },
     {
-      "experimentIds": ["12198292376"],
-      "id": "4482920079",
-      "key": "feature_exp_no_traffic",
+      "experimentIds": ["10390977674"],
+      "key": "ab_running_exp_single_exact_match_string_typedaudience",
       "rolloutId": "",
-      "variables": []
+      "variables": [],
+      "id": "1000000017"
     }
   ],
   "experiments": [
     {
       "status": "Running",
-      "key": "exp_with_audience",
+      "key": "ab_running_exp_single_exact_match_string_untypedaudience",
       "layerId": "10420273888",
       "trafficAllocation": [
         {
-          "entityId": "10389729780",
+          "entityId": "10416523121",
           "endOfRange": 10000
         }
       ],
-      "audienceIds": [],
+      "audienceIds": ["10413101794"],
       "variations": [
         {
           "variables": [],
-          "featureEnabled": true,
-          "id": "10389729780",
-          "key": "a"
-        },
-        {
-          "variables": [],
           "id": "10416523121",
-          "key": "b"
+          "key": "all_traffic_variation"
         }
       ],
       "forcedVariations": {},
       "id": "10390977673"
-    }
-  ],
-  "audiences": [],
-  "groups": [
-    {
-      "policy": "random",
-      "trafficAllocation": [
-        {
-          "entityId": "12198292373",
-          "endOfRange": 4000
-        },
-        {
-          "entityId": "12198292374",
-          "endOfRange": 8000
-        }
-      ],
-      "experiments": [
-        {
-          "status": "Running",
-          "key": "experiment_4000",
-          "layerId": "12235440722",
-          "trafficAllocation": [
-            {
-              "entityId": "12098126626",
-              "endOfRange": 10000
-            }
-          ],
-          "audienceIds": [],
-          "variations": [
-            {
-              "variables": [
-                {
-                  "value": "50",
-                  "id": "2687470094"
-                },
-                {
-                  "value": "50.5",
-                  "id": "2687470095"
-                },
-                {
-                  "value": "false",
-                  "id": "2687470096"
-                },
-                {
-                  "value": "s1",
-                  "id": "2687470097"
-                }
-              ],
-              "featureEnabled": true,
-              "id": "12098126626",
-              "key": "all_traffic_variation_exp_1"
-            },
-            {
-              "variables": [],
-              "id": "12107729995",
-              "featureEnabled": true,
-              "key": "no_traffic_variation_exp_1"
-            }
-          ],
-          "forcedVariations": {},
-          "id": "12198292373"
-        },
-        {
-          "status": "Running",
-          "key": "experiment_8000",
-          "layerId": "12187694825",
-          "trafficAllocation": [
-            {
-              "entityId": "12232050369",
-              "endOfRange": 10000
-            }
-          ],
-          "audienceIds": [],
-          "variations": [
-            {
-              "variables": [
-                {
-                  "value": "50",
-                  "id": "2687470094"
-                },
-                {
-                  "value": "50.5",
-                  "id": "2687470095"
-                }
-              ],
-              "id": "12252360417",
-              "featureEnabled": false,
-              "key": "no_traffic_variation_exp_2"
-            }
-          ],
-          "forcedVariations": {},
-          "id": "12198292374"
-        }
-      ],
-      "id": "12115595438"
     },
     {
-      "policy": "random",
+      "status": "Running",
+      "key": "ab_running_exp_single_exact_match_string_typedaudience",
+      "layerId": "10420273888",
       "trafficAllocation": [
         {
-          "entityId": "12198292375",
+          "entityId": "10416523121",
           "endOfRange": 10000
         }
       ],
-      "experiments": [
+      "audienceIds": ["20413101794"],
+      "variations": [
         {
-          "status": "Running",
-          "key": "all_traffic_experiment",
-          "layerId": "12235440723",
-          "trafficAllocation": [
-            {
-              "entityId": "12098126627",
-              "endOfRange": 10000
-            }
-          ],
-          "audienceIds": [],
-          "variations": [
-            {
-              "variables": [
-                {
-                  "value": "4",
-                  "id": "2687470094"
-                },
-                {
-                  "value": "10.6",
-                  "id": "2687470095"
-                },
-                {
-                  "value": "true",
-                  "id": "2687470096"
-                },
-                {
-                  "value": "s1 foo",
-                  "id": "2687470097"
-                }
-              ],
-              "id": "12098126627",
-              "featureEnabled": true,
-              "key": "all_traffic_variation"
-            },
-            {
-              "variables": [],
-              "id": "12098126628",
-              "featureEnabled": true,
-              "key": "no_traffic_variation"
-            }
-          ],
-          "forcedVariations": {},
-          "id": "12198292375"
-        },
-        {
-          "status": "Running",
-          "key": "no_traffic_experiment",
-          "layerId": "12187694826",
-          "trafficAllocation": [
-            {
-              "entityId": "12098126629",
-              "endOfRange": 5000
-            },
-            {
-              "entityId": "12098126630",
-              "endOfRange": 10000
-            }
-          ],
-          "audienceIds": [],
-          "variations": [
-            {
-              "variables": [],
-              "id": "12098126629",
-              "featureEnabled": true,
-              "key": "variation_5000"
-            },
-            {
-              "variables": [],
-              "id": "12098126630",
-              "featureEnabled": true,
-              "key": "variation_10000"
-            }
-          ],
-          "forcedVariations": {},
-          "id": "12198292376"
+          "variables": [],
+          "id": "10416523121",
+          "key": "all_traffic_variation"
         }
       ],
-      "id": "12115595439"
+      "forcedVariations": {},
+      "id": "10390977674"
     }
   ],
-  "attributes": [],
-  "botFiltering": false,
-  "accountId": "8272261422",
-  "events": [],
-  "revision": "9"
+  "audiences": [
+    {
+      "id": "10413101794",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"value\": \"exact_match\"}]]]",
+      "name": "untyped_single_condition_exact_string_match"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "20413101794",
+      "conditions": {
+        "type": "custom_attribute",
+        "name": "s_foo",
+        "match": "exact",
+        "value": "leaf_root"
+      },
+      "name": "single_condition_leaf_root"
+    }
+  ],
+  "groups": [],
+  "attributes": [
+    {
+      "id": "10401066170",
+      "key": "string_attribute"
+    },
+    {
+      "id": "10401066171",
+      "key": "s_foo"
+    }
+  ],
+  "accountId": "10367498574",
+  "events": [
+    {
+      "experimentIds": ["10390977673"],
+      "id": "10404198135",
+      "key": "event_single_targeted_exp"
+    },
+    {
+      "experimentIds": ["10390977674"],
+      "id": "10404198136",
+      "key": "event_single_untargeted_exp"
+    }
+  ],
+  "revision": "242"
 }

--- a/pkg/config/testdata/optimizely_config_expected.json
+++ b/pkg/config/testdata/optimizely_config_expected.json
@@ -1,345 +1,135 @@
 {
-  "experimentsMap":{
-    "all_traffic_experiment":{
-      "id":"12198292375",
-      "key":"all_traffic_experiment",
-      "variationsMap":{
-        "all_traffic_variation":{
-          "featureEnabled":true,
-          "id":"12098126627",
-          "key":"all_traffic_variation",
-          "variablesMap":{
-          }
-        },
-        "no_traffic_variation":{
-          "featureEnabled":true,
-          "id":"12098126628",
-          "key":"no_traffic_variation",
-          "variablesMap":{
-
-          }
+  "environmentKey": "",
+  "sdkKey": "",
+  "revision": "242",
+  "experimentsMap": {
+    "ab_running_exp_single_exact_match_string_typedaudience": {
+      "id": "10390977674",
+      "key": "ab_running_exp_single_exact_match_string_typedaudience",
+      "audiences": "",
+      "variationsMap": {
+        "all_traffic_variation": {
+          "id": "10416523121",
+          "key": "all_traffic_variation",
+          "featureEnabled": false,
+          "variablesMap": {}
         }
       }
     },
-    "exp_with_audience":{
-      "id":"10390977673",
-      "key":"exp_with_audience",
-      "variationsMap":{
-        "a":{
-          "featureEnabled":true,
-          "id":"10389729780",
-          "key":"a",
-          "variablesMap":{
-
-          }
-        },
-        "b":{
-          "featureEnabled":false,
-          "id":"10416523121",
-          "key":"b",
-          "variablesMap":{
-
-          }
+    "ab_running_exp_single_exact_match_string_untypedaudience": {
+      "id": "10390977673",
+      "key": "ab_running_exp_single_exact_match_string_untypedaudience",
+      "audiences": "",
+      "variationsMap": {
+        "all_traffic_variation": {
+          "id": "10416523121",
+          "key": "all_traffic_variation",
+          "featureEnabled": false,
+          "variablesMap": {}
         }
       }
-    },
-    "experiment_4000":{
-      "id":"12198292373",
-      "key":"experiment_4000",
-      "variationsMap":{
-        "all_traffic_variation_exp_1":{
-          "featureEnabled":true,
-          "id":"12098126626",
-          "key":"all_traffic_variation_exp_1",
-          "variablesMap":{
-            "b_true":{
-              "id":"2687470096",
-              "key":"b_true",
-              "type":"boolean",
-              "value":"false"
-            },
-            "d_4_2":{
-              "id":"2687470095",
-              "key":"d_4_2",
-              "type":"double",
-              "value":"50.5"
-            },
-            "i_42":{
-              "id":"2687470094",
-              "key":"i_42",
-              "type":"integer",
-              "value":"50"
-            },
-            "s_foo":{
-              "id":"2687470097",
-              "key":"s_foo",
-              "type":"string",
-              "value":"s1"
+    }
+  },
+  "featuresMap": {
+    "ab_running_exp_single_exact_match_string_typedaudience": {
+      "id": "1000000017",
+      "key": "ab_running_exp_single_exact_match_string_typedaudience",
+      "experimentRules": [
+        {
+          "id": "10390977674",
+          "key": "ab_running_exp_single_exact_match_string_typedaudience",
+          "audiences": "",
+          "variationsMap": {
+            "all_traffic_variation": {
+              "id": "10416523121",
+              "key": "all_traffic_variation",
+              "featureEnabled": false,
+              "variablesMap": {}
             }
           }
-        },
-        "no_traffic_variation_exp_1":{
-          "featureEnabled":true,
-          "id":"12107729995",
-          "key":"no_traffic_variation_exp_1",
-          "variablesMap":{
-            "b_true":{
-              "id":"2687470096",
-              "key":"b_true",
-              "type":"boolean",
-              "value":"true"
-            },
-            "d_4_2":{
-              "id":"2687470095",
-              "key":"d_4_2",
-              "type":"double",
-              "value":"42.2"
-            },
-            "i_42":{
-              "id":"2687470094",
-              "key":"i_42",
-              "type":"integer",
-              "value":"42"
-            },
-            "s_foo":{
-              "id":"2687470097",
-              "key":"s_foo",
-              "type":"string",
-              "value":"foo"
+        }
+      ],
+      "deliveryRules": [],
+      "variablesMap": {},
+      "experimentsMap": {
+        "ab_running_exp_single_exact_match_string_typedaudience": {
+          "id": "10390977674",
+          "key": "ab_running_exp_single_exact_match_string_typedaudience",
+          "audiences": "",
+          "variationsMap": {
+            "all_traffic_variation": {
+              "id": "10416523121",
+              "key": "all_traffic_variation",
+              "featureEnabled": false,
+              "variablesMap": {}
             }
           }
         }
       }
     },
-    "experiment_8000":{
-      "id":"12198292374",
-      "key":"experiment_8000",
-      "variationsMap":{
-        "no_traffic_variation_exp_2":{
-          "featureEnabled":false,
-          "id":"12252360417",
-          "key":"no_traffic_variation_exp_2",
-          "variablesMap":{
-            "b_true":{
-              "id":"2687470096",
-              "key":"b_true",
-              "type":"boolean",
-              "value":"true"
-            },
-            "d_4_2":{
-              "id":"2687470095",
-              "key":"d_4_2",
-              "type":"double",
-              "value":"42.2"
-            },
-            "i_42":{
-              "id":"2687470094",
-              "key":"i_42",
-              "type":"integer",
-              "value":"42"
-            },
-            "s_foo":{
-              "id":"2687470097",
-              "key":"s_foo",
-              "type":"string",
-              "value":"foo"
+    "ab_running_exp_single_exact_match_string_untypedaudience": {
+      "id": "1000000016",
+      "key": "ab_running_exp_single_exact_match_string_untypedaudience",
+      "experimentRules": [
+        {
+          "id": "10390977673",
+          "key": "ab_running_exp_single_exact_match_string_untypedaudience",
+          "audiences": "",
+          "variationsMap": {
+            "all_traffic_variation": {
+              "id": "10416523121",
+              "key": "all_traffic_variation",
+              "featureEnabled": false,
+              "variablesMap": {}
             }
           }
         }
-      }
-    },
-    "no_traffic_experiment":{
-      "id":"12198292376",
-      "key":"no_traffic_experiment",
-      "variationsMap":{
-        "variation_5000":{
-          "featureEnabled":true,
-          "id":"12098126629",
-          "key":"variation_5000",
-          "variablesMap":{
-
-          }
-        },
-        "variation_10000":{
-          "featureEnabled":true,
-          "id":"12098126630",
-          "key":"variation_10000",
-          "variablesMap":{
-
+      ],
+      "deliveryRules": [],
+      "variablesMap": {},
+      "experimentsMap": {
+        "ab_running_exp_single_exact_match_string_untypedaudience": {
+          "id": "10390977673",
+          "key": "ab_running_exp_single_exact_match_string_untypedaudience",
+          "audiences": "",
+          "variationsMap": {
+            "all_traffic_variation": {
+              "id": "10416523121",
+              "key": "all_traffic_variation",
+              "featureEnabled": false,
+              "variablesMap": {}
+            }
           }
         }
       }
     }
   },
-  "featuresMap":{
-    "feature_exp_no_traffic":{
-      "experimentsMap":{
-        "no_traffic_experiment":{
-          "id":"12198292376",
-          "key":"no_traffic_experiment",
-          "variationsMap":{
-            "variation_5000":{
-              "featureEnabled":true,
-              "id":"12098126629",
-              "key":"variation_5000",
-              "variablesMap":{
-
-              }
-            },
-            "variation_10000":{
-              "featureEnabled":true,
-              "id":"12098126630",
-              "key":"variation_10000",
-              "variablesMap":{
-
-              }
-            }
-          }
-        }
-      },
-      "id":"4482920079",
-      "key":"feature_exp_no_traffic",
-      "variablesMap":{
-
-      }
+  "attributes": [
+    { "id": "10401066170", "key": "string_attribute" },
+    { "id": "10401066171", "key": "s_foo" }
+  ],
+  "audiences": [
+    {
+      "id": "20413101794",
+      "name": "single_condition_leaf_root",
+      "conditions": "{\"match\":\"exact\",\"name\":\"s_foo\",\"type\":\"custom_attribute\",\"value\":\"leaf_root\"}"
     },
-    "mutex_group_feature":{
-      "experimentsMap":{
-        "experiment_4000":{
-          "id":"12198292373",
-          "key":"experiment_4000",
-          "variationsMap":{
-            "all_traffic_variation_exp_1":{
-              "featureEnabled":true,
-              "id":"12098126626",
-              "key":"all_traffic_variation_exp_1",
-              "variablesMap":{
-                "b_true":{
-                  "id":"2687470096",
-                  "key":"b_true",
-                  "type":"boolean",
-                  "value":"false"
-                },
-                "d_4_2":{
-                  "id":"2687470095",
-                  "key":"d_4_2",
-                  "type":"double",
-                  "value":"50.5"
-                },
-                "i_42":{
-                  "id":"2687470094",
-                  "key":"i_42",
-                  "type":"integer",
-                  "value":"50"
-                },
-                "s_foo":{
-                  "id":"2687470097",
-                  "key":"s_foo",
-                  "type":"string",
-                  "value":"s1"
-                }
-              }
-            },
-            "no_traffic_variation_exp_1":{
-              "featureEnabled":true,
-              "id":"12107729995",
-              "key":"no_traffic_variation_exp_1",
-              "variablesMap":{
-                "b_true":{
-                  "id":"2687470096",
-                  "key":"b_true",
-                  "type":"boolean",
-                  "value":"true"
-                },
-                "d_4_2":{
-                  "id":"2687470095",
-                  "key":"d_4_2",
-                  "type":"double",
-                  "value":"42.2"
-                },
-                "i_42":{
-                  "id":"2687470094",
-                  "key":"i_42",
-                  "type":"integer",
-                  "value":"42"
-                },
-                "s_foo":{
-                  "id":"2687470097",
-                  "key":"s_foo",
-                  "type":"string",
-                  "value":"foo"
-                }
-              }
-            }
-          }
-        },
-        "experiment_8000":{
-          "id":"12198292374",
-          "key":"experiment_8000",
-          "variationsMap":{
-            "no_traffic_variation_exp_2":{
-              "featureEnabled":false,
-              "id":"12252360417",
-              "key":"no_traffic_variation_exp_2",
-              "variablesMap":{
-                "b_true":{
-                  "id":"2687470096",
-                  "key":"b_true",
-                  "type":"boolean",
-                  "value":"true"
-                },
-                "d_4_2":{
-                  "id":"2687470095",
-                  "key":"d_4_2",
-                  "type":"double",
-                  "value":"42.2"
-                },
-                "i_42":{
-                  "id":"2687470094",
-                  "key":"i_42",
-                  "type":"integer",
-                  "value":"42"
-                },
-                "s_foo":{
-                  "id":"2687470097",
-                  "key":"s_foo",
-                  "type":"string",
-                  "value":"foo"
-                }
-              }
-            }
-          }
-        }
-      },
-      "id":"4482920077",
-      "key":"mutex_group_feature",
-      "variablesMap":{
-        "b_true":{
-          "id":"2687470096",
-          "key":"b_true",
-          "type":"boolean",
-          "value":"true"
-        },
-        "d_4_2":{
-          "id":"2687470095",
-          "key":"d_4_2",
-          "type":"double",
-          "value":"42.2"
-        },
-        "i_42":{
-          "id":"2687470094",
-          "key":"i_42",
-          "type":"integer",
-          "value":"42"
-        },
-        "s_foo":{
-          "id":"2687470097",
-          "key":"s_foo",
-          "type":"string",
-          "value":"foo"
-        }
-      }
+    {
+      "id": "10413101794",
+      "name": "untyped_single_condition_exact_string_match",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"value\": \"exact_match\"}]]]"
     }
-  },
-  "revision":"9"
+  ],
+  "events": [
+    {
+      "id": "10404198135",
+      "key": "event_single_targeted_exp",
+      "experimentIds": ["10390977673"]
+    },
+    {
+      "id": "10404198136",
+      "key": "event_single_untargeted_exp",
+      "experimentIds": ["10390977674"]
+    }
+  ]
 }

--- a/pkg/config/testdata/similar_exp_keys_datafile.json
+++ b/pkg/config/testdata/similar_exp_keys_datafile.json
@@ -1,0 +1,125 @@
+{
+    "version": "4",
+    "rollouts": [],
+    "typedAudiences": [
+      {
+        "id": "20415611520",
+        "conditions": [
+          "and",
+          [
+            "or",
+            [
+              "or",
+              {
+                "value": true,
+                "type": "custom_attribute",
+                "name": "hiddenLiveEnabled",
+                "match": "exact"
+              }
+            ]
+          ]
+        ],
+        "name": "test1"
+      },
+      {
+        "id": "20406066925",
+        "conditions": [
+          "and",
+          [
+            "or",
+            [
+              "or",
+              {
+                "value": false,
+                "type": "custom_attribute",
+                "name": "hiddenLiveEnabled",
+                "match": "exact"
+              }
+            ]
+          ]
+        ],
+        "name": "test2"
+      }
+    ],
+    "anonymizeIP": true,
+    "projectId": "20430981610",
+    "variables": [],
+    "featureFlags": [
+      {
+        "experimentIds": ["9300000007569"],
+        "rolloutId": "",
+        "variables": [],
+        "id": "3045",
+        "key": "flag1"
+      },
+      {
+        "experimentIds": ["9300000007573"],
+        "rolloutId": "",
+        "variables": [],
+        "id": "3046",
+        "key": "flag2"
+      }
+    ],
+    "experiments": [
+      {
+        "status": "Running",
+        "audienceConditions": ["or", "20415611520"],
+        "audienceIds": ["20415611520"],
+        "variations": [
+          {
+            "variables": [],
+            "id": "8045",
+            "key": "variation1",
+            "featureEnabled": true
+          }
+        ],
+        "forcedVariations": {},
+        "key": "targeted_delivery",
+        "layerId": "9300000007569",
+        "trafficAllocation": [{ "entityId": "8045", "endOfRange": 10000 }],
+        "id": "9300000007569"
+      },
+      {
+        "status": "Running",
+        "audienceConditions": ["or", "20406066925"],
+        "audienceIds": ["20406066925"],
+        "variations": [
+          {
+            "variables": [],
+            "id": "8048",
+            "key": "variation2",
+            "featureEnabled": true
+          }
+        ],
+        "forcedVariations": {},
+        "key": "targeted_delivery",
+        "layerId": "9300000007573",
+        "trafficAllocation": [{ "entityId": "8048", "endOfRange": 10000 }],
+        "id": "9300000007573"
+      }
+    ],
+    "audiences": [
+      {
+        "id": "20415611520",
+        "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
+        "name": "test1"
+      },
+      {
+        "id": "20406066925",
+        "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
+        "name": "test2"
+      },
+      {
+        "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
+        "id": "$opt_dummy_audience",
+        "name": "Optimizely-Generated Audience for Backwards Compatibility"
+      }
+    ],
+    "groups": [],
+    "attributes": [{ "id": "20408641883", "key": "hiddenLiveEnabled" }],
+    "botFiltering": false,
+    "accountId": "17882702980",
+    "events": [],
+    "revision": "25",
+    "sendFlagDecisions": true
+  }

--- a/pkg/config/testdata/similar_exp_keys_expected.json
+++ b/pkg/config/testdata/similar_exp_keys_expected.json
@@ -1,0 +1,108 @@
+{
+  "environmentKey": "",
+  "sdkKey": "",
+  "revision": "25",
+  "experimentsMap": {
+    "targeted_delivery": {
+      "id": "9300000007573",
+      "key": "targeted_delivery",
+      "audiences": "\"test2\"",
+      "variationsMap": {
+        "variation2": {
+          "id": "8048",
+          "key": "variation2",
+          "featureEnabled": true,
+          "variablesMap": {}
+        }
+      }
+    }
+  },
+  "featuresMap": {
+    "flag1": {
+      "id": "3045",
+      "key": "flag1",
+      "experimentRules": [
+        {
+          "id": "9300000007569",
+          "key": "targeted_delivery",
+          "audiences": "\"test1\"",
+          "variationsMap": {
+            "variation1": {
+              "id": "8045",
+              "key": "variation1",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        }
+      ],
+      "deliveryRules": [],
+      "variablesMap": {},
+      "experimentsMap": {
+        "targeted_delivery": {
+          "id": "9300000007569",
+          "key": "targeted_delivery",
+          "audiences": "\"test1\"",
+          "variationsMap": {
+            "variation1": {
+              "id": "8045",
+              "key": "variation1",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        }
+      }
+    },
+    "flag2": {
+      "id": "3046",
+      "key": "flag2",
+      "experimentRules": [
+        {
+          "id": "9300000007573",
+          "key": "targeted_delivery",
+          "audiences": "\"test2\"",
+          "variationsMap": {
+            "variation2": {
+              "id": "8048",
+              "key": "variation2",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        }
+      ],
+      "deliveryRules": [],
+      "variablesMap": {},
+      "experimentsMap": {
+        "targeted_delivery": {
+          "id": "9300000007573",
+          "key": "targeted_delivery",
+          "audiences": "\"test2\"",
+          "variationsMap": {
+            "variation2": {
+              "id": "8048",
+              "key": "variation2",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "attributes": [{ "id": "20408641883", "key": "hiddenLiveEnabled" }],
+  "audiences": [
+    {
+      "id": "20415611520",
+      "name": "test1",
+      "conditions": "[\"and\",[\"or\",[\"or\",{\"match\":\"exact\",\"name\":\"hiddenLiveEnabled\",\"type\":\"custom_attribute\",\"value\":true}]]]"
+    },
+    {
+      "id": "20406066925",
+      "name": "test2",
+      "conditions": "[\"and\",[\"or\",[\"or\",{\"match\":\"exact\",\"name\":\"hiddenLiveEnabled\",\"type\":\"custom_attribute\",\"value\":false}]]]"
+    }
+  ],
+  "events": []
+}

--- a/pkg/config/testdata/similar_rule_keys_bucketing_datafile.json
+++ b/pkg/config/testdata/similar_rule_keys_bucketing_datafile.json
@@ -1,0 +1,170 @@
+{
+    "version": "4",
+    "rollouts": [
+      {
+        "experiments": [
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5452",
+                "key": "on",
+                "featureEnabled": true
+              }
+            ],
+            "forcedVariations": {},
+            "key": "targeted_delivery",
+            "layerId": "9300000004981",
+            "trafficAllocation": [{ "entityId": "5452", "endOfRange": 10000 }],
+            "id": "9300000004981"
+          },
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5451",
+                "key": "off",
+                "featureEnabled": false
+              }
+            ],
+            "forcedVariations": {},
+            "key": "default-rollout-2029-20301771717",
+            "layerId": "default-layer-rollout-2029-20301771717",
+            "trafficAllocation": [{ "entityId": "5451", "endOfRange": 10000 }],
+            "id": "default-rollout-2029-20301771717"
+          }
+        ],
+        "id": "rollout-2029-20301771717"
+      },
+      {
+        "experiments": [
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5450",
+                "key": "on",
+                "featureEnabled": true
+              }
+            ],
+            "forcedVariations": {},
+            "key": "targeted_delivery",
+            "layerId": "9300000004979",
+            "trafficAllocation": [{ "entityId": "5450", "endOfRange": 10000 }],
+            "id": "9300000004979"
+          },
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5449",
+                "key": "off",
+                "featureEnabled": false
+              }
+            ],
+            "forcedVariations": {},
+            "key": "default-rollout-2028-20301771717",
+            "layerId": "default-layer-rollout-2028-20301771717",
+            "trafficAllocation": [{ "entityId": "5449", "endOfRange": 10000 }],
+            "id": "default-rollout-2028-20301771717"
+          }
+        ],
+        "id": "rollout-2028-20301771717"
+      },
+      {
+        "experiments": [
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5448",
+                "key": "on",
+                "featureEnabled": true
+              }
+            ],
+            "forcedVariations": {},
+            "key": "targeted_delivery",
+            "layerId": "9300000004977",
+            "trafficAllocation": [{ "entityId": "5448", "endOfRange": 10000 }],
+            "id": "9300000004977"
+          },
+          {
+            "status": "Running",
+            "audienceConditions": [],
+            "audienceIds": [],
+            "variations": [
+              {
+                "variables": [],
+                "id": "5447",
+                "key": "off",
+                "featureEnabled": false
+              }
+            ],
+            "forcedVariations": {},
+            "key": "default-rollout-2027-20301771717",
+            "layerId": "default-layer-rollout-2027-20301771717",
+            "trafficAllocation": [{ "entityId": "5447", "endOfRange": 10000 }],
+            "id": "default-rollout-2027-20301771717"
+          }
+        ],
+        "id": "rollout-2027-20301771717"
+      }
+    ],
+    "typedAudiences": [],
+    "anonymizeIP": true,
+    "projectId": "20286295225",
+    "variables": [],
+    "featureFlags": [
+      {
+        "experimentIds": [],
+        "rolloutId": "rollout-2029-20301771717",
+        "variables": [],
+        "id": "2029",
+        "key": "flag_3"
+      },
+      {
+        "experimentIds": [],
+        "rolloutId": "rollout-2028-20301771717",
+        "variables": [],
+        "id": "2028",
+        "key": "flag_2"
+      },
+      {
+        "experimentIds": [],
+        "rolloutId": "rollout-2027-20301771717",
+        "variables": [],
+        "id": "2027",
+        "key": "flag_1"
+      }
+    ],
+    "experiments": [],
+    "audiences": [
+      {
+        "conditions": "[\"or\", {\"match\": \"exact\", \"name\": \"$opt_dummy_attribute\", \"type\": \"custom_attribute\", \"value\": \"$opt_dummy_value\"}]",
+        "id": "$opt_dummy_audience",
+        "name": "Optimizely-Generated Audience for Backwards Compatibility"
+      }
+    ],
+    "groups": [],
+    "attributes": [],
+    "botFiltering": false,
+    "accountId": "19947277778",
+    "events": [],
+    "revision": "11",
+    "sendFlagDecisions": true
+  }

--- a/pkg/config/testdata/similar_rule_keys_bucketing_expected.json
+++ b/pkg/config/testdata/similar_rule_keys_bucketing_expected.json
@@ -1,0 +1,116 @@
+{
+  "environmentKey": "",
+  "sdkKey": "",
+  "revision": "11",
+  "experimentsMap": {},
+  "featuresMap": {
+    "flag_1": {
+      "id": "2027",
+      "key": "flag_1",
+      "experimentRules": [],
+      "deliveryRules": [
+        {
+          "id": "9300000004977",
+          "key": "targeted_delivery",
+          "audiences": "",
+          "variationsMap": {
+            "on": {
+              "id": "5448",
+              "key": "on",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        },
+        {
+          "id": "default-rollout-2027-20301771717",
+          "key": "default-rollout-2027-20301771717",
+          "audiences": "",
+          "variationsMap": {
+            "off": {
+              "id": "5447",
+              "key": "off",
+              "featureEnabled": false,
+              "variablesMap": {}
+            }
+          }
+        }
+      ],
+      "variablesMap": {},
+      "experimentsMap": {}
+    },
+    "flag_2": {
+      "id": "2028",
+      "key": "flag_2",
+      "experimentRules": [],
+      "deliveryRules": [
+        {
+          "id": "9300000004979",
+          "key": "targeted_delivery",
+          "audiences": "",
+          "variationsMap": {
+            "on": {
+              "id": "5450",
+              "key": "on",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        },
+        {
+          "id": "default-rollout-2028-20301771717",
+          "key": "default-rollout-2028-20301771717",
+          "audiences": "",
+          "variationsMap": {
+            "off": {
+              "id": "5449",
+              "key": "off",
+              "featureEnabled": false,
+              "variablesMap": {}
+            }
+          }
+        }
+      ],
+      "variablesMap": {},
+      "experimentsMap": {}
+    },
+    "flag_3": {
+      "id": "2029",
+      "key": "flag_3",
+      "experimentRules": [],
+      "deliveryRules": [
+        {
+          "id": "9300000004981",
+          "key": "targeted_delivery",
+          "audiences": "",
+          "variationsMap": {
+            "on": {
+              "id": "5452",
+              "key": "on",
+              "featureEnabled": true,
+              "variablesMap": {}
+            }
+          }
+        },
+        {
+          "id": "default-rollout-2029-20301771717",
+          "key": "default-rollout-2029-20301771717",
+          "audiences": "",
+          "variationsMap": {
+            "off": {
+              "id": "5451",
+              "key": "off",
+              "featureEnabled": false,
+              "variablesMap": {}
+            }
+          }
+        }
+      ],
+      "variablesMap": {},
+      "experimentsMap": {}
+    }
+  },
+  "attributes": [],
+  "audiences": [],
+  "events": []
+}

--- a/pkg/config/testdata/typed_audience_datafile.json
+++ b/pkg/config/testdata/typed_audience_datafile.json
@@ -1,0 +1,379 @@
+{
+	"version": "4",
+	"rollouts": [{
+			"experiments": [{
+				"status": "Running",
+				"key": "feat_no_vars_rule",
+				"layerId": "11551226731",
+				"trafficAllocation": [{
+					"entityId": "11557362669",
+					"endOfRange": 10000
+				}],
+				"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+				"variations": [{
+					"variables": [],
+					"id": "11557362669",
+					"key": "11557362669",
+					"featureEnabled": true
+				}],
+				"forcedVariations": {},
+				"id": "11488548027"
+			}],
+			"id": "11551226731"
+		},
+		{
+			"experiments": [{
+				"status": "Paused",
+				"key": "feat_with_var_rule",
+				"layerId": "11638870867",
+				"trafficAllocation": [{
+					"entityId": "11475708558",
+					"endOfRange": 0
+				}],
+				"audienceIds": [],
+				"variations": [{
+					"variables": [],
+					"id": "11475708558",
+					"key": "11475708558",
+					"featureEnabled": false
+				}],
+				"forcedVariations": {},
+				"id": "11630490911"
+			}],
+			"id": "11638870867"
+		},
+		{
+			"experiments": [{
+				"status": "Running",
+				"key": "11488548028",
+				"layerId": "11551226732",
+				"trafficAllocation": [{
+					"entityId": "11557362670",
+					"endOfRange": 10000
+				}],
+				"audienceIds": ["0"],
+				"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
+					["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
+				],
+				"variations": [{
+					"variables": [],
+					"id": "11557362670",
+					"key": "11557362670",
+					"featureEnabled": true
+				}],
+				"forcedVariations": {},
+				"id": "11488548028"
+			}],
+			"id": "11551226732"
+		},
+		{
+			"experiments": [{
+				"status": "Paused",
+				"key": "11630490912",
+				"layerId": "11638870868",
+				"trafficAllocation": [{
+					"entityId": "11475708559",
+					"endOfRange": 0
+				}],
+				"audienceIds": [],
+				"variations": [{
+					"variables": [],
+					"id": "11475708559",
+					"key": "11475708559",
+					"featureEnabled": false
+				}],
+				"forcedVariations": {},
+				"id": "11630490912"
+			}],
+			"id": "11638870868"
+		}
+	],
+	"anonymizeIP": false,
+	"projectId": "11624721371",
+	"variables": [],
+	"featureFlags": [{
+			"experimentIds": [],
+			"rolloutId": "11551226731",
+			"variables": [],
+			"id": "11477755619",
+			"key": "feat_no_vars"
+		},
+		{
+			"experimentIds": [
+				"11564051718"
+			],
+			"rolloutId": "11638870867",
+			"variables": [{
+				"defaultValue": "x",
+				"type": "string",
+				"id": "11535264366",
+				"key": "x"
+			}],
+			"id": "11567102051",
+			"key": "feat_with_var"
+		},
+		{
+			"experimentIds": [],
+			"rolloutId": "11551226732",
+			"variables": [],
+			"id": "11567102052",
+			"key": "feat2"
+		},
+		{
+			"experimentIds": ["1323241599"],
+			"rolloutId": "11638870868",
+			"variables": [{
+				"defaultValue": "10",
+				"type": "integer",
+				"id": "11535264367",
+				"key": "z"
+			}],
+			"id": "11567102053",
+			"key": "feat2_with_var"
+		}
+	],
+	"experiments": [{
+			"status": "Running",
+			"key": "feat_with_var_test",
+			"layerId": "11504144555",
+			"trafficAllocation": [{
+				"entityId": "11617170975",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+			"variations": [{
+				"variables": [{
+					"id": "11535264366",
+					"value": "xyz"
+				}],
+				"id": "11617170975",
+				"key": "variation_2",
+				"featureEnabled": true
+			}],
+			"forcedVariations": {},
+			"id": "11564051718"
+		},
+		{
+			"id": "1323241597",
+			"key": "typed_audience_experiment",
+			"layerId": "1630555627",
+			"status": "Running",
+			"variations": [{
+				"id": "1423767503",
+				"key": "A",
+				"variables": []
+			}],
+			"trafficAllocation": [{
+				"entityId": "1423767503",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+			"forcedVariations": {}
+		},
+		{
+			"id": "1323241598",
+			"key": "audience_combinations_experiment",
+			"layerId": "1323241598",
+			"status": "Running",
+			"variations": [{
+				"id": "1423767504",
+				"key": "A",
+				"variables": []
+			}],
+			"trafficAllocation": [{
+				"entityId": "1423767504",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["0"],
+			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
+				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
+			],
+			"forcedVariations": {}
+		},
+		{
+			"id": "1323241599",
+			"key": "feat2_with_var_test",
+			"layerId": "1323241600",
+			"status": "Running",
+			"variations": [{
+				"variables": [{
+					"id": "11535264367",
+					"value": "150"
+				}],
+				"id": "1423767505",
+				"key": "variation_2",
+				"featureEnabled": true
+			}],
+			"trafficAllocation": [{
+				"entityId": "1423767505",
+				"endOfRange": 10000
+			}],
+			"audienceIds": ["0"],
+			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
+				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
+			],
+			"forcedVariations": {}
+		}
+	],
+	"audiences": [
+		{
+			"id": "3468206642",
+			"name": "exactString",
+			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
+		},
+		{
+			"id": "3468206645",
+			"name": "notChrome",
+			"conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
+		},
+		{
+			"id": "3988293898",
+			"name": "$$dummySubstringString",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3988293899",
+			"name": "$$dummyExists",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206646",
+			"name": "$$dummyExactNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206647",
+			"name": "$$dummyGtNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206644",
+			"name": "$$dummyLtNumber",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "3468206643",
+			"name": "$$dummyExactBoolean",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "0",
+			"name": "$$dummy",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		},
+		{
+			"id": "$opt_dummy_audience",
+			"name": "dummy_audience",
+			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+		}
+	],
+	"typedAudiences": [{
+			"id": "3988293898",
+			"name": "substringString",
+			"conditions": ["and", ["or", ["or", {
+				"name": "house",
+				"type": "custom_attribute",
+				"match": "substring",
+				"value": "Slytherin"
+			}]]]
+		},
+		{
+			"id": "3988293899",
+			"name": "exists",
+			"conditions": ["and", ["or", ["or", {
+				"name": "favorite_ice_cream",
+				"type": "custom_attribute",
+				"match": "exists"
+			}]]]
+		},
+		{
+			"id": "3468206646",
+			"name": "exactNumber",
+			"conditions": ["and", ["or", ["or", {
+				"name": "lasers",
+				"type": "custom_attribute",
+				"match": "exact",
+				"value": 45.5
+			}]]]
+		},
+		{
+			"id": "3468206647",
+			"name": "gtNumber",
+			"conditions": ["and", ["or", ["or", {
+				"name": "lasers",
+				"type": "custom_attribute",
+				"match": "gt",
+				"value": 70
+			}]]]
+		},
+		{
+			"id": "3468206644",
+			"name": "ltNumber",
+			"conditions": ["and", ["or", ["or", {
+				"name": "lasers",
+				"type": "custom_attribute",
+				"match": "lt",
+				"value": 1.0
+			}]]]
+		},
+		{
+			"id": "3468206643",
+			"name": "exactBoolean",
+			"conditions": ["and", ["or", ["or", {
+				"name": "should_do_it",
+				"type": "custom_attribute",
+				"match": "exact",
+				"value": true
+			}]]]
+		},
+		{
+			"id": "3468206648",
+			"name": "notExist",
+			"conditions": ["not", {
+				"name": "input_value",
+				"type": "custom_attribute",
+				"match": "exists"
+			}]
+		}
+	],
+	"groups": [],
+	"attributes": [{
+			"key": "house",
+			"id": "594015"
+		},
+		{
+			"key": "lasers",
+			"id": "594016"
+		},
+		{
+			"key": "should_do_it",
+			"id": "594017"
+		},
+		{
+			"key": "favorite_ice_cream",
+			"id": "594018"
+		}
+	],
+	"botFiltering": false,
+	"accountId": "4879520872",
+	"events": [{
+			"key": "item_bought",
+			"id": "594089",
+			"experimentIds": [
+				"11564051718",
+				"1323241597"
+			]
+		},
+		{
+			"key": "user_signed_up",
+			"id": "594090",
+			"experimentIds": [
+				"1323241598",
+				"1323241599"
+			]
+		}
+	],
+	"revision": "3",
+	"sdkKey": "typedAudienceDatafile",
+	"environmentKey": "Production"
+}

--- a/pkg/entities/audience.go
+++ b/pkg/entities/audience.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -22,6 +22,7 @@ type Audience struct {
 	ID            string
 	Name          string
 	ConditionTree *TreeNode
+	Conditions    interface{}
 }
 
 // Condition has condition info

--- a/pkg/entities/experiment.go
+++ b/pkg/entities/experiment.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -28,6 +28,7 @@ type Variation struct {
 // Experiment represents an experiment
 type Experiment struct {
 	AudienceIds           []string
+	AudienceConditions    interface{}
 	ID                    string
 	LayerID               string
 	Key                   string

--- a/pkg/entities/feature.go
+++ b/pkg/entities/feature.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -22,6 +22,7 @@ type Feature struct {
 	ID                 string
 	Key                string
 	FeatureExperiments []Experiment
+	ExperimentIDs      []string
 	Rollout            Rollout
 	VariableMap        map[string]Variable
 }


### PR DESCRIPTION
## Summary
The following new public properties are added to OptimizelyConfig:
- sdkKey
- environmentKey
- attributes
- audiences
- events
- experimentRules and deliveryRules to OptimizelyFeature
- audiences to OptimizelyExperiment

## Test plan
All FSC tests OPTIMIZELY_CONFIG_V2 tests should pass.
FSC OptimizelyConfig [link](https://app.travis-ci.com/github/optimizely/fullstack-sdk-compatibility-suite/builds/236568182) 

## Dependent PR
https://github.com/optimizely/go-testapp/pull/62