### PR TITLE
refact(odp): Removes support for odp batchSize and fixes ticker.

### DIFF
--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020,2022 Optimizely, Inc. and contributors               *
+ * Copyright 2019-2020,2022-2023 Optimizely, Inc. and contributors          *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/client/factory.go
+++ b/pkg/client/factory.go
@@ -331,10 +331,8 @@ func (f *OptimizelyFactory) startOdpManager(eg *utils.ExecGroup, appClient *Opti
 	}
 
 	// Start odp ticker
-	apiKey := odpManager.OdpConfig.GetAPIKey()
-	apiHost := odpManager.OdpConfig.GetAPIHost()
 	eg.Go(func(ctx context.Context) {
-		odpManager.EventManager.Start(ctx, apiKey, apiHost)
+		odpManager.EventManager.Start(ctx, odpManager.OdpConfig)
 	})
 
 	// Only check for changes if ConfigManager is non static
@@ -351,7 +349,7 @@ func (f *OptimizelyFactory) startOdpManager(eg *utils.ExecGroup, appClient *Opti
 			segmentList := conf.GetSegmentList()
 			eg.Go(func(ctx context.Context) {
 				odpManager.Update(apiKey, apiHost, segmentList)
-				odpManager.EventManager.Start(ctx, apiKey, apiHost)
+				odpManager.EventManager.Start(ctx, odpManager.OdpConfig)
 			})
 		}
 	}

--- a/pkg/client/optimizely_user_context_odp_test.go
+++ b/pkg/client/optimizely_user_context_odp_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -211,7 +211,7 @@ func (o *OptimizelyUserContextODPTestSuite) TestFetchQualifiedSegmentsParameters
 
 func (o *OptimizelyUserContextODPTestSuite) TestOdpEventsEarlyEventsDispatched() {
 	eventAPIManager := &MockEventAPIManager{}
-	eventManager := event.NewBatchEventManager(event.WithAPIManager(eventAPIManager), event.WithBatchSize(1))
+	eventManager := event.NewBatchEventManager(event.WithAPIManager(eventAPIManager), event.WithFlushInterval(0))
 	odpManager := odp.NewOdpManager("", false, odp.WithEventManager(eventManager))
 	factory := OptimizelyFactory{Datafile: o.datafile, odpManager: odpManager}
 	optimizelyClient, _ := factory.Client()
@@ -239,9 +239,9 @@ func (o *OptimizelyUserContextODPTestSuite) TestOdpEventsEarlyEventsDispatched()
 // 	userContext := optimizelyClient.CreateUserContext(o.userID, nil)
 // 	var wg sync.WaitGroup
 // 	wg.Add(1)
-// 	userContext.FetchQualifiedSegments(nil, func(segments []string, err error) {
-// 		o.NoError(err)
-// 		o.Equal([]string{}, segments)
+// 	userContext.FetchQualifiedSegmentsAsync(nil, func(success bool) {
+// 		o.True(success)
+// 		o.Equal([]string{}, userContext.GetQualifiedSegments())
 // 		wg.Done()
 // 	})
 // 	wg.Wait()

--- a/pkg/odp/event/event_manager.go
+++ b/pkg/odp/event/event_manager.go
@@ -40,6 +40,7 @@ const maxRetries = 3
 
 // Manager represents the event manager.
 type Manager interface {
+	// odpConfig is required here since it can be updated anytime and ticker needs to be aware of latest changes
 	Start(ctx context.Context, odpConfig config.Config)
 	IdentifyUser(apiKey, apiHost, userID string)
 	ProcessEvent(apiKey, apiHost string, odpEvent Event) bool
@@ -142,6 +143,7 @@ func NewBatchEventManager(options ...EMOptionFunc) *BatchEventManager {
 }
 
 // Start does not do any initialization, just starts the ticker
+// odpConfig is required here since it can be updated anytime and ticker needs to be aware of latest changes
 func (bm *BatchEventManager) Start(ctx context.Context, odpConfig config.Config) {
 	if !bm.IsOdpServiceIntegrated(odpConfig.GetAPIKey(), odpConfig.GetAPIHost()) {
 		return

--- a/pkg/odp/event/event_manager_test.go
+++ b/pkg/odp/event/event_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -40,19 +40,18 @@ type EventManagerTestSuite struct {
 
 func (e *EventManagerTestSuite) SetupTest() {
 	e.eventAPIManager = &MockEventAPIManager{}
-	e.eventManager = NewBatchEventManager(WithAPIManager(e.eventAPIManager), WithBatchSize(2))
+	e.eventManager = NewBatchEventManager(WithAPIManager(e.eventAPIManager))
 }
 
 func (e *EventManagerTestSuite) TestEventManagerWithOptions() {
-	batchSize := 1
-	queueSize := 2
+	queueSize := 50
 	flushInterval := 3 * time.Second
 	sdkKey := "abc"
 	eventAPIManager := NewEventAPIManager(sdkKey, nil)
 	eventQueue := event.NewInMemoryQueue(queueSize)
-	em := NewBatchEventManager(WithBatchSize(batchSize), WithQueueSize(queueSize), WithFlushInterval(flushInterval), WithSDKKey(sdkKey),
+	em := NewBatchEventManager(WithQueueSize(queueSize), WithFlushInterval(flushInterval), WithSDKKey(sdkKey),
 		WithAPIManager(eventAPIManager), WithQueue(eventQueue))
-	e.Equal(batchSize, em.batchSize)
+	e.Equal(event.DefaultBatchSize, em.batchSize)
 	e.Equal(queueSize, em.maxQueueSize)
 	e.Equal(flushInterval, em.flushInterval)
 	e.Equal(sdkKey, em.sdkKey)
@@ -61,13 +60,21 @@ func (e *EventManagerTestSuite) TestEventManagerWithOptions() {
 }
 
 func (e *EventManagerTestSuite) TestEventManagerWithInvalidOptions() {
-	batchSize := -1
 	queueSize := -1
 	flushInterval := -1 * time.Second
-	em := NewBatchEventManager(WithBatchSize(batchSize), WithQueueSize(queueSize), WithFlushInterval(flushInterval))
+	em := NewBatchEventManager(WithQueueSize(queueSize), WithFlushInterval(flushInterval))
 	e.Equal(utils.DefaultBatchSize, em.batchSize)
 	e.Equal(utils.DefaultEventQueueSize, em.maxQueueSize)
 	e.Equal(utils.DefaultEventFlushInterval, em.flushInterval)
+}
+
+func (e *EventManagerTestSuite) TestEventManagerWithZeroFlushInterval() {
+	queueSize := 0
+	flushInterval := 0 * time.Second
+	em := NewBatchEventManager(WithQueueSize(queueSize), WithFlushInterval(flushInterval))
+	e.Equal(1, em.batchSize)
+	e.Equal(utils.DefaultEventQueueSize, em.maxQueueSize)
+	e.Equal(flushInterval, em.flushInterval)
 }
 
 func (e *EventManagerTestSuite) TestEventManagerWithoutOptions() {
@@ -167,7 +174,7 @@ func (e *EventManagerTestSuite) TestIdentifyUserWhenODPIntegrated() {
 }
 
 func (e *EventManagerTestSuite) TestProcessEventWithInvalidODPConfig() {
-	em := NewBatchEventManager(WithAPIManager(&MockEventAPIManager{}), WithBatchSize(2))
+	em := NewBatchEventManager(WithAPIManager(&MockEventAPIManager{}))
 	e.False(em.ProcessEvent("", "", Event{}))
 	e.Equal(0, em.eventQueue.Size())
 }
@@ -212,133 +219,140 @@ func (e *EventManagerTestSuite) TestProcessEventDiscardsEventExceedingMaxQueueSi
 }
 
 func (e *EventManagerTestSuite) TestProcessEventWithBatchSizeNotReached() {
-	em := NewBatchEventManager(WithAPIManager(&MockEventAPIManager{}), WithBatchSize(2))
+	em := NewBatchEventManager(WithAPIManager(&MockEventAPIManager{}))
 	e.True(em.ProcessEvent("a", "b", Event{}))
 	e.Equal(1, em.eventQueue.Size())
 	e.Equal(0, e.eventAPIManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventWithBatchSizeReached() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(1, e.eventManager.eventQueue.Size())
-	e.eventAPIManager.wg.Add(1)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	e.Equal(0, em.eventQueue.Size())
+	apiManager.wg.Add(1)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for event fire through go routine
-	e.eventAPIManager.wg.Wait()
-	e.Equal(0, e.eventManager.eventQueue.Size())
-	e.Equal(1, e.eventAPIManager.timesSendEventsCalled)
+	apiManager.wg.Wait()
+	e.Equal(0, em.eventQueue.Size())
+	e.Equal(1, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventsExceedingBatchSize() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(2, e.eventManager.eventQueue.Size())
-	// Two batch events should be fired
-	e.eventAPIManager.wg.Add(2)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	em.eventQueue.Add(Event{})
+	em.eventQueue.Add(Event{})
+	e.Equal(2, em.eventQueue.Size())
+	// Three batch events should be fired
+	apiManager.wg.Add(3)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for event fire through go routine
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Since all events fired successfully, queue should be empty
-	e.Equal(0, e.eventManager.eventQueue.Size())
-	e.Equal(2, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(0, em.eventQueue.Size())
+	e.Equal(3, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventFirstEventFailsWithRetries() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(2, e.eventManager.eventQueue.Size())
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	em.eventQueue.Add(Event{})
+	e.Equal(1, em.eventQueue.Size())
 	// Return true for retry for all calls
-	e.eventAPIManager.retryResponses = []bool{true, true, true}
+	apiManager.retryResponses = []bool{true, true, true}
 	tmpError := errors.New("")
-	// Return nil error for for all calls
-	e.eventAPIManager.errResponses = []error{tmpError, tmpError, tmpError}
-	// Total 3 events in queue which make 2 batches
+	// Return nil error for all calls
+	apiManager.errResponses = []error{tmpError, tmpError, tmpError}
+	// Total 2 events in queue which make 2 batches
 	// first batch will be retried thrice, second one wont be fired since first failed thrice
-	e.eventAPIManager.wg.Add(maxRetries)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager.wg.Add(maxRetries)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for three retries
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Since all events failed, queue should contain all events
-	e.Equal(3, e.eventManager.eventQueue.Size())
-	e.Equal(3, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(2, em.eventQueue.Size())
+	e.Equal(3, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventFirstEventFailsWithRetryNotAllowed() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(2, e.eventManager.eventQueue.Size())
-	e.eventAPIManager.retryResponses = []bool{false}
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	em.eventQueue.Add(Event{})
+	e.Equal(1, em.eventQueue.Size())
+	apiManager.retryResponses = []bool{false}
 	tmpError := errors.New("")
-	e.eventAPIManager.errResponses = []error{tmpError}
-	// Total 3 events in queue which make 2 batches
+	apiManager.errResponses = []error{tmpError}
 	// first batch will not be retried, second one wont be fired since first failed
-	e.eventAPIManager.wg.Add(1)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager.wg.Add(1)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for three retries
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Since first batch of 2 events failed with no retry allowed, queue should only contain 1 event
-	e.Equal(1, e.eventManager.eventQueue.Size())
-	e.Equal(1, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(1, em.eventQueue.Size())
+	e.Equal(1, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventSecondEventFailsWithRetriesLaterPasses() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(2, e.eventManager.eventQueue.Size())
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	em.eventQueue.Add(Event{})
+	e.Equal(1, em.eventQueue.Size())
 	// Return true for retry for all second batch calls
-	e.eventAPIManager.retryResponses = []bool{false, true, true, true, false}
+	apiManager.retryResponses = []bool{false, true, true, true, false, false}
 	tmpError := errors.New("")
 	// Return error for all second batch calls
-	e.eventAPIManager.errResponses = []error{nil, tmpError, tmpError, tmpError, nil}
-	// Total 3 events in queue which make 2 batches
+	apiManager.errResponses = []error{nil, tmpError, tmpError, tmpError, nil, nil}
+	// Total 2 events in queue which make 2 batches
 	// first batch will be successfully dispatched, second will be retried thrice
-	e.eventAPIManager.wg.Add(4)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager.wg.Add(4)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for events to fire
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Since second batch of 1 event failed, queue should be contain 1 event
-	e.Equal(1, e.eventManager.eventQueue.Size())
+	e.Equal(1, em.eventQueue.Size())
 	// SendOdpEvents should be called 4 times with 1 success and 3 failures
-	e.Equal(4, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(4, apiManager.timesSendEventsCalled)
 
 	// Wait for lock to be released
 	time.Sleep(200 * time.Millisecond)
 
-	e.eventAPIManager.wg.Add(1)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager.wg.Add(2)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for events to fire
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Queue should be empty since remaining event was sent now
-	e.Equal(0, e.eventManager.eventQueue.Size())
-	// SendOdpEvents should be called 5 times with 2 success and 3 failures
-	e.Equal(5, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(0, em.eventQueue.Size())
+	// SendOdpEvents should be called 6 times with 3 success and 3 failures
+	e.Equal(6, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestProcessEventFirstEventPassesWithRetries() {
-	e.eventManager.eventQueue.Add(Event{})
-	e.eventManager.eventQueue.Add(Event{})
-	e.Equal(2, e.eventManager.eventQueue.Size())
+	apiManager := &MockEventAPIManager{}
+	em := NewBatchEventManager(WithAPIManager(apiManager), WithFlushInterval(0))
+	em.eventQueue.Add(Event{})
+	e.Equal(1, em.eventQueue.Size())
 	// Return true for first batch call only
-	e.eventAPIManager.retryResponses = []bool{true, false, false}
+	apiManager.retryResponses = []bool{true, false, false}
 	tmpError := errors.New("")
 	// Return error first time only
-	e.eventAPIManager.errResponses = []error{tmpError, nil, nil}
-	// Total 3 events in queue which make 2 batches
+	apiManager.errResponses = []error{tmpError, nil, nil}
+	// Total 2 events in queue which make 2 batches
 	// first batch will be retried once, second will be successful immediately
-	e.eventAPIManager.wg.Add(3)
-	e.True(e.eventManager.ProcessEvent("a", "b", Event{}))
+	apiManager.wg.Add(3)
+	e.True(em.ProcessEvent("a", "b", Event{}))
 	// Wait for events to fire
-	e.eventAPIManager.wg.Wait()
+	apiManager.wg.Wait()
 	// Since all events were successful, queue should be empty
-	e.Equal(0, e.eventManager.eventQueue.Size())
-	e.Equal(3, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(0, em.eventQueue.Size())
+	e.Equal(3, apiManager.timesSendEventsCalled)
 }
 
 func (e *EventManagerTestSuite) TestEventManagerAsyncBehaviour() {
 	eventAPIManager := &MockEventAPIManager{}
-	eventManager := NewBatchEventManager(WithAPIManager(eventAPIManager), WithBatchSize(2))
+	eventManager := NewBatchEventManager(WithAPIManager(eventAPIManager))
 
 	iterations := 100
+	eventsSentPerIteration := 2
 	eventAPIManager.shouldNotInformWaitgroup = true
 	eg := newExecutionContext()
 	callAllMethods := func(id string) {
@@ -356,19 +370,19 @@ func (e *EventManagerTestSuite) TestEventManagerAsyncBehaviour() {
 	eg.TerminateAndWait()
 
 	// Total expected events sent should be equal to event in queue and events sent
-	e.Equal(iterations*2, eventManager.eventQueue.Size()+len(eventAPIManager.eventsSent))
+	e.Equal(iterations*eventsSentPerIteration, eventManager.eventQueue.Size()+len(eventAPIManager.eventsSent))
 	// It is possible that during concurrent dispatching, timesSendEventsCalled can exceed our expected value
 	// This is because there might be odd number of events in queue when flush is called in which case
 	// Flush will send the last incomplete batch too
-	e.True(eventAPIManager.timesSendEventsCalled >= iterations)
+	totalCompleteBatches := (iterations * eventsSentPerIteration / eventManager.batchSize)
+	e.True(eventAPIManager.timesSendEventsCalled >= totalCompleteBatches)
 }
 
 func (e *EventManagerTestSuite) TestFlushEventsAsyncBehaviour() {
 	eventAPIManager := &MockEventAPIManager{}
-	batchSize := 2
-	eventManager := NewBatchEventManager(WithAPIManager(eventAPIManager), WithBatchSize(batchSize))
+	eventManager := NewBatchEventManager(WithAPIManager(eventAPIManager))
 	iterations := 100
-	eventAPIManager.wg.Add(50)
+	eventAPIManager.wg.Add(10)
 	// Add 100 events to queue
 	for i := 0; i < iterations; i++ {
 		eventManager.eventQueue.Add(Event{Type: fmt.Sprintf("%d", i)})
@@ -382,7 +396,7 @@ func (e *EventManagerTestSuite) TestFlushEventsAsyncBehaviour() {
 	eventAPIManager.wg.Wait()
 
 	e.Equal(0, eventManager.eventQueue.Size())
-	e.Equal(iterations/batchSize, eventAPIManager.timesSendEventsCalled)
+	e.Equal(iterations/event.DefaultBatchSize, eventAPIManager.timesSendEventsCalled)
 	e.Equal(iterations, len(eventAPIManager.eventsSent))
 }
 

--- a/pkg/odp/odp_manager_test.go
+++ b/pkg/odp/odp_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/odp/odp_manager_test.go
+++ b/pkg/odp/odp_manager_test.go
@@ -37,8 +37,8 @@ type MockEventManager struct {
 	event.Manager
 }
 
-func (m *MockEventManager) Start(ctx context.Context, apiKey, apiHost string) {
-	m.Called(ctx, apiKey, apiHost)
+func (m *MockEventManager) Start(ctx context.Context, odpConfig config.Config) {
+	m.Called(ctx, odpConfig)
 }
 
 func (m *MockEventManager) IdentifyUser(apiKey, apiHost, userID string) {


### PR DESCRIPTION
## Summary
- Removes support for changing odp batchSize. 
- If flush interval is set to 0, flushEvent timer is not started and batchSize is set to 1 to dispatch events immediately .
- Fixes a bug which restricted flushEvent timer to only send events using the odpConfiguration it was initialized with, whereas it should send events using the latest odp configuration.

## Tests
- Added new unit tests.
- All previous tests should pass.