### PR TITLE
Update segments options with strings

### DIFF
--- a/pkg/odp/segment/segment_option.go
+++ b/pkg/odp/segment/segment_option.go
@@ -29,12 +29,6 @@ const (
 	ResetCache OptimizelySegmentOption = "RESET_CACHE"
 )
 
-// Options defines options for controlling audience segments.
-type Options struct {
-	IgnoreCache bool
-	ResetCache  bool
-}
-
 // TranslateOptions converts string options array to array of OptimizelySegmentOptions
 func TranslateOptions(options []string) ([]OptimizelySegmentOption, error) {
 	segmentOptions := []OptimizelySegmentOption{}

--- a/pkg/odp/segment/segment_option.go
+++ b/pkg/odp/segment/segment_option.go
@@ -17,12 +17,36 @@
 // Package segment //
 package segment
 
+import "errors"
+
 // OptimizelySegmentOption represents options controlling audience segments.
-type OptimizelySegmentOption int
+type OptimizelySegmentOption string
 
 const (
 	// IgnoreCache ignores cache (save/lookup)
-	IgnoreCache OptimizelySegmentOption = iota
+	IgnoreCache OptimizelySegmentOption = "IGNORE_CACHE"
 	// ResetCache resets cache
-	ResetCache
+	ResetCache OptimizelySegmentOption = "RESET_CACHE"
 )
+
+// Options defines options for controlling audience segments.
+type Options struct {
+	IgnoreCache bool
+	ResetCache  bool
+}
+
+// TranslateOptions converts string options array to array of OptimizelySegmentOptions
+func TranslateOptions(options []string) ([]OptimizelySegmentOption, error) {
+	segmentOptions := []OptimizelySegmentOption{}
+	for _, val := range options {
+		switch OptimizelySegmentOption(val) {
+		case IgnoreCache:
+			segmentOptions = append(segmentOptions, IgnoreCache)
+		case ResetCache:
+			segmentOptions = append(segmentOptions, ResetCache)
+		default:
+			return []OptimizelySegmentOption{}, errors.New("invalid option: " + val)
+		}
+	}
+	return segmentOptions, nil
+}

--- a/pkg/odp/segment/segment_option_test.go
+++ b/pkg/odp/segment/segment_option_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2021, Optimizely, Inc. and contributors                        *
+ * Copyright 2023, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/odp/segment/segment_option_test.go
+++ b/pkg/odp/segment/segment_option_test.go
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright 2021, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+package segment
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateOptionsValidCases(t *testing.T) {
+	// Checking nil options
+	translatedOptions, err := TranslateOptions(nil)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 0)
+
+	// Checking empty options
+	options := []string{}
+	translatedOptions, err = TranslateOptions(options)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 0)
+
+	// Checking correct options
+	options = []string{"IGNORE_CACHE"}
+	translatedOptions, err = TranslateOptions(options)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 1)
+	assert.Equal(t, IgnoreCache, translatedOptions[0])
+
+	// Checking after appending further options
+	options = append(options, "RESET_CACHE")
+	translatedOptions, err = TranslateOptions(options)
+	assert.NoError(t, err)
+	assert.Len(t, translatedOptions, 2)
+	assert.Equal(t, ResetCache, translatedOptions[1])
+}
+
+func TestTranslateOptionsInvalidCases(t *testing.T) {
+	// Checking empty value as option
+	options := []string{""}
+	translatedOptions, err := TranslateOptions(options)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Errorf("invalid option: %v", options[0]), err)
+	assert.Len(t, translatedOptions, 0)
+
+	// Checking invalid value as option
+	options[0] = "INVALID"
+	translatedOptions, err = TranslateOptions(options)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Errorf("invalid option: %v", options[0]), err)
+	assert.Len(t, translatedOptions, 0)
+}


### PR DESCRIPTION
segment_option.go has enumerated constants assigning integers to ResetCache and IgnoreCache.
However decide_options.go uses strings.

Changing segments options to also use strings.

This will enable to make work fetch qualified segments in ODP for Agent.

https://jira.sso.episerver.net/browse/FSSDK-8933