### PR TITLE
[FSSDK-9591] chore: bump go version to 1.21.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.21.0'
     - run: make install lint
 
   unit_test_latest:
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '>=1.20'
+        go-version: '>=1.21.0'
     - run: make cover
 
   unit_test_legacy:
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.21.0'
         check-latest: true
     - run: make cover
           
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.7'
+        go-version: '1.21.0'
     - run: |
         go test -race -covermode atomic -coverprofile=covprofile ./...
         go install github.com/mattn/goveralls@latest
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '>=1.20'
+        go-version: '>=1.21.0'
     - run: make benchmark
 
   integration_tests:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Refer to the [Go SDK's developer documentation](https://docs.developers.optimize
   
 ### Requirements  
 
-Requires Golang version 1.19 or higher.
+Requires Golang version 1.21.0 or higher.
 
 ### Install the SDK
 
@@ -41,7 +41,7 @@ We practice trunk-based development, and as such our default branch, `master` mi
 ```
 module mymodule
 
-go 1.19
+go 1.21.0
 
 require (
 	github.com/optimizely/go-sdk v2.0.0-beta

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Refer to the [Go SDK's developer documentation](https://docs.developers.optimize
   
 ### Requirements  
 
-Requires Golang version 1.21.0 or higher.
+Requires Golang version 1.19 or higher.
 
 ### Install the SDK
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/optimizely/go-sdk
 
-go 1.19
+go 1.21.0
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
## Ticket: 
[FSSDK-9591](https://jira.sso.episerver.net/browse/FSSDK-9591)