### PR TITLE
OASIS-8551 fix(attribute-validation): Adds validation on user attributes to only allow primitive types.

### DIFF
--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2020,2022 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/event/factory.go
+++ b/pkg/event/factory.go
@@ -243,7 +243,7 @@ func getEventAttributes(projectConfig config.ProjectConfig, attributes map[strin
 	var eventAttributes = []VisitorAttribute{}
 
 	for key, value := range attributes {
-		if value == nil {
+		if !isValidAttribute(value) {
 			continue
 		}
 		visitorAttribute := VisitorAttribute{}
@@ -290,4 +290,24 @@ func getTagValue(eventTags map[string]interface{}) (float64, error) {
 	}
 
 	return 0, errors.New("no event tag found for value")
+}
+
+// check if attribute value is valid
+func isValidAttribute(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+	if _, ok := value.(string); ok {
+		return true
+	}
+	if _, ok := value.(float64); ok {
+		return true
+	}
+	if _, ok := value.(int); ok {
+		return true
+	}
+	if _, ok := value.(bool); ok {
+		return true
+	}
+	return false
 }

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2022 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/event/factory_test.go
+++ b/pkg/event/factory_test.go
@@ -234,3 +234,15 @@ func TestCreateImpressionUserEvent(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidAttribute(t *testing.T) {
+	assert.False(t, isValidAttribute(nil))
+	assert.False(t, isValidAttribute(map[string]interface{}{}))
+	assert.False(t, isValidAttribute([]string{}))
+	assert.False(t, isValidAttribute([]interface{}{}))
+	assert.False(t, isValidAttribute(make(chan int)))
+	assert.True(t, isValidAttribute("123"))
+	assert.True(t, isValidAttribute(1.11))
+	assert.True(t, isValidAttribute(1))
+	assert.True(t, isValidAttribute(true))
+}


### PR DESCRIPTION
## Summary
- Adds validation on user attributes to only allow primitive types.
- Adds unit tests.

## Test plan
All tests should pass

# ISSUE
OASIS-8551