### PR TITLE
[FSSDK-9078] fix: odp event validation

### DIFF
--- a/pkg/odp/utils/errors.go
+++ b/pkg/odp/utils/errors.go
@@ -40,3 +40,6 @@ const OdpEventFailed = "ODP event send failed (%s)"
 
 // OdpInvalidData error string when odp event data is invalid
 const OdpInvalidData = "ODP data is not valid"
+
+// OdpInvalidAction error string when odp event action is invalid
+const OdpInvalidAction = "ODP action is not valid (cannot be empty)"


### PR DESCRIPTION
Summary
-------
Add validation to SendOdpEvent:

- log error when action == ""
- fix case and/or "-" for `fs_user_id` identifier key

Test plan
---------
- Unit tests added
- All previous tests should pass

Ticket
------
[FSSDK-9078](https://jira.sso.episerver.net/browse/FSSDK-9078)
