### PR TITLE
feat(custom-httpclient): Adds Client option to provide a custom http.Client.

### DIFF
--- a/pkg/utils/requester.go
+++ b/pkg/utils/requester.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2022 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -21,11 +21,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/optimizely/go-sdk/pkg/logging"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -50,10 +51,17 @@ type Header struct {
 	Name, Value string
 }
 
+// Client sets http client
+func Client(client http.Client) func(r *HTTPRequester) {
+	return func(r *HTTPRequester) {
+		r.client = client
+	}
+}
+
 // Timeout sets http client timeout
 func Timeout(timeout time.Duration) func(r *HTTPRequester) {
 	return func(r *HTTPRequester) {
-		r.client = http.Client{Timeout: timeout}
+		r.client.Timeout = timeout
 	}
 }
 

--- a/pkg/utils/requester_test.go
+++ b/pkg/utils/requester_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, 2021 Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2021-2022 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -19,7 +19,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/optimizely/go-sdk/pkg/logging"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -27,8 +26,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/optimizely/go-sdk/pkg/logging"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestClientFunction(t *testing.T) {
+	requester := &HTTPRequester{}
+	fn := Client(http.Client{Timeout: 125})
+	fn(requester)
+	assert.Equal(t, time.Duration(125), requester.client.Timeout)
+}
+
+func TestNewHTTPRequesterWithClient(t *testing.T) {
+	fn := Client(http.Client{Timeout: 125})
+	requester := NewHTTPRequester(logging.GetLogger("", ""), fn)
+	assert.Equal(t, time.Duration(125), requester.client.Timeout)
+}
+
+func TestNewHTTPRequesterWithoutClient(t *testing.T) {
+	requester := NewHTTPRequester(logging.GetLogger("", ""))
+	assert.Equal(t, defaultTTL, requester.client.Timeout)
+}
 
 func TestHeaders(t *testing.T) {
 	requester := &HTTPRequester{}


### PR DESCRIPTION
## Summary
- Adds Client option to provide a custom http.Client.

## Tests
- All unit and integration tests should pass.

## Issue
- https://github.com/optimizely/go-sdk/issues/193