### PR TITLE
[FSSDK-11635] remove duplicated fetch method, add cache wrapper

### DIFF
--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -593,7 +594,8 @@ func TestPollingInterval(t *testing.T) {
 	assert.Equal(t, configManager.pollingInterval, 5*time.Second)
 	assert.Equal(t, asyncConfigManager.pollingInterval, 5*time.Second)
 
-	assert.Equal(t, configManager.err, Err403Forbidden)
+	assert.True(t, configManager.err == Err403Forbidden || 
+		strings.Contains(configManager.err.Error(), "context deadline exceeded"))
 	assert.Nil(t, asyncConfigManager.err)
 }
 

--- a/pkg/config/polling_manager_test.go
+++ b/pkg/config/polling_manager_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"context"
 	"net/http"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -594,8 +593,7 @@ func TestPollingInterval(t *testing.T) {
 	assert.Equal(t, configManager.pollingInterval, 5*time.Second)
 	assert.Equal(t, asyncConfigManager.pollingInterval, 5*time.Second)
 
-	assert.True(t, configManager.err == Err403Forbidden || 
-		strings.Contains(configManager.err.Error(), "context deadline exceeded"))
+	assert.Equal(t, configManager.err, Err403Forbidden)
 	assert.Nil(t, asyncConfigManager.err)
 }
 

--- a/pkg/odp/cache.go
+++ b/pkg/odp/cache.go
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * Copyright 2022-2025, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    https://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package odp provides compatibility with the previously located cache package.
+// This file exists to maintain backward compatibility with code that imports
+// cache from the odp package. New code should import from pkg/cache directly.
+package odp
+
+import (
+	"time"
+
+	"github.com/optimizely/go-sdk/v2/pkg/cache"
+)
+
+// LRUCache wraps the cache.LRUCache to maintain backward compatibility
+type LRUCache struct {
+	*cache.LRUCache
+}
+
+// NewLRUCache returns a new instance of Least Recently Used in-memory cache
+// Deprecated: For new code, use pkg/cache directly instead.
+// This function exists for backward compatibility with code that imports from pkg/odp
+func NewLRUCache(size int, timeout time.Duration) *LRUCache {
+	return &LRUCache{
+		LRUCache: cache.NewLRUCache(size, timeout),
+	}
+}


### PR DESCRIPTION
- remove duplicated retry logic from cmab_service.go, only keep retry in cmab_client
- lru_cache file has been moved to own pkg.cache, that can break cache related to odp code, creating a cache wrapper such that all new code uses the new location in pkg/cache/cache.go and old odp code will stil be compatible and work with the old cache location.
- added deprecation comment to the wrapper

All unit tests pass, unchanged.

Jira: https://jira.sso.episerver.net/browse/FSSDK-11635