### PR TITLE
[FSSDK-8984] fix: Updates SendOdpEvent to return error instead of bool.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -287,9 +287,8 @@ func (o *OptimizelyClient) fetchQualifiedSegments(userContext *OptimizelyUserCon
 }
 
 // SendOdpEvent sends an event to the ODP server.
-func (o *OptimizelyClient) SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) bool {
+func (o *OptimizelyClient) SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) (err error) {
 
-	var err error
 	defer func() {
 		if r := recover(); r != nil {
 			switch t := r.(type) {
@@ -312,8 +311,9 @@ func (o *OptimizelyClient) SendOdpEvent(eventType, action string, identifiers ma
 	}
 
 	if len(identifiers) == 0 {
-		o.logger.Error("ODP events must have at least one key-value pair in identifiers", err)
-		return false
+		err = errors.New("ODP events must have at least one key-value pair in identifiers")
+		o.logger.Error("received an error while sending ODP event", err)
+		return err
 	}
 
 	return o.OdpManager.SendOdpEvent(eventType, action, identifiers, data)

--- a/pkg/odp/odp_manager.go
+++ b/pkg/odp/odp_manager.go
@@ -36,7 +36,7 @@ type OMOptionFunc func(em *DefaultOdpManager)
 type Manager interface {
 	FetchQualifiedSegments(userID string, options []segment.OptimizelySegmentOption) (segments []string, err error)
 	IdentifyUser(userID string)
-	SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) bool
+	SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) (err error)
 	Update(apiKey, apiHost string, segmentsToCheck []string)
 }
 
@@ -145,10 +145,10 @@ func (om *DefaultOdpManager) IdentifyUser(userID string) {
 }
 
 // SendOdpEvent sends an event to the ODP server.
-func (om *DefaultOdpManager) SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) bool {
+func (om *DefaultOdpManager) SendOdpEvent(eventType, action string, identifiers map[string]string, data map[string]interface{}) (err error) {
 	if !om.enabled {
 		om.logger.Debug(utils.OdpNotEnabled)
-		return false
+		return errors.New(utils.OdpNotEnabled)
 	}
 	if identifiers == nil {
 		identifiers = map[string]string{}

--- a/pkg/odp/odp_manager_test.go
+++ b/pkg/odp/odp_manager_test.go
@@ -45,8 +45,12 @@ func (m *MockEventManager) IdentifyUser(apiKey, apiHost, userID string) {
 	m.Called(apiKey, apiHost, userID)
 }
 
-func (m *MockEventManager) ProcessEvent(apiKey, apiHost string, odpEvent event.Event) bool {
-	return m.Called(apiKey, apiHost, odpEvent).Get(0).(bool)
+func (m *MockEventManager) ProcessEvent(apiKey, apiHost string, odpEvent event.Event) error {
+	err := m.Called(apiKey, apiHost, odpEvent).Get(0)
+	if err == nil {
+		return nil
+	}
+	return err.(error)
 }
 
 func (m *MockEventManager) FlushEvents(apiKey, apiHost string) {
@@ -209,8 +213,8 @@ func (o *ODPManagerTestSuite) TestSendOdpEvent() {
 		}}
 	o.config.On("GetAPIKey").Return("")
 	o.config.On("GetAPIHost").Return("")
-	o.eventManager.On("ProcessEvent", "", "", userEvent).Return(true)
-	o.True(o.odpManager.SendOdpEvent(userEvent.Type, userEvent.Action, userEvent.Identifiers, userEvent.Data))
+	o.eventManager.On("ProcessEvent", "", "", userEvent).Return(nil)
+	o.NoError(o.odpManager.SendOdpEvent(userEvent.Type, userEvent.Action, userEvent.Identifiers, userEvent.Data))
 	o.segmentManager.AssertExpectations(o.T())
 }
 

--- a/pkg/odp/utils/errors.go
+++ b/pkg/odp/utils/errors.go
@@ -33,7 +33,7 @@ const IdentityOdpDisabled = "ODP identify event is not dispatched (ODP disabled)
 const IdentityOdpNotIntegrated = "ODP identify event is not dispatched (ODP not integrated)"
 
 // OdpNotIntegrated error string when odp is not integrated
-const OdpNotIntegrated = "ODP not integrated"
+const OdpNotIntegrated = "ODP is not integrated"
 
 // OdpEventFailed error string when odp event failed with provided reason
 const OdpEventFailed = "ODP event send failed (%s)"


### PR DESCRIPTION
Summary
-------
-  Updates SendOdpEvent to return error as response instead of boolean value.


Test plan
---------
- Added new unit tests.

Ticket
------

-  [FSSDK-8984](https://jira.sso.episerver.net/browse/FSSDK-8984)
