### PR TITLE
[FSSDK-8943] fix: make odp event identifiers required

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -310,6 +310,12 @@ func (o *OptimizelyClient) SendOdpEvent(eventType, action string, identifiers ma
 	if eventType == "" {
 		eventType = pkgOdpUtils.OdpEventType
 	}
+
+	if len(identifiers) == 0 {
+		o.logger.Error("ODP events must have at least one key-value pair in identifiers", err)
+		return false
+	}
+
 	return o.OdpManager.SendOdpEvent(eventType, action, identifiers, data)
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -256,8 +256,8 @@ func TestSendODPEventEmptyIdentifiers(t *testing.T) {
 	optimizelyClient := OptimizelyClient{
 		logger: logging.GetLogger("", ""),
 	}
-	sendErr := optimizelyClient.SendOdpEvent("", action, identifiers, data)
-	assert.Equal(t, sendErr, errors.New("ODP events must have at least one key-value pair in identifiers"))
+	success := optimizelyClient.SendOdpEvent("", action, identifiers, data)
+	assert.False(t, success)
 }
 
 func TestSendODPEventNilIdentifiers(t *testing.T) {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -243,13 +243,46 @@ func TestSendODPEventEmptyType(t *testing.T) {
 	mockOdpManager.AssertExpectations(t)
 }
 
+func TestSendODPEventEmptyIdentifiers(t *testing.T) {
+	action := "456"
+	identifiers := map[string]string{}
+	data := map[string]interface{}{
+		"abc":                 nil,
+		"idempotence_id":      234,
+		"data_source_type":    "456",
+		"data_source":         true,
+		"data_source_version": 6.78,
+	}
+	optimizelyClient := OptimizelyClient{
+		logger: logging.GetLogger("", ""),
+	}
+	sendErr := optimizelyClient.SendOdpEvent("", action, identifiers, data)
+	assert.Equal(t, sendErr, errors.New("ODP events must have at least one key-value pair in identifiers"))
+}
+
+func TestSendODPEventNilIdentifiers(t *testing.T) {
+	action := "456"
+	data := map[string]interface{}{
+		"abc":                 nil,
+		"idempotence_id":      234,
+		"data_source_type":    "456",
+		"data_source":         true,
+		"data_source_version": 6.78,
+	}
+	optimizelyClient := OptimizelyClient{
+		logger: logging.GetLogger("", ""),
+	}
+	success := optimizelyClient.SendOdpEvent("", action, nil, data)
+	assert.False(t, success)
+}
+
 func TestSendODPEvent(t *testing.T) {
 	mockOdpManager := &MockODPManager{}
-	mockOdpManager.On("SendOdpEvent", "123", "", mock.Anything, mock.Anything).Return(true)
+	mockOdpManager.On("SendOdpEvent", "123", "", map[string]string{"identifier": "123"}, mock.Anything).Return(true)
 	optimizelyClient := OptimizelyClient{
 		OdpManager: mockOdpManager,
 	}
-	success := optimizelyClient.SendOdpEvent("123", "", nil, nil)
+	success := optimizelyClient.SendOdpEvent("123", "", map[string]string{"identifier": "123"}, nil)
 	assert.True(t, success)
 	mockOdpManager.AssertExpectations(t)
 }


### PR DESCRIPTION
Summary
-------
-  Updated SendOdpEvent to require identifiers and contain at least one key


Test plan
---------
- updated client_test.go

Ticket
------

-  [FSSDK-8943](https://jira.sso.episerver.net/browse/FSSDK-8943)
