### PR TITLE
chore: prepare for patch release 1.8.3

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
-## [1.8.3] - October 11, 2022
+## [1.8.3] - October 12, 2022
 
 ### New Features
 * Add option to set custom http.Client on HTTPRequester. ([#335](https://github.com/optimizely/go-sdk/pull/335))

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 Changes that have landed but are not yet released.
 
+## [1.8.3] - October 11, 2022
+
+### New Features
+* Add option to set custom http.Client on HTTPRequester. ([#335](https://github.com/optimizely/go-sdk/pull/335))
+
+### Bug Fix
+* Fixes issue with visitor where dispatch timestamp was used instead of userEvent creation timestamp. ([#345](https://github.com/optimizely/go-sdk/pull/345))
+
 ## [1.8.2] - September 1, 2022
 
 ### Bug Fix

--- a/pkg/event/version.go
+++ b/pkg/event/version.go
@@ -18,7 +18,7 @@
 package event
 
 // Version is the current version of the client
-var Version = "1.8.2"
+var Version = "1.8.3"
 
 // ClientName is the name of the client
 var ClientName = "go-sdk"


### PR DESCRIPTION
### Summary 
Prepare for patch release 1.8.3

- update golang version and changelog
- PR with the patch: https://github.com/optimizely/go-sdk/pull/345
- PR with the feature: https://github.com/optimizely/go-sdk/pull/335

Jira ticket: FSSDK-8560