### PR TITLE
 [FSSDK-9511] refact: Implements a warning log for polling interval less than 30s

### DIFF
--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -184,6 +184,9 @@ func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
 		cm.logger.Info("Polling Config Manager Disabled")
 		return
 	}
+	if cm.pollingInterval < 30*time.Second {
+		cm.logger.Warning("Polling interval below 30s can create high number of requests.")
+	}
 	cm.logger.Debug("Polling Config Manager Initiated")
 	t := time.NewTicker(cm.pollingInterval)
 	for {

--- a/pkg/config/polling_manager.go
+++ b/pkg/config/polling_manager.go
@@ -185,7 +185,7 @@ func (cm *PollingProjectConfigManager) Start(ctx context.Context) {
 		return
 	}
 	if cm.pollingInterval < 30*time.Second {
-		cm.logger.Warning("Polling interval below 30s can create high number of requests.")
+		cm.logger.Warning("Polling intervals below 30 seconds are not recommended.")
 	}
 	cm.logger.Debug("Polling Config Manager Initiated")
 	t := time.NewTicker(cm.pollingInterval)


### PR DESCRIPTION
### Summary
-  Implements a warning log for polling interval less than 30s

## Issues
- [FSSDK-9511](https://jira.sso.episerver.net/browse/FSSDK-9511)