### PR TITLE
chore: update version and changelog for patch release

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [1.8.1] - August 29, 2022
+
+### Bug Fix
+* Add validation for user attribute types when building an event object. Only allow primitive types ([#339](https://github.com/optimizely/go-sdk/pull/339))
+
 ## [1.8.0] - January 12, 2022
 
 ### New Features

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-var Version = "1.8.0"
+var Version = "1.8.1"
 
 // ClientName is the name of the client
 var ClientName = "go-sdk"


### PR DESCRIPTION
Prepare for patch release 1.8.1.
- update golang version and changelog

PR with the patch: [PR 339 Adds validation on user attributes to only allow primitive types. ](https://github.com/optimizely/go-sdk/pull/339)

Jira ticket: [OASIS-8563 Release go-sdk (patch release)](https://optimizely.atlassian.net/browse/OASIS-8563)