### PR TITLE
[FSSDK-9155] fix(ticker): stop all tickers to prevent goroutine leak

### DIFF
--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -191,6 +191,7 @@ func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
 		case <-t.C:
 			cm.SyncConfig()
 		case <-ctx.Done():
+			t.Stop()
 			cm.logger.Debug("Polling Config Manager Stopped")
 			return
 		}

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020,2022 Optimizely, Inc. and contributors               *
+ * Copyright 2019-2020,2022-2023 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020,2022-2023 Optimizely, Inc. and contributors               *
+ * Copyright 2019-2020,2022-2023 Optimizely, Inc. and contributors          *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2020,2023 Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020,2023 Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2020,2023 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/pkg/event/processor.go
+++ b/pkg/event/processor.go
@@ -246,6 +246,7 @@ func (p *BatchEventProcessor) startTicker(ctx context.Context) {
 			if ok {
 				d.flushEvents()
 			}
+			p.Ticker.Stop()
 			return
 		}
 	}

--- a/pkg/odp/event/event_manager.go
+++ b/pkg/odp/event/event_manager.go
@@ -237,6 +237,9 @@ func (bm *BatchEventManager) startTicker(ctx context.Context, odpConfig config.C
 		case <-ctx.Done():
 			bm.logger.Debug("BatchEventManager stopped, flushing events.")
 			bm.FlushEvents(odpConfig.GetAPIKey(), odpConfig.GetAPIHost())
+			bm.flushLock.Lock()
+			bm.ticker.Stop()
+			bm.flushLock.Unlock()
 			return
 		}
 	}


### PR DESCRIPTION
### Summary
- Fix goroutine leak for ticker

## Issues
- [FSSDK-9155](https://jira.sso.episerver.net/browse/FSSDK-9155)