### PR TITLE
[FSSDK-11451] Go Implementation: Add Experiment ID + Variation ID to Decision Notification Listener Payload

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -180,6 +180,8 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	decisionContext.Variable = entities.Variable{}
 	var featureDecision decision.FeatureDecision
 	var reasons decide.DecisionReasons
+	var experimentId string
+	var variationId string
 
 	// To avoid cyclo-complexity warning
 	findRegularDecision := func() {
@@ -210,6 +212,8 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	if featureDecision.Variation != nil {
 		variationKey = featureDecision.Variation.Key
 		flagEnabled = featureDecision.Variation.FeatureEnabled
+		experimentId = featureDecision.Experiment.ID
+		variationId = featureDecision.Variation.ID
 	}
 
 	if !allOptions.DisableDecisionEvent {
@@ -230,7 +234,7 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	ruleKey := featureDecision.Experiment.Key
 
 	if o.notificationCenter != nil {
-		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport)
+		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport, experimentId, variationId)
 		o.logger.Debug(fmt.Sprintf(`Feature %q is enabled for user %q? %v`, key, usrContext.ID, flagEnabled))
 		if e := o.notificationCenter.Send(notification.Decision, *decisionNotification); e != nil {
 			o.logger.Warning("Problem with sending notification")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -180,8 +180,8 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	decisionContext.Variable = entities.Variable{}
 	var featureDecision decision.FeatureDecision
 	var reasons decide.DecisionReasons
-	var experimentId string
-	var variationId string
+	var experimentID string
+	var variationID string
 
 	// To avoid cyclo-complexity warning
 	findRegularDecision := func() {
@@ -212,8 +212,8 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	if featureDecision.Variation != nil {
 		variationKey = featureDecision.Variation.Key
 		flagEnabled = featureDecision.Variation.FeatureEnabled
-		experimentId = featureDecision.Experiment.ID
-		variationId = featureDecision.Variation.ID
+		experimentID = featureDecision.Experiment.ID
+		variationID = featureDecision.Variation.ID
 	}
 
 	if !allOptions.DisableDecisionEvent {
@@ -234,7 +234,7 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	ruleKey := featureDecision.Experiment.Key
 
 	if o.notificationCenter != nil {
-		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport, experimentId, variationId)
+		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport, experimentID, variationID)
 		o.logger.Debug(fmt.Sprintf(`Feature %q is enabled for user %q? %v`, key, usrContext.ID, flagEnabled))
 		if e := o.notificationCenter.Send(notification.Decision, *decisionNotification); e != nil {
 			o.logger.Warning("Problem with sending notification")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -234,7 +234,7 @@ func (o *OptimizelyClient) decide(userContext *OptimizelyUserContext, key string
 	ruleKey := featureDecision.Experiment.Key
 
 	if o.notificationCenter != nil {
-		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport, experimentID, variationID)
+		decisionNotification := decision.FlagNotification(key, variationKey, ruleKey, experimentID, variationID, flagEnabled, eventSent, usrContext, variableMap, reasonsToReport)
 		o.logger.Debug(fmt.Sprintf(`Feature %q is enabled for user %q? %v`, key, usrContext.ID, flagEnabled))
 		if e := o.notificationCenter.Send(notification.Decision, *decisionNotification); e != nil {
 			o.logger.Warning("Problem with sending notification")

--- a/pkg/client/optimizely_user_context_test.go
+++ b/pkg/client/optimizely_user_context_test.go
@@ -821,6 +821,8 @@ func (s *OptimizelyUserContextTestSuite) TestDecisionNotification() {
 	enabled := true
 	variablesExpected, err := s.OptimizelyClient.GetAllFeatureVariables(flagKey, entities.UserContext{ID: s.userID})
 	s.Nil(err)
+	experimentId := "10420810910"
+	variationId := "10418551353"
 
 	ruleKey := "exp_no_audience"
 	reasons := []string{}
@@ -839,6 +841,8 @@ func (s *OptimizelyUserContextTestSuite) TestDecisionNotification() {
 		"ruleKey":                 ruleKey,
 		"reasons":                 reasons,
 		"decisionEventDispatched": true,
+		"experimentId":            experimentId,
+		"variationId":             variationId,
 	}
 	s.OptimizelyClient.DecisionService.OnDecision(callback)
 	_ = user.Decide(flagKey, nil)

--- a/pkg/decision/flag_notification.go
+++ b/pkg/decision/flag_notification.go
@@ -23,7 +23,7 @@ import (
 )
 
 // FlagNotification constructs default flag notification
-func FlagNotification(flagKey, variationKey, ruleKey string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string) *notification.DecisionNotification {
+func FlagNotification(flagKey, variationKey, ruleKey string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string, experimentId string, variationId string) *notification.DecisionNotification {
 
 	if flagKey == "" {
 		return nil
@@ -37,6 +37,8 @@ func FlagNotification(flagKey, variationKey, ruleKey string, enabled, decisionEv
 		"ruleKey":                 ruleKey,
 		"reasons":                 reasons,
 		"decisionEventDispatched": decisionEventDispatched,
+		"experimentId":            experimentId,
+		"variationId":             variationId,
 	}
 
 	decisionNotification := &notification.DecisionNotification{

--- a/pkg/decision/flag_notification.go
+++ b/pkg/decision/flag_notification.go
@@ -23,7 +23,7 @@ import (
 )
 
 // FlagNotification constructs default flag notification
-func FlagNotification(flagKey, variationKey, ruleKey string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string, experimentId string, variationId string) *notification.DecisionNotification {
+func FlagNotification(flagKey, variationKey, ruleKey, experimentId, variationId string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string) *notification.DecisionNotification {
 
 	if flagKey == "" {
 		return nil

--- a/pkg/decision/flag_notification.go
+++ b/pkg/decision/flag_notification.go
@@ -23,7 +23,7 @@ import (
 )
 
 // FlagNotification constructs default flag notification
-func FlagNotification(flagKey, variationKey, ruleKey, experimentId, variationId string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string) *notification.DecisionNotification {
+func FlagNotification(flagKey, variationKey, ruleKey, experimentID, variationID string, enabled, decisionEventDispatched bool, userContext entities.UserContext, variables map[string]interface{}, reasons []string) *notification.DecisionNotification {
 
 	if flagKey == "" {
 		return nil
@@ -37,8 +37,8 @@ func FlagNotification(flagKey, variationKey, ruleKey, experimentId, variationId 
 		"ruleKey":                 ruleKey,
 		"reasons":                 reasons,
 		"decisionEventDispatched": decisionEventDispatched,
-		"experimentId":            experimentId,
-		"variationId":             variationId,
+		"experimentId":            experimentID,
+		"variationId":             variationID,
 	}
 
 	decisionNotification := &notification.DecisionNotification{


### PR DESCRIPTION
## Summary
- Added `experimentId` and `variationId` to decision notification

## Issues
- [FSSDK-11451](https://jira.sso.episerver.net/browse/FSSDK-11451)