### PR TITLE
[FSSDK-11857] go-sdk CMAB bug fixes from bug bash

### DIFF
--- a/pkg/cmab/service.go
+++ b/pkg/cmab/service.go
@@ -18,9 +18,11 @@
 package cmab
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/optimizely/go-sdk/v2/pkg/cache"
@@ -31,11 +33,30 @@ import (
 	"github.com/twmb/murmur3"
 )
 
+const (
+	// NumLockStripes defines the number of mutexes for lock striping to reduce contention
+	NumLockStripes = 1000
+)
+
 // DefaultCmabService implements the CmabService interface
 type DefaultCmabService struct {
 	cmabCache  cache.CacheWithRemove
 	cmabClient Client
 	logger     logging.OptimizelyLogProducer
+	// Lock striping to prevent race conditions in concurrent CMAB requests
+	locks [NumLockStripes]sync.Mutex
+}
+
+// getLockIndex calculates the lock index for a given user and rule combination
+func (s *DefaultCmabService) getLockIndex(userID, ruleID string) int {
+	// Create a hash of userID + ruleID for consistent lock selection
+	hash := sha256.Sum256([]byte(userID + ruleID))
+	// Use the first 8 bytes as a uint64 for modulo calculation
+	var hashValue uint64
+	for i := 0; i < 8; i++ {
+		hashValue = (hashValue << 8) | uint64(hash[i])
+	}
+	return int(hashValue % NumLockStripes)
 }
 
 // ServiceOptions defines options for creating a CMAB service
@@ -66,6 +87,11 @@ func (s *DefaultCmabService) GetDecision(
 	ruleID string,
 	options *decide.Options,
 ) (Decision, error) {
+	// Use lock striping to prevent race conditions in concurrent requests
+	lockIndex := s.getLockIndex(userContext.ID, ruleID)
+	s.locks[lockIndex].Lock()
+	defer s.locks[lockIndex].Unlock()
+
 	// Initialize reasons slice for decision
 	reasons := []string{}
 

--- a/pkg/cmab/service_test.go
+++ b/pkg/cmab/service_test.go
@@ -852,10 +852,10 @@ func TestConcurrentCmabRequests(t *testing.T) {
 	// Test concurrent access to the same lock index
 	userID := "test_user"
 	ruleID := "test_rule"
-	
+
 	// Verify that the same combination always gets the same lock index
 	lockIndex := service.getLockIndex(userID, ruleID)
-	
+
 	numGoroutines := 10
 	var wg sync.WaitGroup
 	results := make([]int, numGoroutines)
@@ -898,11 +898,11 @@ func TestLockStripingDistribution(t *testing.T) {
 	lockIndices := make(map[int]bool)
 	for _, tc := range testCases {
 		index := service.getLockIndex(tc.userID, tc.ruleID)
-		
+
 		// Verify index is within expected range
 		assert.GreaterOrEqual(t, index, 0, "Lock index should be non-negative")
 		assert.Less(t, index, NumLockStripes, "Lock index should be less than NumLockStripes")
-		
+
 		lockIndices[index] = true
 	}
 

--- a/pkg/cmab/service_test.go
+++ b/pkg/cmab/service_test.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/optimizely/go-sdk/v2/pkg/decide"
 	"github.com/optimizely/go-sdk/v2/pkg/entities"
 	"github.com/optimizely/go-sdk/v2/pkg/logging"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/murmur3"
@@ -842,4 +844,86 @@ func (s *CmabServiceTestSuite) TestGetDecisionApiError() {
 	s.mockConfig.AssertExpectations(s.T())
 	s.mockCache.AssertExpectations(s.T())
 	s.mockClient.AssertExpectations(s.T())
+}
+
+func TestConcurrentCmabRequests(t *testing.T) {
+	service := &DefaultCmabService{}
+
+	// Test concurrent access to the same lock index
+	userID := "test_user"
+	ruleID := "test_rule"
+	
+	// Verify that the same combination always gets the same lock index
+	lockIndex := service.getLockIndex(userID, ruleID)
+	
+	numGoroutines := 10
+	var wg sync.WaitGroup
+	results := make([]int, numGoroutines)
+
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(index int) {
+			defer wg.Done()
+			// All goroutines should get the same lock index for the same user/rule
+			results[index] = service.getLockIndex(userID, ruleID)
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Verify all goroutines got the same lock index
+	for i := 0; i < numGoroutines; i++ {
+		assert.Equal(t, lockIndex, results[i], "All goroutines should get the same lock index for the same user/rule combination")
+	}
+}
+
+// TestLockStripingDistribution verifies that different user/rule combinations
+// use different locks to allow for better concurrency
+func TestLockStripingDistribution(t *testing.T) {
+	service := &DefaultCmabService{}
+
+	// Test different combinations to ensure they get different lock indices
+	testCases := []struct {
+		userID string
+		ruleID string
+	}{
+		{"user1", "rule1"},
+		{"user2", "rule1"},
+		{"user1", "rule2"},
+		{"user3", "rule3"},
+		{"user4", "rule4"},
+	}
+
+	lockIndices := make(map[int]bool)
+	for _, tc := range testCases {
+		index := service.getLockIndex(tc.userID, tc.ruleID)
+		
+		// Verify index is within expected range
+		assert.GreaterOrEqual(t, index, 0, "Lock index should be non-negative")
+		assert.Less(t, index, NumLockStripes, "Lock index should be less than NumLockStripes")
+		
+		lockIndices[index] = true
+	}
+
+	// We should have multiple different lock indices (though not necessarily all unique due to hash collisions)
+	assert.Greater(t, len(lockIndices), 1, "Different user/rule combinations should generally use different locks")
+}
+
+// TestSameUserRuleCombinationUsesConsistentLock verifies that the same user/rule combination
+// always uses the same lock index
+func TestSameUserRuleCombinationUsesConsistentLock(t *testing.T) {
+	service := &DefaultCmabService{}
+
+	userID := "test_user"
+	ruleID := "test_rule"
+
+	// Get lock index multiple times
+	index1 := service.getLockIndex(userID, ruleID)
+	index2 := service.getLockIndex(userID, ruleID)
+	index3 := service.getLockIndex(userID, ruleID)
+
+	// All should be the same
+	assert.Equal(t, index1, index2, "Same user/rule should always use same lock")
+	assert.Equal(t, index2, index3, "Same user/rule should always use same lock")
 }

--- a/pkg/decision/composite_experiment_service.go
+++ b/pkg/decision/composite_experiment_service.go
@@ -124,6 +124,18 @@ func (s *CompositeExperimentService) GetDecision(decisionContext ExperimentDecis
 			return decision, reasons, nil
 		}
 
+		// For CMAB service, if it processed a CMAB experiment but didn't return a variation,
+		// it means the experiment was definitively handled (failed audience or traffic allocation)
+		// Don't continue to bucketer service to avoid redundant audience evaluation
+		if _, ok := experimentService.(*ExperimentCmabService); ok {
+			// Check if this was a CMAB experiment that was processed
+			if decisionContext.Experiment != nil && decisionContext.Experiment.Cmab != nil {
+				// CMAB service processed the experiment but didn't return a variation
+				// This is a definitive result - don't continue to other services
+				return decision, reasons, nil
+			}
+		}
+
 		// No error and no decision - continue to next service
 	}
 

--- a/pkg/decision/reasons/reason.go
+++ b/pkg/decision/reasons/reason.go
@@ -60,5 +60,5 @@ const (
 	// OverrideVariationAssignmentFound - A valid override variation was found for the given user and experiment
 	OverrideVariationAssignmentFound Reason = "Override variation assignment found"
 	// CmabVariationAssigned is the reason when a variation is assigned by the CMAB service
-	CmabVariationAssigned Reason = "cmab_variation_assigned"
+	CmabVariationAssigned Reason = "cmab variation assigned"
 )


### PR DESCRIPTION
Fixed:
- in pkg/decision/reasons.go remove underscores in string CmabVariationAssigned Reason = "cmab_variation_assigned"
- Redundant audience evaluation logs
- concurrency bug


Jira:
https://jira.sso.episerver.net/browse/FSSDK-11857
https://jira.sso.episerver.net/browse/FSSDK-11856 