### PR TITLE
chore: prepare for patch release 1.8.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [1.8.2] - September 1, 2022
+
+### Bug Fix
+* Add additional validation for numeric attribute types when building an event object. ([#341](https://github.com/optimizely/go-sdk/pull/341))
+
 ## [1.8.1] - August 29, 2022
 
 ### Bug Fix

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-var Version = "1.8.1"
+var Version = "1.8.2"
 
 // ClientName is the name of the client
 var ClientName = "go-sdk"


### PR DESCRIPTION
Prepare for patch release 1.8.2

- update golang version and changelog
- PR with the patch: https://github.com/optimizely/go-sdk/pull/341

Jira ticket: [OASIS-8593 Release go-sdk (patch release)](https://optimizely.atlassian.net/browse/OASIS-8593)