### PR TITLE
chore: Updating minimum go-sdk version to 1.13

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.13.15'
     - run: make install lint
@@ -26,34 +26,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
-        check-latest: true
+        go-version: '>=1.19'
     - run: make cover
 
   unit_test_legacy:
     runs-on: ubuntu-latest
-    env: 
-      BUILD_DIR: ${{ github.workspace }}
-      GOPATH: ${{ github.workspace }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.10.8'
-    - run: |
-        mkdir -p $GOPATH/src/github.com && pushd $GOPATH/src/github.com && ln -s $GOPATH optimizely/go-sdk && popd
-        mkdir $GOPATH/src/github.com/twmb && cd $GOPATH/src/github.com/twmb && git clone https://github.com/twmb/murmur3.git && cd $BUILD_DIR
-        pushd $GOPATH/src/github.com/twmb/murmur3 && git checkout v1.0.0 && popd
-        mkdir $GOPATH/src/github.com/hashicorp && cd $GOPATH/src/github.com/hashicorp && git clone https://github.com/hashicorp/go-multierror.git && cd $BUILD_DIR
-        pushd $GOPATH/src/github.com/hashicorp/go-multierror && git checkout v1.0.0 && popd
-        mkdir $GOPATH/src/gopkg.in && cd $GOPATH/src/gopkg.in && git clone https://github.com/go-yaml/yaml.git && cd $BUILD_DIR
-        mv $GOPATH/src/gopkg.in/yaml $GOPATH/src/gopkg.in/yaml.v2 && pushd $GOPATH/src/gopkg.in/yaml.v2  && git checkout v2.2.2 && popd
-        go get -v -d ./...
-        go get -d -v github.com/stretchr/testify
-        pushd $GOPATH/src/github.com/stretchr/testify && git checkout v1.4.0 && popd
-        make test
+        go-version: '1.13'
+        check-latest: true
+    - run: make cover
           
   unit_test_coverage:
     runs-on: ubuntu-latest
@@ -61,9 +47,10 @@ jobs:
       COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.14.15'
+        go-version: '1.17'
+        check-latest: true
     - run: |
         make cover
         go get github.com/mattn/goveralls
@@ -73,10 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
-        check-latest: true
+        go-version: '>=1.19'
     - run: make benchmark
 
   integration_tests:

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ We practice trunk-based development, and as such our default branch, `master` mi
 ```
 module mymodule
 
-go 1.12
+go 1.13
 
 require (
-	github.com/optimizely/go-sdk v1.0.0-rc1
+	github.com/optimizely/go-sdk v1.8.3
 )
 ```
 
 If you are already using `go.mod` in your application you can run the following:
 
 ```
-go mod edit -require github.com/optimizely/go-sdk@v1.0.0-rc1
+go mod edit -require github.com/optimizely/go-sdk@v1.8.3
 ```
 
 NOTE:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/optimizely/go-sdk
 
-go 1.12
+go 1.13
 
 require (
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
## Summary
- Updating minimum go-sdk version to 1.13
- Updating go-sdk versions for workflows

## Tests
- All tests should pass