### PR TITLE
[FSSDK-9131] fix for ODP INVALID_IDENTIFIER_EXCEPTION code

### DIFF
--- a/pkg/odp/segment/segment_api_manager.go
+++ b/pkg/odp/segment/segment_api_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/odp/segment/segment_api_manager.go
+++ b/pkg/odp/segment/segment_api_manager.go
@@ -108,7 +108,8 @@ type APIManager interface {
          "customer"
        ],
        "extensions": {
-         "classification": "InvalidIdentifierException"
+         "code": "INVALID_IDENTIFIER_EXCEPTION",
+         "classification": "DataFetchingException"
        }
      }
    ],
@@ -160,7 +161,7 @@ func (sm *DefaultSegmentAPIManager) FetchQualifiedSegments(apiKey, apiHost, user
 	if odpErrors, ok := sm.extractComponent("errors", responseMap).([]interface{}); ok {
 		if odpError, ok := odpErrors[0].(map[string]interface{}); ok {
 			if errorClass, ok := sm.extractComponent("extensions.classification", odpError).(string); ok {
-				if errorClass == "InvalidIdentifierException" {
+				if errorCode, ok := sm.extractComponent("extensions.code", odpError).(string); ok && errorCode == "INVALID_IDENTIFIER_EXCEPTION" {
 					return nil, errors.New(utils.InvalidSegmentIdentifier)
 				}
 				return nil, fmt.Errorf(utils.FetchSegmentsFailedError, errorClass)

--- a/pkg/odp/segment/segment_api_manager_test.go
+++ b/pkg/odp/segment/segment_api_manager_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2022, Optimizely, Inc. and contributors                        *
+ * Copyright 2022-2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/odp/segment/segment_api_manager_test.go
+++ b/pkg/odp/segment/segment_api_manager_test.go
@@ -98,7 +98,8 @@ func (s *SegmentAPIManagerTestSuite) SetupTest() {
 			  "customer"
 			],
 			"extensions": {
-			  "classification": "InvalidIdentifierException"
+				"code": "INVALID_IDENTIFIER_EXCEPTION",
+				"classification": "DataFetchingException"
 			}
 		  }
 		],


### PR DESCRIPTION
## Summary

Support a new format for ODP `InvalidIdentifierException` (when SDK fetches segments with a non-registered userId).

```
       "extensions": {
            "code": "INVALID_IDENTIFIER_EXCEPTION",
            "classification": "DataFetchingException"
       }
```

## Test plan
Add unit tests to cover the new response format.

## Issues
- [FSSDK-9131](https://jira.sso.episerver.net/browse/FSSDK-9131)
