### PR TITLE
WIP: Update segment options to strings

### DIFF
--- a/pkg/odp/segment/segment_option.go
+++ b/pkg/odp/segment/segment_option.go
@@ -17,12 +17,36 @@
 // Package segment //
 package segment
 
+import "errors"
+
 // OptimizelySegmentOption represents options controlling audience segments.
-type OptimizelySegmentOption int
+type OptimizelySegmentOption string
 
 const (
 	// IgnoreCache ignores cache (save/lookup)
-	IgnoreCache OptimizelySegmentOption = iota
+	IgnoreCache OptimizelySegmentOption = "IGNORE_CACHE"
 	// ResetCache resets cache
-	ResetCache
+	ResetCache OptimizelySegmentOption = "RESET_CACHE"
 )
+
+// Options defines options for controlling audience segments.
+type Options struct {
+	IgnoreCache bool
+	ResetCache  bool
+}
+
+// TranslateOptions converts string options array to array of OptimizelySegmentOptions
+func TranslateOptions(options []string) ([]OptimizelySegmentOption, error) {
+	segmentOptions := []OptimizelySegmentOption{}
+	for _, val := range options {
+		switch OptimizelySegmentOption(val) {
+		case IgnoreCache:
+			segmentOptions = append(segmentOptions, IgnoreCache)
+		case ResetCache:
+			segmentOptions = append(segmentOptions, ResetCache)
+		default:
+			return []OptimizelySegmentOption{}, errors.New("invalid option: " + val)
+		}
+	}
+	return segmentOptions, nil
+}


### PR DESCRIPTION
segment_option.go has enumerated constants assigning integers to ResetCache and IgnoreCache.
However decide_options.go uses strings.

Changing segments options to also use strings.
