### PR TITLE
[AI-FSSDK] [FSSDK-12369] Add local holdouts support to Go SDK

### DIFF
--- a/pkg/cmab/service_test.go
+++ b/pkg/cmab/service_test.go
@@ -235,6 +235,16 @@ func (m *MockProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Hol
 	return args.Get(0).([]entities.Holdout)
 }
 
+func (m *MockProjectConfig) GetGlobalHoldouts() []entities.Holdout {
+	args := m.Called()
+	return args.Get(0).([]entities.Holdout)
+}
+
+func (m *MockProjectConfig) GetHoldoutsForRule(ruleID string) []entities.Holdout {
+	args := m.Called(ruleID)
+	return args.Get(0).([]entities.Holdout)
+}
+
 type CmabServiceTestSuite struct {
 	suite.Suite
 	mockClient     *MockCmabClient

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -62,7 +62,6 @@ type DatafileProjectConfig struct {
 	flagVariationsMap map[string][]entities.Variation
 	holdouts          []entities.Holdout
 	holdoutIDMap      map[string]entities.Holdout
-	flagHoldoutsMap   map[string][]entities.Holdout
 	// ruleHoldoutsMap maps rule IDs to local holdouts targeting those rules
 	ruleHoldoutsMap map[string][]entities.Holdout
 	// globalHoldouts holds only global holdouts (IncludedRules == nil)
@@ -288,16 +287,6 @@ func (c DatafileProjectConfig) GetRegion() string {
 	return c.region
 }
 
-// GetHoldoutsForFlag returns all global holdouts applicable to the given feature flag.
-// Only global holdouts (those with IncludedRules == nil) are returned here.
-// Local holdouts are retrieved per rule via GetHoldoutsForRule.
-func (c DatafileProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Holdout {
-	if holdouts, exists := c.flagHoldoutsMap[featureKey]; exists {
-		return holdouts
-	}
-	return []entities.Holdout{}
-}
-
 // GetGlobalHoldouts returns all global holdouts (those with IncludedRules == nil).
 // These are evaluated at flag level, before any per-rule evaluation.
 func (c DatafileProjectConfig) GetGlobalHoldouts() []entities.Holdout {
@@ -359,15 +348,7 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 
 	audienceMap, audienceSegmentList := mappers.MapAudiences(append(datafile.TypedAudiences, datafile.Audiences...))
 	flagVariationsMap := mappers.MapFlagVariations(featureMap)
-	holdouts, holdoutIDMap, flagHoldoutsMap, ruleHoldoutsMap := mappers.MapHoldouts(datafile.Holdouts, featureMap)
-
-	// Collect global holdouts (IncludedRules == nil) for direct access
-	globalHoldouts := []entities.Holdout{}
-	for i := range holdouts {
-		if holdouts[i].IsGlobal() {
-			globalHoldouts = append(globalHoldouts, holdouts[i])
-		}
-	}
+	holdouts, holdoutIDMap, globalHoldouts, ruleHoldoutsMap := mappers.MapHoldouts(datafile.Holdouts)
 
 	attributeKeyMap := make(map[string]entities.Attribute)
 	attributeIDToKeyMap := make(map[string]string)
@@ -412,7 +393,6 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 		region:               region,
 		holdouts:             holdouts,
 		holdoutIDMap:         holdoutIDMap,
-		flagHoldoutsMap:      flagHoldoutsMap,
 		ruleHoldoutsMap:      ruleHoldoutsMap,
 		globalHoldouts:       globalHoldouts,
 	}

--- a/pkg/config/datafileprojectconfig/config.go
+++ b/pkg/config/datafileprojectconfig/config.go
@@ -63,6 +63,10 @@ type DatafileProjectConfig struct {
 	holdouts          []entities.Holdout
 	holdoutIDMap      map[string]entities.Holdout
 	flagHoldoutsMap   map[string][]entities.Holdout
+	// ruleHoldoutsMap maps rule IDs to local holdouts targeting those rules
+	ruleHoldoutsMap map[string][]entities.Holdout
+	// globalHoldouts holds only global holdouts (IncludedRules == nil)
+	globalHoldouts []entities.Holdout
 }
 
 // GetDatafile returns a string representation of the environment's datafile
@@ -284,9 +288,26 @@ func (c DatafileProjectConfig) GetRegion() string {
 	return c.region
 }
 
-// GetHoldoutsForFlag returns all holdouts applicable to the given feature flag
+// GetHoldoutsForFlag returns all global holdouts applicable to the given feature flag.
+// Only global holdouts (those with IncludedRules == nil) are returned here.
+// Local holdouts are retrieved per rule via GetHoldoutsForRule.
 func (c DatafileProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Holdout {
 	if holdouts, exists := c.flagHoldoutsMap[featureKey]; exists {
+		return holdouts
+	}
+	return []entities.Holdout{}
+}
+
+// GetGlobalHoldouts returns all global holdouts (those with IncludedRules == nil).
+// These are evaluated at flag level, before any per-rule evaluation.
+func (c DatafileProjectConfig) GetGlobalHoldouts() []entities.Holdout {
+	return c.globalHoldouts
+}
+
+// GetHoldoutsForRule returns all local holdouts that target the given rule ID.
+// These are evaluated per-rule, after forced decisions, before audience/traffic checks.
+func (c DatafileProjectConfig) GetHoldoutsForRule(ruleID string) []entities.Holdout {
+	if holdouts, exists := c.ruleHoldoutsMap[ruleID]; exists {
 		return holdouts
 	}
 	return []entities.Holdout{}
@@ -338,7 +359,15 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 
 	audienceMap, audienceSegmentList := mappers.MapAudiences(append(datafile.TypedAudiences, datafile.Audiences...))
 	flagVariationsMap := mappers.MapFlagVariations(featureMap)
-	holdouts, holdoutIDMap, flagHoldoutsMap := mappers.MapHoldouts(datafile.Holdouts, featureMap)
+	holdouts, holdoutIDMap, flagHoldoutsMap, ruleHoldoutsMap := mappers.MapHoldouts(datafile.Holdouts, featureMap)
+
+	// Collect global holdouts (IncludedRules == nil) for direct access
+	globalHoldouts := []entities.Holdout{}
+	for i := range holdouts {
+		if holdouts[i].IsGlobal() {
+			globalHoldouts = append(globalHoldouts, holdouts[i])
+		}
+	}
 
 	attributeKeyMap := make(map[string]entities.Attribute)
 	attributeIDToKeyMap := make(map[string]string)
@@ -384,6 +413,8 @@ func NewDatafileProjectConfig(jsonDatafile []byte, logger logging.OptimizelyLogP
 		holdouts:             holdouts,
 		holdoutIDMap:         holdoutIDMap,
 		flagHoldoutsMap:      flagHoldoutsMap,
+		ruleHoldoutsMap:      ruleHoldoutsMap,
+		globalHoldouts:       globalHoldouts,
 	}
 
 	logger.Info("Datafile is valid.")

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -789,3 +789,42 @@ func TestGetHoldoutsForFlagWithDifferentFlag(t *testing.T) {
 	assert.Len(t, actual, 0)
 	assert.Equal(t, []entities.Holdout{}, actual)
 }
+
+func TestGetHoldoutsForRuleWithHoldouts(t *testing.T) {
+	ruleID := "test_rule_id"
+	holdout1 := entities.Holdout{
+		ID:     "holdout_1",
+		Key:    "test_holdout_1",
+		Status: entities.HoldoutStatusRunning,
+	}
+	holdout2 := entities.Holdout{
+		ID:     "holdout_2",
+		Key:    "test_holdout_2",
+		Status: entities.HoldoutStatusRunning,
+	}
+
+	ruleHoldoutsMap := make(map[string][]entities.Holdout)
+	ruleHoldoutsMap[ruleID] = []entities.Holdout{holdout1, holdout2}
+
+	config := &DatafileProjectConfig{
+		ruleHoldoutsMap: ruleHoldoutsMap,
+	}
+
+	actual := config.GetHoldoutsForRule(ruleID)
+	assert.Len(t, actual, 2)
+	assert.Equal(t, holdout1, actual[0])
+	assert.Equal(t, holdout2, actual[1])
+}
+
+func TestGetHoldoutsForRuleWithNoHoldouts(t *testing.T) {
+	ruleID := "test_rule_id"
+	ruleHoldoutsMap := make(map[string][]entities.Holdout)
+
+	config := &DatafileProjectConfig{
+		ruleHoldoutsMap: ruleHoldoutsMap,
+	}
+
+	actual := config.GetHoldoutsForRule(ruleID)
+	assert.Len(t, actual, 0)
+	assert.Equal(t, []entities.Holdout{}, actual)
+}

--- a/pkg/config/datafileprojectconfig/config_test.go
+++ b/pkg/config/datafileprojectconfig/config_test.go
@@ -729,67 +729,6 @@ func TestGetAttributeByKeyWithDirectMapping(t *testing.T) {
 	assert.Equal(t, attribute, actual)
 }
 
-func TestGetHoldoutsForFlagWithHoldouts(t *testing.T) {
-	flagKey := "test_flag"
-	holdout1 := entities.Holdout{
-		ID:     "holdout_1",
-		Key:    "test_holdout_1",
-		Status: entities.HoldoutStatusRunning,
-	}
-	holdout2 := entities.Holdout{
-		ID:     "holdout_2",
-		Key:    "test_holdout_2",
-		Status: entities.HoldoutStatusRunning,
-	}
-
-	flagHoldoutsMap := make(map[string][]entities.Holdout)
-	flagHoldoutsMap[flagKey] = []entities.Holdout{holdout1, holdout2}
-
-	config := &DatafileProjectConfig{
-		flagHoldoutsMap: flagHoldoutsMap,
-	}
-
-	actual := config.GetHoldoutsForFlag(flagKey)
-	assert.Len(t, actual, 2)
-	assert.Equal(t, holdout1, actual[0])
-	assert.Equal(t, holdout2, actual[1])
-}
-
-func TestGetHoldoutsForFlagWithNoHoldouts(t *testing.T) {
-	flagKey := "test_flag"
-	flagHoldoutsMap := make(map[string][]entities.Holdout)
-
-	config := &DatafileProjectConfig{
-		flagHoldoutsMap: flagHoldoutsMap,
-	}
-
-	actual := config.GetHoldoutsForFlag(flagKey)
-	assert.Len(t, actual, 0)
-	assert.Equal(t, []entities.Holdout{}, actual)
-}
-
-func TestGetHoldoutsForFlagWithDifferentFlag(t *testing.T) {
-	flagKey := "test_flag"
-	otherFlagKey := "other_flag"
-	holdout := entities.Holdout{
-		ID:     "holdout_1",
-		Key:    "test_holdout_1",
-		Status: entities.HoldoutStatusRunning,
-	}
-
-	flagHoldoutsMap := make(map[string][]entities.Holdout)
-	flagHoldoutsMap[otherFlagKey] = []entities.Holdout{holdout}
-
-	config := &DatafileProjectConfig{
-		flagHoldoutsMap: flagHoldoutsMap,
-	}
-
-	// Request different flag - should return empty
-	actual := config.GetHoldoutsForFlag(flagKey)
-	assert.Len(t, actual, 0)
-	assert.Equal(t, []entities.Holdout{}, actual)
-}
-
 func TestGetHoldoutsForRuleWithHoldouts(t *testing.T) {
 	ruleID := "test_rule_id"
 	holdout1 := entities.Holdout{

--- a/pkg/config/datafileprojectconfig/entities/entities.go
+++ b/pkg/config/datafileprojectconfig/entities/entities.go
@@ -123,6 +123,10 @@ type Holdout struct {
 	AudienceConditions interface{}         `json:"audienceConditions"`
 	Variations         []Variation         `json:"variations"`
 	TrafficAllocation  []TrafficAllocation `json:"trafficAllocation"`
+	// IncludedRules is optional. nil = global holdout (applies to all rules across all flags).
+	// Non-nil array = local holdout (applies only to the specified rule IDs).
+	// An empty non-nil array means a local holdout that targets no rules.
+	IncludedRules *[]string `json:"includedRules,omitempty"`
 }
 
 // Integration represents a integration from the Optimizely datafile

--- a/pkg/config/datafileprojectconfig/mappers/holdout.go
+++ b/pkg/config/datafileprojectconfig/mappers/holdout.go
@@ -22,18 +22,21 @@ import (
 	"github.com/optimizely/go-sdk/v2/pkg/entities"
 )
 
-// MapHoldouts maps the raw datafile holdout entities to SDK Holdout entities
-// All running holdouts apply to all flags
+// MapHoldouts maps the raw datafile holdout entities to SDK Holdout entities.
+// Global holdouts (IncludedRules == nil) apply to all flags via flagHoldoutsMap.
+// Local holdouts (IncludedRules != nil) are indexed by rule ID in ruleHoldoutsMap.
 func MapHoldouts(holdouts []datafileEntities.Holdout, featureMap map[string]entities.Feature) (
 	holdoutList []entities.Holdout,
 	holdoutIDMap map[string]entities.Holdout,
 	flagHoldoutsMap map[string][]entities.Holdout,
+	ruleHoldoutsMap map[string][]entities.Holdout,
 ) {
 	holdoutList = []entities.Holdout{}
 	holdoutIDMap = make(map[string]entities.Holdout)
 	flagHoldoutsMap = make(map[string][]entities.Holdout)
+	ruleHoldoutsMap = make(map[string][]entities.Holdout)
 
-	runningHoldouts := []entities.Holdout{}
+	globalHoldouts := []entities.Holdout{}
 
 	for _, holdout := range holdouts {
 		// Only process running holdouts
@@ -44,17 +47,26 @@ func MapHoldouts(holdouts []datafileEntities.Holdout, featureMap map[string]enti
 		mappedHoldout := mapHoldout(holdout)
 		holdoutList = append(holdoutList, mappedHoldout)
 		holdoutIDMap[holdout.ID] = mappedHoldout
-		runningHoldouts = append(runningHoldouts, mappedHoldout)
-	}
 
-	// All running holdouts apply to all flags
-	for _, feature := range featureMap {
-		if len(runningHoldouts) > 0 {
-			flagHoldoutsMap[feature.Key] = runningHoldouts
+		if mappedHoldout.IsGlobal() {
+			// Global holdout: applies to all rules across all flags
+			globalHoldouts = append(globalHoldouts, mappedHoldout)
+		} else {
+			// Local holdout: applies only to the specified rule IDs
+			for _, ruleID := range *mappedHoldout.IncludedRules {
+				ruleHoldoutsMap[ruleID] = append(ruleHoldoutsMap[ruleID], mappedHoldout)
+			}
 		}
 	}
 
-	return holdoutList, holdoutIDMap, flagHoldoutsMap
+	// Global holdouts apply to all flags (flag-level evaluation)
+	for _, feature := range featureMap {
+		if len(globalHoldouts) > 0 {
+			flagHoldoutsMap[feature.Key] = globalHoldouts
+		}
+	}
+
+	return holdoutList, holdoutIDMap, flagHoldoutsMap, ruleHoldoutsMap
 }
 
 func mapHoldout(datafileHoldout datafileEntities.Holdout) entities.Holdout {
@@ -107,5 +119,6 @@ func mapHoldout(datafileHoldout datafileEntities.Holdout) entities.Holdout {
 		Variations:            variations,
 		TrafficAllocation:     trafficAllocation,
 		AudienceConditionTree: audienceConditionTree,
+		IncludedRules:         datafileHoldout.IncludedRules,
 	}
 }

--- a/pkg/config/datafileprojectconfig/mappers/holdout.go
+++ b/pkg/config/datafileprojectconfig/mappers/holdout.go
@@ -23,20 +23,18 @@ import (
 )
 
 // MapHoldouts maps the raw datafile holdout entities to SDK Holdout entities.
-// Global holdouts (IncludedRules == nil) apply to all flags via flagHoldoutsMap.
+// Global holdouts (IncludedRules == nil) are returned in globalHoldouts for flag-level evaluation.
 // Local holdouts (IncludedRules != nil) are indexed by rule ID in ruleHoldoutsMap.
-func MapHoldouts(holdouts []datafileEntities.Holdout, featureMap map[string]entities.Feature) (
+func MapHoldouts(holdouts []datafileEntities.Holdout) (
 	holdoutList []entities.Holdout,
 	holdoutIDMap map[string]entities.Holdout,
-	flagHoldoutsMap map[string][]entities.Holdout,
+	globalHoldouts []entities.Holdout,
 	ruleHoldoutsMap map[string][]entities.Holdout,
 ) {
 	holdoutList = []entities.Holdout{}
 	holdoutIDMap = make(map[string]entities.Holdout)
-	flagHoldoutsMap = make(map[string][]entities.Holdout)
+	globalHoldouts = []entities.Holdout{}
 	ruleHoldoutsMap = make(map[string][]entities.Holdout)
-
-	globalHoldouts := []entities.Holdout{}
 
 	for _, holdout := range holdouts {
 		// Only process running holdouts
@@ -49,7 +47,6 @@ func MapHoldouts(holdouts []datafileEntities.Holdout, featureMap map[string]enti
 		holdoutIDMap[holdout.ID] = mappedHoldout
 
 		if mappedHoldout.IsGlobal() {
-			// Global holdout: applies to all rules across all flags
 			globalHoldouts = append(globalHoldouts, mappedHoldout)
 		} else {
 			// Local holdout: applies only to the specified rule IDs
@@ -59,14 +56,7 @@ func MapHoldouts(holdouts []datafileEntities.Holdout, featureMap map[string]enti
 		}
 	}
 
-	// Global holdouts apply to all flags (flag-level evaluation)
-	for _, feature := range featureMap {
-		if len(globalHoldouts) > 0 {
-			flagHoldoutsMap[feature.Key] = globalHoldouts
-		}
-	}
-
-	return holdoutList, holdoutIDMap, flagHoldoutsMap, ruleHoldoutsMap
+	return holdoutList, holdoutIDMap, globalHoldouts, ruleHoldoutsMap
 }
 
 func mapHoldout(datafileHoldout datafileEntities.Holdout) entities.Holdout {

--- a/pkg/config/datafileprojectconfig/mappers/holdout_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/holdout_test.go
@@ -28,7 +28,7 @@ func TestMapHoldoutsEmpty(t *testing.T) {
 	rawHoldouts := []datafileEntities.Holdout{}
 	featureMap := map[string]entities.Feature{}
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	assert.Empty(t, holdoutList)
 	assert.Empty(t, holdoutIDMap)
@@ -57,7 +57,7 @@ func TestMapHoldoutsAppliestoAllFlags(t *testing.T) {
 		"feature_3": {ID: "feature_3", Key: "feature_3"},
 	}
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	// Verify holdout list and ID map
 	assert.Len(t, holdoutList, 1)
@@ -93,7 +93,7 @@ func TestMapHoldoutsNotRunning(t *testing.T) {
 		"feature_1": {ID: "feature_1", Key: "feature_1"},
 	}
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	// Non-running holdouts should be filtered out
 	assert.Empty(t, holdoutList)
@@ -133,7 +133,7 @@ func TestMapHoldoutsMultipleHoldouts(t *testing.T) {
 		"feature_2": {ID: "feature_2", Key: "feature_2"},
 	}
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	// Verify both holdouts are in the list
 	assert.Len(t, holdoutList, 2)
@@ -174,7 +174,7 @@ func TestMapHoldoutsWithAudienceConditions(t *testing.T) {
 		"feature_1": {ID: "feature_1", Key: "feature_1"},
 	}
 
-	holdoutList, _, _ := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, _, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	// Verify audience conditions are mapped
 	assert.Len(t, holdoutList, 1)
@@ -214,7 +214,7 @@ func TestMapHoldoutsVariationsMapping(t *testing.T) {
 		"feature_1": {ID: "feature_1", Key: "feature_1"},
 	}
 
-	holdoutList, _, _ := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, _, _ := MapHoldouts(rawHoldouts, featureMap)
 
 	// Verify variations are mapped correctly
 	assert.Len(t, holdoutList, 1)
@@ -228,4 +228,232 @@ func TestMapHoldoutsVariationsMapping(t *testing.T) {
 	assert.Equal(t, 5000, holdoutList[0].TrafficAllocation[0].EndOfRange)
 	assert.Equal(t, "var_2", holdoutList[0].TrafficAllocation[1].EntityID)
 	assert.Equal(t, 10000, holdoutList[0].TrafficAllocation[1].EndOfRange)
+}
+
+// Level 1 tests for local holdout support (FSSDK-12369)
+
+func TestMapHoldoutsIsGlobalNilIncludedRules(t *testing.T) {
+	// A holdout with no IncludedRules field (nil pointer) should be global
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:            "holdout_global",
+			Key:           "global_holdout",
+			Status:        "Running",
+			IncludedRules: nil, // nil = global
+			Variations: []datafileEntities.Variation{
+				{ID: "var_1", Key: "variation_1"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_1", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{
+		"feature_1": {ID: "feature_1", Key: "feature_1"},
+	}
+
+	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	assert.Len(t, holdoutList, 1)
+	// nil IncludedRules should be classified as global
+	assert.True(t, holdoutList[0].IsGlobal())
+	assert.Nil(t, holdoutList[0].IncludedRules)
+	// Global holdout should appear in flagHoldoutsMap for every feature
+	assert.Contains(t, flagHoldoutsMap, "feature_1")
+	assert.Len(t, flagHoldoutsMap["feature_1"], 1)
+	// ruleHoldoutsMap should be empty for a global holdout
+	assert.Empty(t, ruleHoldoutsMap)
+}
+
+func TestMapHoldoutsLocalHoldoutWithIncludedRules(t *testing.T) {
+	// A holdout with IncludedRules pointing to specific rule IDs should be local
+	includedRules := []string{"rule_id_1", "rule_id_2"}
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:            "holdout_local",
+			Key:           "local_holdout",
+			Status:        "Running",
+			IncludedRules: &includedRules,
+			Variations: []datafileEntities.Variation{
+				{ID: "var_1", Key: "variation_1"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_1", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{
+		"feature_1": {ID: "feature_1", Key: "feature_1"},
+	}
+
+	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	assert.Len(t, holdoutList, 1)
+	// Non-nil IncludedRules should be classified as local (not global)
+	assert.False(t, holdoutList[0].IsGlobal())
+	assert.NotNil(t, holdoutList[0].IncludedRules)
+	// Local holdout must NOT appear in flagHoldoutsMap
+	assert.Empty(t, flagHoldoutsMap)
+	// Local holdout should appear in ruleHoldoutsMap for each rule it targets
+	assert.Contains(t, ruleHoldoutsMap, "rule_id_1")
+	assert.Contains(t, ruleHoldoutsMap, "rule_id_2")
+	assert.Len(t, ruleHoldoutsMap["rule_id_1"], 1)
+	assert.Len(t, ruleHoldoutsMap["rule_id_2"], 1)
+	assert.Equal(t, "local_holdout", ruleHoldoutsMap["rule_id_1"][0].Key)
+	assert.Equal(t, "local_holdout", ruleHoldoutsMap["rule_id_2"][0].Key)
+}
+
+func TestMapHoldoutsEmptyIncludedRulesIsLocalNotGlobal(t *testing.T) {
+	// An empty (non-nil) IncludedRules slice is local (targets no rules), NOT global
+	emptyRules := []string{}
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:            "holdout_empty_local",
+			Key:           "empty_local_holdout",
+			Status:        "Running",
+			IncludedRules: &emptyRules, // non-nil, but empty
+			Variations: []datafileEntities.Variation{
+				{ID: "var_1", Key: "variation_1"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_1", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{
+		"feature_1": {ID: "feature_1", Key: "feature_1"},
+	}
+
+	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	assert.Len(t, holdoutList, 1)
+	// Empty non-nil IncludedRules should be local (not global)
+	assert.False(t, holdoutList[0].IsGlobal())
+	// Empty local holdout must NOT appear in flagHoldoutsMap
+	assert.Empty(t, flagHoldoutsMap)
+	// ruleHoldoutsMap should also be empty (no rules to target)
+	assert.Empty(t, ruleHoldoutsMap)
+}
+
+func TestMapHoldoutsMixedGlobalAndLocal(t *testing.T) {
+	// Mix of global and local holdouts
+	includedRules := []string{"rule_1"}
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:            "holdout_global",
+			Key:           "global_holdout",
+			Status:        "Running",
+			IncludedRules: nil,
+			Variations: []datafileEntities.Variation{
+				{ID: "var_g", Key: "var_global"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_g", EndOfRange: 10000},
+			},
+		},
+		{
+			ID:            "holdout_local",
+			Key:           "local_holdout",
+			Status:        "Running",
+			IncludedRules: &includedRules,
+			Variations: []datafileEntities.Variation{
+				{ID: "var_l", Key: "var_local"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_l", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{
+		"feature_1": {ID: "feature_1", Key: "feature_1"},
+	}
+
+	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	assert.Len(t, holdoutList, 2)
+
+	// Global holdout in flagHoldoutsMap (only the global one)
+	assert.Contains(t, flagHoldoutsMap, "feature_1")
+	assert.Len(t, flagHoldoutsMap["feature_1"], 1)
+	assert.Equal(t, "global_holdout", flagHoldoutsMap["feature_1"][0].Key)
+
+	// Local holdout in ruleHoldoutsMap
+	assert.Contains(t, ruleHoldoutsMap, "rule_1")
+	assert.Len(t, ruleHoldoutsMap["rule_1"], 1)
+	assert.Equal(t, "local_holdout", ruleHoldoutsMap["rule_1"][0].Key)
+}
+
+func TestMapHoldoutsLocalHoldoutCrossRuleTargeting(t *testing.T) {
+	// A single local holdout can target rules from multiple flags
+	includedRules := []string{"rule_a", "rule_b", "rule_c"}
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:            "holdout_cross",
+			Key:           "cross_rule_holdout",
+			Status:        "Running",
+			IncludedRules: &includedRules,
+			Variations: []datafileEntities.Variation{
+				{ID: "var_1", Key: "variation_1"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_1", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{}
+
+	_, _, _, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	// Each rule should have the holdout mapped
+	assert.Contains(t, ruleHoldoutsMap, "rule_a")
+	assert.Contains(t, ruleHoldoutsMap, "rule_b")
+	assert.Contains(t, ruleHoldoutsMap, "rule_c")
+	assert.Len(t, ruleHoldoutsMap["rule_a"], 1)
+	assert.Len(t, ruleHoldoutsMap["rule_b"], 1)
+	assert.Len(t, ruleHoldoutsMap["rule_c"], 1)
+}
+
+func TestMapHoldoutsIsGlobalProperty(t *testing.T) {
+	// Verify IsGlobal() works correctly for both global and local holdouts
+	nilRules := (*[]string)(nil)
+	emptyRules := []string{}
+	ruleIDs := []string{"rule_1"}
+
+	globalHoldout := entities.Holdout{IncludedRules: nilRules}
+	localHoldoutEmpty := entities.Holdout{IncludedRules: &emptyRules}
+	localHoldoutWithRules := entities.Holdout{IncludedRules: &ruleIDs}
+
+	assert.True(t, globalHoldout.IsGlobal(), "nil IncludedRules should be global")
+	assert.False(t, localHoldoutEmpty.IsGlobal(), "empty non-nil IncludedRules should NOT be global")
+	assert.False(t, localHoldoutWithRules.IsGlobal(), "non-nil IncludedRules with rules should NOT be global")
+}
+
+func TestMapHoldoutsBackwardCompatibilityOldDatafile(t *testing.T) {
+	// Old datafiles without IncludedRules field should be treated as global
+	rawHoldouts := []datafileEntities.Holdout{
+		{
+			ID:     "holdout_old",
+			Key:    "old_global_holdout",
+			Status: "Running",
+			// No IncludedRules field — simulates old datafile format
+			Variations: []datafileEntities.Variation{
+				{ID: "var_1", Key: "variation_1"},
+			},
+			TrafficAllocation: []datafileEntities.TrafficAllocation{
+				{EntityID: "var_1", EndOfRange: 10000},
+			},
+		},
+	}
+	featureMap := map[string]entities.Feature{
+		"my_feature": {ID: "my_feature", Key: "my_feature"},
+	}
+
+	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+
+	assert.Len(t, holdoutList, 1)
+	// Old datafile holdout with no IncludedRules should default to global
+	assert.True(t, holdoutList[0].IsGlobal())
+	assert.Contains(t, flagHoldoutsMap, "my_feature")
+	assert.Len(t, flagHoldoutsMap["my_feature"], 1)
+	assert.Empty(t, ruleHoldoutsMap)
 }

--- a/pkg/config/datafileprojectconfig/mappers/holdout_test.go
+++ b/pkg/config/datafileprojectconfig/mappers/holdout_test.go
@@ -26,17 +26,16 @@ import (
 
 func TestMapHoldoutsEmpty(t *testing.T) {
 	rawHoldouts := []datafileEntities.Holdout{}
-	featureMap := map[string]entities.Feature{}
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, holdoutIDMap, globalHoldouts, _ := MapHoldouts(rawHoldouts)
 
 	assert.Empty(t, holdoutList)
 	assert.Empty(t, holdoutIDMap)
-	assert.Empty(t, flagHoldoutsMap)
+	assert.Empty(t, globalHoldouts)
 }
 
 func TestMapHoldoutsAppliestoAllFlags(t *testing.T) {
-	// Running holdouts apply to all flags
+	// Running holdouts with nil IncludedRules are global and returned in globalHoldouts
 	rawHoldouts := []datafileEntities.Holdout{
 		{
 			ID:     "holdout_1",
@@ -51,30 +50,17 @@ func TestMapHoldoutsAppliestoAllFlags(t *testing.T) {
 		},
 	}
 
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-		"feature_2": {ID: "feature_2", Key: "feature_2"},
-		"feature_3": {ID: "feature_3", Key: "feature_3"},
-	}
+	holdoutList, holdoutIDMap, globalHoldouts, _ := MapHoldouts(rawHoldouts)
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
-
-	// Verify holdout list and ID map
 	assert.Len(t, holdoutList, 1)
 	assert.Len(t, holdoutIDMap, 1)
 	assert.Equal(t, "holdout_1", holdoutList[0].ID)
 	assert.Equal(t, "running_holdout", holdoutList[0].Key)
 
-	// Running holdout should apply to all flags
-	assert.Contains(t, flagHoldoutsMap, "feature_1")
-	assert.Contains(t, flagHoldoutsMap, "feature_2")
-	assert.Contains(t, flagHoldoutsMap, "feature_3")
-
-	assert.Len(t, flagHoldoutsMap["feature_1"], 1)
-	assert.Len(t, flagHoldoutsMap["feature_2"], 1)
-	assert.Len(t, flagHoldoutsMap["feature_3"], 1)
+	// Global holdout should appear in globalHoldouts
+	assert.Len(t, globalHoldouts, 1)
+	assert.Equal(t, "running_holdout", globalHoldouts[0].Key)
 }
-
 
 func TestMapHoldoutsNotRunning(t *testing.T) {
 	// Holdout with non-Running status should be filtered out
@@ -89,20 +75,15 @@ func TestMapHoldoutsNotRunning(t *testing.T) {
 		},
 	}
 
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
+	holdoutList, holdoutIDMap, globalHoldouts, _ := MapHoldouts(rawHoldouts)
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
-
-	// Non-running holdouts should be filtered out
 	assert.Empty(t, holdoutList)
 	assert.Empty(t, holdoutIDMap)
-	assert.Empty(t, flagHoldoutsMap)
+	assert.Empty(t, globalHoldouts)
 }
 
 func TestMapHoldoutsMultipleHoldouts(t *testing.T) {
-	// Multiple running holdouts all apply to all flags
+	// Multiple running global holdouts all appear in globalHoldouts
 	rawHoldouts := []datafileEntities.Holdout{
 		{
 			ID:     "holdout_1",
@@ -128,30 +109,16 @@ func TestMapHoldoutsMultipleHoldouts(t *testing.T) {
 		},
 	}
 
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-		"feature_2": {ID: "feature_2", Key: "feature_2"},
-	}
+	holdoutList, holdoutIDMap, globalHoldouts, _ := MapHoldouts(rawHoldouts)
 
-	holdoutList, holdoutIDMap, flagHoldoutsMap, _ := MapHoldouts(rawHoldouts, featureMap)
-
-	// Verify both holdouts are in the list
 	assert.Len(t, holdoutList, 2)
 	assert.Len(t, holdoutIDMap, 2)
 
-	// Both features should get both holdouts
-	assert.Contains(t, flagHoldoutsMap, "feature_1")
-	assert.Len(t, flagHoldoutsMap["feature_1"], 2)
-	assert.Equal(t, "holdout_1", flagHoldoutsMap["feature_1"][0].Key)
-	assert.Equal(t, "holdout_2", flagHoldoutsMap["feature_1"][1].Key)
-
-	assert.Contains(t, flagHoldoutsMap, "feature_2")
-	assert.Len(t, flagHoldoutsMap["feature_2"], 2)
-	assert.Equal(t, "holdout_1", flagHoldoutsMap["feature_2"][0].Key)
-	assert.Equal(t, "holdout_2", flagHoldoutsMap["feature_2"][1].Key)
+	// Both global holdouts appear in globalHoldouts
+	assert.Len(t, globalHoldouts, 2)
+	assert.Equal(t, "holdout_1", globalHoldouts[0].Key)
+	assert.Equal(t, "holdout_2", globalHoldouts[1].Key)
 }
-
-
 
 func TestMapHoldoutsWithAudienceConditions(t *testing.T) {
 	rawHoldouts := []datafileEntities.Holdout{
@@ -170,11 +137,7 @@ func TestMapHoldoutsWithAudienceConditions(t *testing.T) {
 		},
 	}
 
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
-
-	holdoutList, _, _, _ := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, _, _ := MapHoldouts(rawHoldouts)
 
 	// Verify audience conditions are mapped
 	assert.Len(t, holdoutList, 1)
@@ -210,11 +173,7 @@ func TestMapHoldoutsVariationsMapping(t *testing.T) {
 		},
 	}
 
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
-
-	holdoutList, _, _, _ := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, _, _ := MapHoldouts(rawHoldouts)
 
 	// Verify variations are mapped correctly
 	assert.Len(t, holdoutList, 1)
@@ -248,19 +207,16 @@ func TestMapHoldoutsIsGlobalNilIncludedRules(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
 
-	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, globalHoldouts, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	assert.Len(t, holdoutList, 1)
 	// nil IncludedRules should be classified as global
 	assert.True(t, holdoutList[0].IsGlobal())
 	assert.Nil(t, holdoutList[0].IncludedRules)
-	// Global holdout should appear in flagHoldoutsMap for every feature
-	assert.Contains(t, flagHoldoutsMap, "feature_1")
-	assert.Len(t, flagHoldoutsMap["feature_1"], 1)
+	// Global holdout should appear in globalHoldouts
+	assert.Len(t, globalHoldouts, 1)
+	assert.Equal(t, "global_holdout", globalHoldouts[0].Key)
 	// ruleHoldoutsMap should be empty for a global holdout
 	assert.Empty(t, ruleHoldoutsMap)
 }
@@ -282,18 +238,15 @@ func TestMapHoldoutsLocalHoldoutWithIncludedRules(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
 
-	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, globalHoldouts, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	assert.Len(t, holdoutList, 1)
 	// Non-nil IncludedRules should be classified as local (not global)
 	assert.False(t, holdoutList[0].IsGlobal())
 	assert.NotNil(t, holdoutList[0].IncludedRules)
-	// Local holdout must NOT appear in flagHoldoutsMap
-	assert.Empty(t, flagHoldoutsMap)
+	// Local holdout must NOT appear in globalHoldouts
+	assert.Empty(t, globalHoldouts)
 	// Local holdout should appear in ruleHoldoutsMap for each rule it targets
 	assert.Contains(t, ruleHoldoutsMap, "rule_id_1")
 	assert.Contains(t, ruleHoldoutsMap, "rule_id_2")
@@ -320,17 +273,14 @@ func TestMapHoldoutsEmptyIncludedRulesIsLocalNotGlobal(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
 
-	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, globalHoldouts, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	assert.Len(t, holdoutList, 1)
 	// Empty non-nil IncludedRules should be local (not global)
 	assert.False(t, holdoutList[0].IsGlobal())
-	// Empty local holdout must NOT appear in flagHoldoutsMap
-	assert.Empty(t, flagHoldoutsMap)
+	// Empty local holdout must NOT appear in globalHoldouts
+	assert.Empty(t, globalHoldouts)
 	// ruleHoldoutsMap should also be empty (no rules to target)
 	assert.Empty(t, ruleHoldoutsMap)
 }
@@ -364,18 +314,14 @@ func TestMapHoldoutsMixedGlobalAndLocal(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{
-		"feature_1": {ID: "feature_1", Key: "feature_1"},
-	}
 
-	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, globalHoldouts, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	assert.Len(t, holdoutList, 2)
 
-	// Global holdout in flagHoldoutsMap (only the global one)
-	assert.Contains(t, flagHoldoutsMap, "feature_1")
-	assert.Len(t, flagHoldoutsMap["feature_1"], 1)
-	assert.Equal(t, "global_holdout", flagHoldoutsMap["feature_1"][0].Key)
+	// Only global holdout in globalHoldouts
+	assert.Len(t, globalHoldouts, 1)
+	assert.Equal(t, "global_holdout", globalHoldouts[0].Key)
 
 	// Local holdout in ruleHoldoutsMap
 	assert.Contains(t, ruleHoldoutsMap, "rule_1")
@@ -400,9 +346,8 @@ func TestMapHoldoutsLocalHoldoutCrossRuleTargeting(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{}
 
-	_, _, _, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	_, _, _, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	// Each rule should have the holdout mapped
 	assert.Contains(t, ruleHoldoutsMap, "rule_a")
@@ -444,16 +389,13 @@ func TestMapHoldoutsBackwardCompatibilityOldDatafile(t *testing.T) {
 			},
 		},
 	}
-	featureMap := map[string]entities.Feature{
-		"my_feature": {ID: "my_feature", Key: "my_feature"},
-	}
 
-	holdoutList, _, flagHoldoutsMap, ruleHoldoutsMap := MapHoldouts(rawHoldouts, featureMap)
+	holdoutList, _, globalHoldouts, ruleHoldoutsMap := MapHoldouts(rawHoldouts)
 
 	assert.Len(t, holdoutList, 1)
 	// Old datafile holdout with no IncludedRules should default to global
 	assert.True(t, holdoutList[0].IsGlobal())
-	assert.Contains(t, flagHoldoutsMap, "my_feature")
-	assert.Len(t, flagHoldoutsMap["my_feature"], 1)
+	assert.Len(t, globalHoldouts, 1)
+	assert.Equal(t, "old_global_holdout", globalHoldouts[0].Key)
 	assert.Empty(t, ruleHoldoutsMap)
 }

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -56,7 +56,6 @@ type ProjectConfig interface {
 	GetAttributes() []entities.Attribute
 	GetFlagVariationsMap() map[string][]entities.Variation
 	GetRegion() string
-	GetHoldoutsForFlag(featureKey string) []entities.Holdout
 	// GetGlobalHoldouts returns all global holdouts (those with IncludedRules == nil).
 	// These are evaluated at flag level before any per-rule evaluation.
 	GetGlobalHoldouts() []entities.Holdout

--- a/pkg/config/interface.go
+++ b/pkg/config/interface.go
@@ -57,6 +57,12 @@ type ProjectConfig interface {
 	GetFlagVariationsMap() map[string][]entities.Variation
 	GetRegion() string
 	GetHoldoutsForFlag(featureKey string) []entities.Holdout
+	// GetGlobalHoldouts returns all global holdouts (those with IncludedRules == nil).
+	// These are evaluated at flag level before any per-rule evaluation.
+	GetGlobalHoldouts() []entities.Holdout
+	// GetHoldoutsForRule returns all local holdouts targeting the given rule ID.
+	// These are evaluated per-rule, after forced decisions, before audience/traffic checks.
+	GetHoldoutsForRule(ruleID string) []entities.Holdout
 }
 
 // ProjectConfigManager maintains an instance of the ProjectConfig

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -25,6 +25,7 @@ import (
 
 // CompositeFeatureService is the default out-of-the-box feature decision service
 type CompositeFeatureService struct {
+	holdoutService  *HoldoutService
 	featureServices []FeatureService
 	logger          logging.OptimizelyLogProducer
 }
@@ -33,9 +34,9 @@ type CompositeFeatureService struct {
 func NewCompositeFeatureService(sdkKey string, compositeExperimentService ExperimentService) *CompositeFeatureService {
 	holdoutService := NewHoldoutService(sdkKey)
 	return &CompositeFeatureService{
-		logger: logging.GetLogger(sdkKey, "CompositeFeatureService"),
+		holdoutService: holdoutService,
+		logger:         logging.GetLogger(sdkKey, "CompositeFeatureService"),
 		featureServices: []FeatureService{
-			holdoutService,
 			NewFeatureExperimentService(logging.GetLogger(sdkKey, "FeatureExperimentService"), compositeExperimentService, holdoutService),
 			NewRolloutService(sdkKey),
 		},
@@ -44,8 +45,18 @@ func NewCompositeFeatureService(sdkKey string, compositeExperimentService Experi
 
 // GetDecision returns a decision for the given feature and user context
 func (f CompositeFeatureService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
-	var featureDecision = FeatureDecision{}
 	reasons := decide.NewDecisionReasons(options)
+
+	// Evaluate global holdouts first, before any rule-level services
+	if f.holdoutService != nil {
+		holdoutDecision, holdoutReasons, _ := f.holdoutService.GetGlobalDecision(decisionContext, userContext, options)
+		reasons.Append(holdoutReasons)
+		if holdoutDecision.Variation != nil {
+			return holdoutDecision, reasons, nil
+		}
+	}
+
+	var featureDecision FeatureDecision
 	var err error
 	for _, featureDecisionService := range f.featureServices {
 		var decisionReasons decide.DecisionReasons

--- a/pkg/decision/composite_feature_service.go
+++ b/pkg/decision/composite_feature_service.go
@@ -31,11 +31,12 @@ type CompositeFeatureService struct {
 
 // NewCompositeFeatureService returns a new instance of the CompositeFeatureService
 func NewCompositeFeatureService(sdkKey string, compositeExperimentService ExperimentService) *CompositeFeatureService {
+	holdoutService := NewHoldoutService(sdkKey)
 	return &CompositeFeatureService{
 		logger: logging.GetLogger(sdkKey, "CompositeFeatureService"),
 		featureServices: []FeatureService{
-			NewHoldoutService(sdkKey),
-			NewFeatureExperimentService(logging.GetLogger(sdkKey, "FeatureExperimentService"), compositeExperimentService),
+			holdoutService,
+			NewFeatureExperimentService(logging.GetLogger(sdkKey, "FeatureExperimentService"), compositeExperimentService, holdoutService),
 			NewRolloutService(sdkKey),
 		},
 	}

--- a/pkg/decision/composite_feature_service_test.go
+++ b/pkg/decision/composite_feature_service_test.go
@@ -202,10 +202,10 @@ func (s *CompositeFeatureServiceTestSuite) TestNewCompositeFeatureService() {
 	// Assert that the service is instantiated with the correct child services in the right order
 	compositeExperimentService := NewCompositeExperimentService("")
 	compositeFeatureService := NewCompositeFeatureService("", compositeExperimentService)
-	s.Equal(3, len(compositeFeatureService.featureServices))
-	s.IsType(&HoldoutService{}, compositeFeatureService.featureServices[0])
-	s.IsType(&FeatureExperimentService{compositeExperimentService: compositeExperimentService}, compositeFeatureService.featureServices[1])
-	s.IsType(&RolloutService{}, compositeFeatureService.featureServices[2])
+	s.NotNil(compositeFeatureService.holdoutService)
+	s.Equal(2, len(compositeFeatureService.featureServices))
+	s.IsType(&FeatureExperimentService{compositeExperimentService: compositeExperimentService}, compositeFeatureService.featureServices[0])
+	s.IsType(&RolloutService{}, compositeFeatureService.featureServices[1])
 }
 
 func TestCompositeFeatureTestSuite(t *testing.T) {

--- a/pkg/decision/evaluator/audience_evaluator_test.go
+++ b/pkg/decision/evaluator/audience_evaluator_test.go
@@ -205,6 +205,16 @@ func (m *MockProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Hol
 	return args.Get(0).([]entities.Holdout)
 }
 
+func (m *MockProjectConfig) GetGlobalHoldouts() []entities.Holdout {
+	args := m.Called()
+	return args.Get(0).([]entities.Holdout)
+}
+
+func (m *MockProjectConfig) GetHoldoutsForRule(ruleID string) []entities.Holdout {
+	args := m.Called(ruleID)
+	return args.Get(0).([]entities.Holdout)
+}
+
 // MockLogger is a mock implementation of OptimizelyLogProducer
 // (This declaration has been removed to resolve the redeclaration error)
 

--- a/pkg/decision/evaluator/audience_evaluator_test.go
+++ b/pkg/decision/evaluator/audience_evaluator_test.go
@@ -200,11 +200,6 @@ func (m *MockProjectConfig) GetRegion() string {
 	return args.String(0)
 }
 
-func (m *MockProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Holdout {
-	args := m.Called(featureKey)
-	return args.Get(0).([]entities.Holdout)
-}
-
 func (m *MockProjectConfig) GetGlobalHoldouts() []entities.Holdout {
 	args := m.Called()
 	return args.Get(0).([]entities.Holdout)

--- a/pkg/decision/feature_experiment_service.go
+++ b/pkg/decision/feature_experiment_service.go
@@ -28,14 +28,16 @@ import (
 // FeatureExperimentService helps evaluate feature test associated with the feature
 type FeatureExperimentService struct {
 	compositeExperimentService ExperimentService
+	holdoutService             *HoldoutService
 	logger                     logging.OptimizelyLogProducer
 }
 
 // NewFeatureExperimentService returns a new instance of the FeatureExperimentService
-func NewFeatureExperimentService(logger logging.OptimizelyLogProducer, compositeExperimentService ExperimentService) *FeatureExperimentService {
+func NewFeatureExperimentService(logger logging.OptimizelyLogProducer, compositeExperimentService ExperimentService, holdoutService *HoldoutService) *FeatureExperimentService {
 	return &FeatureExperimentService{
 		logger:                     logger,
 		compositeExperimentService: compositeExperimentService,
+		holdoutService:             holdoutService,
 	}
 }
 
@@ -57,6 +59,17 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 					Source:     FeatureTest,
 				}
 				return featureDecision, reasons, nil
+			}
+		}
+
+		// [FSSDK-12369] Check local holdouts targeting this experiment rule.
+		// Local holdouts are evaluated after forced decisions but before audience/traffic checks.
+		if f.holdoutService != nil {
+			holdoutDecision, holdoutReasons, _ := f.holdoutService.GetDecisionForRule(featureExperiment.ID, decisionContext.ProjectConfig, userContext, options)
+			reasons.Append(holdoutReasons)
+			if holdoutDecision.Variation != nil {
+				// User is in a local holdout — return holdout decision, skip rule evaluation
+				return holdoutDecision, reasons, nil
 			}
 		}
 

--- a/pkg/decision/feature_experiment_service.go
+++ b/pkg/decision/feature_experiment_service.go
@@ -65,7 +65,7 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		// [FSSDK-12369] Check local holdouts targeting this experiment rule.
 		// Local holdouts are evaluated after forced decisions but before audience/traffic checks.
 		if f.holdoutService != nil {
-			holdoutDecision, holdoutReasons, _ := f.holdoutService.GetDecisionForRule(featureExperiment.ID, decisionContext.ProjectConfig, userContext, options)
+			holdoutDecision, holdoutReasons, _ := f.holdoutService.GetLocalDecisionForRule(featureExperiment.ID, decisionContext.ProjectConfig, userContext, options)
 			reasons.Append(holdoutReasons)
 			if holdoutDecision.Variation != nil {
 				// User is in a local holdout — return holdout decision, skip rule evaluation

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -174,8 +174,10 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionMutex() {
 
 func (s *FeatureExperimentServiceTestSuite) TestNewFeatureExperimentService() {
 	compositeExperimentService := &CompositeExperimentService{logger: logging.GetLogger("sdkKey", "CompositeExperimentService")}
-	featureExperimentService := NewFeatureExperimentService(logging.GetLogger("", ""), compositeExperimentService)
+	holdoutService := NewHoldoutService("sdkKey")
+	featureExperimentService := NewFeatureExperimentService(logging.GetLogger("", ""), compositeExperimentService, holdoutService)
 	s.IsType(compositeExperimentService, featureExperimentService.compositeExperimentService)
+	s.NotNil(featureExperimentService.holdoutService)
 }
 
 func (s *FeatureExperimentServiceTestSuite) TestGetDecisionWithCmabUUID() {

--- a/pkg/decision/feature_experiment_service_test.go
+++ b/pkg/decision/feature_experiment_service_test.go
@@ -297,6 +297,44 @@ func (s *FeatureExperimentServiceTestSuite) TestGetDecisionWithCmabError() {
 	s.mockExperimentService.AssertExpectations(s.T())
 }
 
+// TestForcedDecisionBeats100PercentLocalHoldout verifies the mandatory ordering:
+// forced decisions must take priority over local holdouts even when the holdout
+// has 100% traffic. This is the critical FD → HO ordering enforcement test.
+func (s *FeatureExperimentServiceTestSuite) TestForcedDecisionBeats100PercentLocalHoldout() {
+	testUserContext := entities.UserContext{
+		ID: "test_user_1",
+	}
+
+	expectedVariation := testExp1113.Variations["2223"]
+	flagVariationsMap := map[string][]entities.Variation{
+		s.testFeatureDecisionContext.Feature.Key: {expectedVariation},
+	}
+	s.mockConfig.On("GetFlagVariationsMap").Return(flagVariationsMap)
+	s.testFeatureDecisionContext.ForcedDecisionService.SetForcedDecision(
+		OptimizelyDecisionContext{FlagKey: s.testFeatureDecisionContext.Feature.Key, RuleKey: testExp1113Key},
+		OptimizelyForcedDecision{VariationKey: expectedVariation.Key},
+	)
+
+	// holdoutService has 100% traffic — would always bucket if reached
+	// GetHoldoutsForRule must NOT be called since FD wins first
+	featureExperimentService := &FeatureExperimentService{
+		compositeExperimentService: s.mockExperimentService,
+		holdoutService:             NewHoldoutService("test_sdk_key"),
+		logger:                     logging.GetLogger("sdkKey", "FeatureExperimentService"),
+	}
+
+	decision, _, err := featureExperimentService.GetDecision(s.testFeatureDecisionContext, testUserContext, s.options)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Equal(expectedVariation.Key, decision.Variation.Key)
+	s.Equal(FeatureTest, decision.Source)
+	// compositeExperimentService must not be called — FD returned before reaching it
+	s.mockExperimentService.AssertNotCalled(s.T(), "GetDecision")
+	// GetHoldoutsForRule must not be called — FD wins before local HO check
+	s.mockConfig.AssertNotCalled(s.T(), "GetHoldoutsForRule")
+}
+
 func TestFeatureExperimentServiceTestSuite(t *testing.T) {
 	suite.Run(t, new(FeatureExperimentServiceTestSuite))
 }

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -59,11 +59,6 @@ func (c *mockProjectConfig) GetFlagVariationsMap() map[string][]entities.Variati
 	return args.Get(0).(map[string][]entities.Variation)
 }
 
-func (c *mockProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Holdout {
-	args := c.Called(featureKey)
-	return args.Get(0).([]entities.Holdout)
-}
-
 func (c *mockProjectConfig) GetGlobalHoldouts() []entities.Holdout {
 	args := c.Called()
 	return args.Get(0).([]entities.Holdout)

--- a/pkg/decision/helpers_test.go
+++ b/pkg/decision/helpers_test.go
@@ -64,6 +64,16 @@ func (c *mockProjectConfig) GetHoldoutsForFlag(featureKey string) []entities.Hol
 	return args.Get(0).([]entities.Holdout)
 }
 
+func (c *mockProjectConfig) GetGlobalHoldouts() []entities.Holdout {
+	args := c.Called()
+	return args.Get(0).([]entities.Holdout)
+}
+
+func (c *mockProjectConfig) GetHoldoutsForRule(ruleID string) []entities.Holdout {
+	args := c.Called(ruleID)
+	return args.Get(0).([]entities.Holdout)
+}
+
 type MockExperimentDecisionService struct {
 	mock.Mock
 }

--- a/pkg/decision/holdout_service.go
+++ b/pkg/decision/holdout_service.go
@@ -45,12 +45,13 @@ func NewHoldoutService(sdkKey string) *HoldoutService {
 	}
 }
 
-// GetDecision returns a decision for holdouts associated with the feature
-func (h HoldoutService) GetDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
+// GetGlobalDecision returns a decision for global holdouts associated with the feature.
+// Global holdouts (IncludedRules == nil) apply at flag level before any rule evaluation.
+func (h HoldoutService) GetGlobalDecision(decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
 	feature := decisionContext.Feature
 	reasons := decide.NewDecisionReasons(options)
 
-	holdouts := decisionContext.ProjectConfig.GetHoldoutsForFlag(feature.Key)
+	holdouts := decisionContext.ProjectConfig.GetGlobalHoldouts()
 
 	for i := range holdouts {
 		holdout := &holdouts[i]
@@ -120,10 +121,10 @@ func (h HoldoutService) GetDecision(decisionContext FeatureDecisionContext, user
 	return FeatureDecision{}, reasons, nil
 }
 
-// GetDecisionForRule evaluates local holdouts targeting the given rule ID.
+// GetLocalDecisionForRule evaluates local holdouts targeting the given rule ID.
 // It returns a non-empty FeatureDecision if the user is bucketed into a local holdout for this rule.
 // Local holdouts are evaluated per-rule, after forced decisions, before audience/traffic checks.
-func (h HoldoutService) GetDecisionForRule(ruleID string, projectConfig config.ProjectConfig, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
+func (h HoldoutService) GetLocalDecisionForRule(ruleID string, projectConfig config.ProjectConfig, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
 	reasons := decide.NewDecisionReasons(options)
 
 	holdouts := projectConfig.GetHoldoutsForRule(ruleID)

--- a/pkg/decision/holdout_service.go
+++ b/pkg/decision/holdout_service.go
@@ -120,6 +120,78 @@ func (h HoldoutService) GetDecision(decisionContext FeatureDecisionContext, user
 	return FeatureDecision{}, reasons, nil
 }
 
+// GetDecisionForRule evaluates local holdouts targeting the given rule ID.
+// It returns a non-empty FeatureDecision if the user is bucketed into a local holdout for this rule.
+// Local holdouts are evaluated per-rule, after forced decisions, before audience/traffic checks.
+func (h HoldoutService) GetDecisionForRule(ruleID string, projectConfig config.ProjectConfig, userContext entities.UserContext, options *decide.Options) (FeatureDecision, decide.DecisionReasons, error) {
+	reasons := decide.NewDecisionReasons(options)
+
+	holdouts := projectConfig.GetHoldoutsForRule(ruleID)
+
+	for i := range holdouts {
+		holdout := &holdouts[i]
+		h.logger.Debug(fmt.Sprintf("Evaluating local holdout %s for rule %s", holdout.Key, ruleID))
+
+		// Check if holdout is running
+		if holdout.Status != entities.HoldoutStatusRunning {
+			reason := reasons.AddInfo("Local holdout %s is not running.", holdout.Key)
+			h.logger.Info(reason)
+			continue
+		}
+
+		// Check audience conditions
+		inAudience := h.checkIfUserInHoldoutAudience(holdout, userContext, projectConfig, options)
+		reasons.Append(inAudience.reasons)
+
+		if !inAudience.result {
+			reason := reasons.AddInfo("User %s does not meet conditions for local holdout %s.", userContext.ID, holdout.Key)
+			h.logger.Info(reason)
+			continue
+		}
+
+		reason := reasons.AddInfo("User %s meets conditions for local holdout %s.", userContext.ID, holdout.Key)
+		h.logger.Info(reason)
+
+		// Get bucketing ID
+		bucketingID, err := userContext.GetBucketingID()
+		if err != nil {
+			errorMessage := reasons.AddInfo("Error computing bucketing ID for local holdout %q: %q", holdout.Key, err.Error())
+			h.logger.Debug(errorMessage)
+		}
+
+		// Convert holdout to experiment structure for bucketing
+		experimentForBucketing := entities.Experiment{
+			ID:                    holdout.ID,
+			Key:                   holdout.Key,
+			Variations:            holdout.Variations,
+			TrafficAllocation:     holdout.TrafficAllocation,
+			AudienceIds:           holdout.AudienceIds,
+			AudienceConditions:    holdout.AudienceConditions,
+			AudienceConditionTree: holdout.AudienceConditionTree,
+		}
+
+		// Bucket user into holdout variation
+		variation, _, _ := h.bucketer.Bucket(bucketingID, experimentForBucketing, entities.Group{})
+
+		if variation != nil {
+			reason = reasons.AddInfo("User %s is in variation %s of local holdout %s for rule %s.", userContext.ID, variation.Key, holdout.Key, ruleID)
+			h.logger.Info(reason)
+
+			featureDecision := FeatureDecision{
+				Experiment: experimentForBucketing,
+				Variation:  variation,
+				Source:     Holdout,
+			}
+			return featureDecision, reasons, nil
+		}
+
+		reason = reasons.AddInfo("User %s is not bucketed into local holdout %s for rule %s.", userContext.ID, holdout.Key, ruleID)
+		h.logger.Info(reason)
+	}
+
+	return FeatureDecision{}, reasons, nil
+}
+
 // checkIfUserInHoldoutAudience evaluates if user meets holdout audience conditions
 func (h HoldoutService) checkIfUserInHoldoutAudience(holdout *entities.Holdout, userContext entities.UserContext, projectConfig config.ProjectConfig, options *decide.Options) decisionResult {
 	decisionReasons := decide.NewDecisionReasons(options)

--- a/pkg/decision/holdout_service_test.go
+++ b/pkg/decision/holdout_service_test.go
@@ -408,3 +408,210 @@ func TestHoldoutServiceIntegration(t *testing.T) {
 	assert.Equal(t, holdoutVar.ID, decision.Variation.ID)
 	assert.Equal(t, Holdout, decision.Source)
 }
+
+// Level 2 — GetDecisionForRule (local holdout decision service) tests (FSSDK-12369)
+
+// TestGetDecisionForRuleNoLocalHoldouts verifies that when there are no local holdouts for a rule,
+// the function returns an empty decision (the rule is evaluated normally).
+func TestGetDecisionForRuleNoLocalHoldouts(t *testing.T) {
+	mockConfig := new(mockProjectConfig)
+	mockBucketer := new(MockExperimentBucketer)
+	mockAudienceEval := new(MockAudienceTreeEvaluator)
+	mockLogger := new(MockLogger)
+
+	mockConfig.On("GetHoldoutsForRule", "rule_id_1").Return([]entities.Holdout{})
+
+	service := HoldoutService{
+		audienceTreeEvaluator: mockAudienceEval,
+		bucketer:              mockBucketer,
+		logger:                mockLogger,
+	}
+
+	userCtx := entities.UserContext{ID: "test_user"}
+	options := &decide.Options{}
+
+	decision, _, err := service.GetDecisionForRule("rule_id_1", mockConfig, userCtx, options)
+
+	assert.NoError(t, err)
+	assert.Nil(t, decision.Variation, "No local holdouts means no holdout decision")
+	mockConfig.AssertExpectations(t)
+}
+
+// TestGetDecisionForRuleUserBucketedIntoLocalHoldout verifies that when a user is bucketed into a
+// local holdout for a specific rule, the holdout variation is returned and rule evaluation is skipped.
+func TestGetDecisionForRuleUserBucketedIntoLocalHoldout(t *testing.T) {
+	mockConfig := new(mockProjectConfig)
+	mockBucketer := new(MockExperimentBucketer)
+	mockAudienceEval := new(MockAudienceTreeEvaluator)
+	mockLogger := new(MockLogger)
+
+	localHoldoutVar := entities.Variation{ID: "local_var_1", Key: "local_variation_1"}
+	localHoldout := entities.Holdout{
+		ID:     "local_holdout_1",
+		Key:    "test_local_holdout",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"local_var_1": localHoldoutVar,
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "local_var_1", EndOfRange: 10000}, // 100% traffic
+		},
+	}
+
+	mockConfig.On("GetHoldoutsForRule", "rule_x").Return([]entities.Holdout{localHoldout})
+	mockBucketer.On("Bucket", "test_user", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(&localHoldoutVar, reasons.Reason(""), nil)
+	mockLogger.On("Debug", mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything).Return()
+
+	service := HoldoutService{
+		audienceTreeEvaluator: mockAudienceEval,
+		bucketer:              mockBucketer,
+		logger:                mockLogger,
+	}
+
+	userCtx := entities.UserContext{ID: "test_user"}
+	options := &decide.Options{}
+
+	decision, _, err := service.GetDecisionForRule("rule_x", mockConfig, userCtx, options)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, decision.Variation, "User bucketed into local holdout should return holdout variation")
+	assert.Equal(t, localHoldoutVar.ID, decision.Variation.ID)
+	assert.Equal(t, Holdout, decision.Source)
+	mockConfig.AssertExpectations(t)
+	mockBucketer.AssertExpectations(t)
+}
+
+// TestGetDecisionForRuleUserMissesLocalHoldout verifies that when a user is NOT bucketed into a
+// local holdout, an empty decision is returned so that regular rule evaluation proceeds.
+func TestGetDecisionForRuleUserMissesLocalHoldout(t *testing.T) {
+	mockConfig := new(mockProjectConfig)
+	mockBucketer := new(MockExperimentBucketer)
+	mockAudienceEval := new(MockAudienceTreeEvaluator)
+	mockLogger := new(MockLogger)
+
+	localHoldout := entities.Holdout{
+		ID:     "local_holdout_miss",
+		Key:    "test_local_holdout_miss",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"local_var_1": {ID: "local_var_1", Key: "local_variation_1"},
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "local_var_1", EndOfRange: 0}, // 0% traffic — no user will bucket in
+		},
+	}
+
+	mockConfig.On("GetHoldoutsForRule", "rule_y").Return([]entities.Holdout{localHoldout})
+	// Bucketer returns nil (user not bucketed)
+	mockBucketer.On("Bucket", "test_user_miss", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(nil, reasons.Reason(""), nil)
+	mockLogger.On("Debug", mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything).Return()
+
+	service := HoldoutService{
+		audienceTreeEvaluator: mockAudienceEval,
+		bucketer:              mockBucketer,
+		logger:                mockLogger,
+	}
+
+	userCtx := entities.UserContext{ID: "test_user_miss"}
+	options := &decide.Options{}
+
+	decision, _, err := service.GetDecisionForRule("rule_y", mockConfig, userCtx, options)
+
+	assert.NoError(t, err)
+	assert.Nil(t, decision.Variation, "User not bucketed into local holdout should fall through to regular evaluation")
+	mockConfig.AssertExpectations(t)
+	mockBucketer.AssertExpectations(t)
+}
+
+// TestGetDecisionForRuleRuleSpecificity verifies that a local holdout targeting rule X
+// does NOT affect rule Y.
+func TestGetDecisionForRuleRuleSpecificity(t *testing.T) {
+	mockConfig := new(mockProjectConfig)
+	mockBucketer := new(MockExperimentBucketer)
+	mockAudienceEval := new(MockAudienceTreeEvaluator)
+	mockLogger := new(MockLogger)
+
+	localHoldoutVar := entities.Variation{ID: "local_var_1", Key: "local_variation_1"}
+	localHoldout := entities.Holdout{
+		ID:     "local_holdout_for_rule_x",
+		Key:    "holdout_for_rule_x",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"local_var_1": localHoldoutVar,
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "local_var_1", EndOfRange: 10000}, // 100% traffic
+		},
+	}
+
+	// rule_x has the holdout; rule_y has none
+	mockConfig.On("GetHoldoutsForRule", "rule_x").Return([]entities.Holdout{localHoldout})
+	mockConfig.On("GetHoldoutsForRule", "rule_y").Return([]entities.Holdout{})
+	mockConfig.On("GetAudienceMap").Return(map[string]entities.Audience{})
+	mockBucketer.On("Bucket", "test_user", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(&localHoldoutVar, reasons.Reason(""), nil)
+	mockLogger.On("Debug", mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything).Return()
+
+	service := HoldoutService{
+		audienceTreeEvaluator: mockAudienceEval,
+		bucketer:              mockBucketer,
+		logger:                mockLogger,
+	}
+
+	userCtx := entities.UserContext{ID: "test_user"}
+	options := &decide.Options{}
+
+	// rule_x: user should be in holdout
+	decisionX, _, errX := service.GetDecisionForRule("rule_x", mockConfig, userCtx, options)
+	assert.NoError(t, errX)
+	assert.NotNil(t, decisionX.Variation, "Local holdout for rule_x must apply to rule_x")
+
+	// rule_y: user should NOT be in any holdout (holdout doesn't target rule_y)
+	decisionY, _, errY := service.GetDecisionForRule("rule_y", mockConfig, userCtx, options)
+	assert.NoError(t, errY)
+	assert.Nil(t, decisionY.Variation, "Local holdout for rule_x must NOT apply to rule_y")
+}
+
+// TestGetDecisionForRuleLocalHoldoutSkippedIfNotRunning verifies that a non-running local holdout
+// is skipped and no holdout decision is returned.
+func TestGetDecisionForRuleLocalHoldoutSkippedIfNotRunning(t *testing.T) {
+	mockConfig := new(mockProjectConfig)
+	mockBucketer := new(MockExperimentBucketer)
+	mockAudienceEval := new(MockAudienceTreeEvaluator)
+	mockLogger := new(MockLogger)
+
+	pausedLocalHoldout := entities.Holdout{
+		ID:     "paused_local_holdout",
+		Key:    "paused_holdout",
+		Status: entities.HoldoutStatus("Paused"), // not running
+		Variations: map[string]entities.Variation{
+			"var_1": {ID: "var_1", Key: "variation_1"},
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "var_1", EndOfRange: 10000},
+		},
+	}
+
+	mockConfig.On("GetHoldoutsForRule", "rule_z").Return([]entities.Holdout{pausedLocalHoldout})
+	mockConfig.On("GetAudienceMap").Return(map[string]entities.Audience{})
+	mockLogger.On("Debug", mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything).Return()
+
+	service := HoldoutService{
+		audienceTreeEvaluator: mockAudienceEval,
+		bucketer:              mockBucketer,
+		logger:                mockLogger,
+	}
+
+	userCtx := entities.UserContext{ID: "test_user"}
+	options := &decide.Options{}
+
+	decision, _, err := service.GetDecisionForRule("rule_z", mockConfig, userCtx, options)
+
+	assert.NoError(t, err)
+	assert.Nil(t, decision.Variation, "Non-running local holdout should be skipped")
+	// Bucketer should never be called for a non-running holdout
+	mockBucketer.AssertNotCalled(t, "Bucket")
+}

--- a/pkg/decision/holdout_service_test.go
+++ b/pkg/decision/holdout_service_test.go
@@ -121,7 +121,7 @@ func (s *HoldoutServiceTestSuite) SetupTest() {
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionWithNoHoldouts() {
 	// Setup: No holdouts for the feature
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{})
 
 	testHoldoutService := HoldoutService{
 		audienceTreeEvaluator: s.mockAudienceTreeEvaluator,
@@ -129,7 +129,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionWithNoHoldouts() {
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(FeatureDecision{}, decision)
@@ -137,7 +137,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionWithNoHoldouts() {
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionWithHoldoutNotRunning() {
 	// Setup: Holdout exists but is not running
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{testHoldout3NotRunning})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{testHoldout3NotRunning})
 	s.mockLogger.On("Debug", mock.Anything).Return()
 	s.mockLogger.On("Info", mock.MatchedBy(func(msg string) bool {
 		return true // Accept any info log message
@@ -149,7 +149,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionWithHoldoutNotRunning() {
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(FeatureDecision{}, decision)
@@ -157,7 +157,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionWithHoldoutNotRunning() {
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionUserNotInAudience() {
 	// Setup: User doesn't meet audience conditions
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{testHoldout1})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{testHoldout1})
 	s.mockAudienceTreeEvaluator.On("Evaluate", testHoldout1.AudienceConditionTree, mock.Anything, s.options).Return(false, true, s.decisionReasons)
 	s.mockLogger.On("Debug", mock.Anything).Return()
 	s.mockLogger.On("Info", mock.Anything).Return()
@@ -168,7 +168,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionUserNotInAudience() {
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(FeatureDecision{}, decision)
@@ -177,7 +177,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionUserNotInAudience() {
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionUserInAudienceButNotBucketed() {
 	// Setup: User meets audience conditions but doesn't get bucketed into a variation
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{testHoldout1})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{testHoldout1})
 	s.mockAudienceTreeEvaluator.On("Evaluate", testHoldout1.AudienceConditionTree, mock.Anything, s.options).Return(true, true, s.decisionReasons)
 	s.mockBucketer.On("Bucket", "test_user_holdout", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(nil, reasons.Reason(""), nil)
 	s.mockLogger.On("Debug", mock.Anything).Return()
@@ -189,7 +189,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionUserInAudienceButNotBucketed() 
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.Equal(FeatureDecision{}, decision)
@@ -199,7 +199,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionUserInAudienceButNotBucketed() 
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionHappyPath() {
 	// Setup: User meets audience conditions and gets bucketed into a variation
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{testHoldout1})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{testHoldout1})
 	s.mockAudienceTreeEvaluator.On("Evaluate", testHoldout1.AudienceConditionTree, mock.Anything, s.options).Return(true, true, s.decisionReasons)
 	s.mockBucketer.On("Bucket", "test_user_holdout", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(&testHoldoutVar1, reasons.Reason(""), nil)
 	s.mockLogger.On("Debug", mock.Anything).Return()
@@ -211,7 +211,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionHappyPath() {
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.NotNil(decision.Variation)
@@ -223,7 +223,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionHappyPath() {
 
 func (s *HoldoutServiceTestSuite) TestGetDecisionNoAudienceTargeting() {
 	// Setup: Holdout with no audience targeting (applies to everyone)
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return([]entities.Holdout{testHoldout2NoAudience})
+	s.mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{testHoldout2NoAudience})
 	s.mockBucketer.On("Bucket", "test_user_holdout", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(&testHoldoutVar1, reasons.Reason(""), nil)
 	s.mockLogger.On("Debug", mock.Anything).Return()
 	s.mockLogger.On("Info", mock.Anything).Return()
@@ -234,7 +234,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionNoAudienceTargeting() {
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.NotNil(decision.Variation)
@@ -246,7 +246,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionNoAudienceTargeting() {
 func (s *HoldoutServiceTestSuite) TestGetDecisionMultipleHoldoutsFirstMatches() {
 	// Setup: Multiple holdouts, first one matches
 	holdouts := []entities.Holdout{testHoldout1, testHoldout2NoAudience}
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return(holdouts)
+	s.mockConfig.On("GetGlobalHoldouts").Return(holdouts)
 	s.mockAudienceTreeEvaluator.On("Evaluate", testHoldout1.AudienceConditionTree, mock.Anything, s.options).Return(true, true, s.decisionReasons)
 	s.mockBucketer.On("Bucket", "test_user_holdout", mock.AnythingOfType("entities.Experiment"), entities.Group{}).Return(&testHoldoutVar1, reasons.Reason(""), nil)
 	s.mockLogger.On("Debug", mock.Anything).Return()
@@ -258,7 +258,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionMultipleHoldoutsFirstMatches() 
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.NotNil(decision.Variation)
@@ -271,7 +271,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionMultipleHoldoutsFirstMatches() 
 func (s *HoldoutServiceTestSuite) TestGetDecisionMultipleHoldoutsSecondMatches() {
 	// Setup: Multiple holdouts, first doesn't match, second does
 	holdouts := []entities.Holdout{testHoldout1, testHoldout2NoAudience}
-	s.mockConfig.On("GetHoldoutsForFlag", "test_feature_with_holdout").Return(holdouts)
+	s.mockConfig.On("GetGlobalHoldouts").Return(holdouts)
 	// First holdout: user not in audience
 	s.mockAudienceTreeEvaluator.On("Evaluate", testHoldout1.AudienceConditionTree, mock.Anything, s.options).Return(false, true, s.decisionReasons)
 	// Second holdout: no audience, user gets bucketed
@@ -285,7 +285,7 @@ func (s *HoldoutServiceTestSuite) TestGetDecisionMultipleHoldoutsSecondMatches()
 		logger:                s.mockLogger,
 	}
 
-	decision, _, err := testHoldoutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+	decision, _, err := testHoldoutService.GetGlobalDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
 
 	s.NoError(err)
 	s.NotNil(decision.Variation)
@@ -380,7 +380,7 @@ func TestHoldoutServiceIntegration(t *testing.T) {
 
 	// Create mock config
 	mockConfig := new(mockProjectConfig)
-	mockConfig.On("GetHoldoutsForFlag", "test_feature").Return([]entities.Holdout{holdout})
+	mockConfig.On("GetGlobalHoldouts").Return([]entities.Holdout{holdout})
 	mockConfig.On("GetAudienceMap").Return(map[string]entities.Audience{})
 
 	feature := entities.Feature{
@@ -400,7 +400,7 @@ func TestHoldoutServiceIntegration(t *testing.T) {
 	options := &decide.Options{}
 
 	// Execute decision
-	decision, _, err := service.GetDecision(decisionContext, userContext, options)
+	decision, _, err := service.GetGlobalDecision(decisionContext, userContext, options)
 
 	// Verify
 	assert.NoError(t, err)
@@ -409,7 +409,7 @@ func TestHoldoutServiceIntegration(t *testing.T) {
 	assert.Equal(t, Holdout, decision.Source)
 }
 
-// Level 2 — GetDecisionForRule (local holdout decision service) tests (FSSDK-12369)
+// Level 2 — GetLocalDecisionForRule (local holdout decision service) tests (FSSDK-12369)
 
 // TestGetDecisionForRuleNoLocalHoldouts verifies that when there are no local holdouts for a rule,
 // the function returns an empty decision (the rule is evaluated normally).
@@ -430,7 +430,7 @@ func TestGetDecisionForRuleNoLocalHoldouts(t *testing.T) {
 	userCtx := entities.UserContext{ID: "test_user"}
 	options := &decide.Options{}
 
-	decision, _, err := service.GetDecisionForRule("rule_id_1", mockConfig, userCtx, options)
+	decision, _, err := service.GetLocalDecisionForRule("rule_id_1", mockConfig, userCtx, options)
 
 	assert.NoError(t, err)
 	assert.Nil(t, decision.Variation, "No local holdouts means no holdout decision")
@@ -472,7 +472,7 @@ func TestGetDecisionForRuleUserBucketedIntoLocalHoldout(t *testing.T) {
 	userCtx := entities.UserContext{ID: "test_user"}
 	options := &decide.Options{}
 
-	decision, _, err := service.GetDecisionForRule("rule_x", mockConfig, userCtx, options)
+	decision, _, err := service.GetLocalDecisionForRule("rule_x", mockConfig, userCtx, options)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, decision.Variation, "User bucketed into local holdout should return holdout variation")
@@ -517,7 +517,7 @@ func TestGetDecisionForRuleUserMissesLocalHoldout(t *testing.T) {
 	userCtx := entities.UserContext{ID: "test_user_miss"}
 	options := &decide.Options{}
 
-	decision, _, err := service.GetDecisionForRule("rule_y", mockConfig, userCtx, options)
+	decision, _, err := service.GetLocalDecisionForRule("rule_y", mockConfig, userCtx, options)
 
 	assert.NoError(t, err)
 	assert.Nil(t, decision.Variation, "User not bucketed into local holdout should fall through to regular evaluation")
@@ -564,12 +564,12 @@ func TestGetDecisionForRuleRuleSpecificity(t *testing.T) {
 	options := &decide.Options{}
 
 	// rule_x: user should be in holdout
-	decisionX, _, errX := service.GetDecisionForRule("rule_x", mockConfig, userCtx, options)
+	decisionX, _, errX := service.GetLocalDecisionForRule("rule_x", mockConfig, userCtx, options)
 	assert.NoError(t, errX)
 	assert.NotNil(t, decisionX.Variation, "Local holdout for rule_x must apply to rule_x")
 
 	// rule_y: user should NOT be in any holdout (holdout doesn't target rule_y)
-	decisionY, _, errY := service.GetDecisionForRule("rule_y", mockConfig, userCtx, options)
+	decisionY, _, errY := service.GetLocalDecisionForRule("rule_y", mockConfig, userCtx, options)
 	assert.NoError(t, errY)
 	assert.Nil(t, decisionY.Variation, "Local holdout for rule_x must NOT apply to rule_y")
 }
@@ -608,7 +608,7 @@ func TestGetDecisionForRuleLocalHoldoutSkippedIfNotRunning(t *testing.T) {
 	userCtx := entities.UserContext{ID: "test_user"}
 	options := &decide.Options{}
 
-	decision, _, err := service.GetDecisionForRule("rule_z", mockConfig, userCtx, options)
+	decision, _, err := service.GetLocalDecisionForRule("rule_z", mockConfig, userCtx, options)
 
 	assert.NoError(t, err)
 	assert.Nil(t, decision.Variation, "Non-running local holdout should be skipped")

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -32,6 +32,7 @@ import (
 type RolloutService struct {
 	audienceTreeEvaluator     evaluator.TreeEvaluator
 	experimentBucketerService ExperimentService
+	holdoutService            *HoldoutService
 	logger                    logging.OptimizelyLogProducer
 }
 
@@ -42,6 +43,7 @@ func NewRolloutService(sdkKey string) *RolloutService {
 		logger:                    logger,
 		audienceTreeEvaluator:     evaluator.NewMixedTreeEvaluator(logger),
 		experimentBucketerService: NewExperimentBucketerService(logging.GetLogger(sdkKey, "ExperimentBucketerService")),
+		holdoutService:            NewHoldoutService(sdkKey),
 	}
 }
 
@@ -98,6 +100,20 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		return nil
 	}
 
+	// checkForLocalHoldout checks if a user is in a local holdout for the given rollout rule.
+	// Returns a FeatureDecision if the user is in a holdout, nil otherwise.
+	checkForLocalHoldout := func(exp *entities.Experiment) *FeatureDecision {
+		if r.holdoutService == nil {
+			return nil
+		}
+		holdoutDecision, holdoutReasons, _ := r.holdoutService.GetDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
+		reasons.Append(holdoutReasons)
+		if holdoutDecision.Variation != nil {
+			return &holdoutDecision
+		}
+		return nil
+	}
+
 	for index := 0; index < numberOfExperiments-1; index++ {
 		loggingKey := strconv.Itoa(index + 1)
 		experiment := &rollout.Experiments[index]
@@ -105,6 +121,12 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		// Checking for forced decision
 		if forcedDecision := checkForForcedDecision(experiment); forcedDecision != nil {
 			return *forcedDecision, reasons, nil
+		}
+
+		// [FSSDK-12369] Check local holdouts targeting this rollout rule.
+		// Local holdouts are evaluated after forced decisions but before audience/traffic checks.
+		if holdoutDecision := checkForLocalHoldout(experiment); holdoutDecision != nil {
+			return *holdoutDecision, reasons, nil
 		}
 
 		experimentDecisionContext := getExperimentDecisionContext(experiment)
@@ -135,6 +157,11 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 	// Checking for forced decision
 	if forcedDecision := checkForForcedDecision(experiment); forcedDecision != nil {
 		return *forcedDecision, reasons, nil
+	}
+
+	// [FSSDK-12369] Check local holdouts for the fallback/everyone else rule
+	if holdoutDecision := checkForLocalHoldout(experiment); holdoutDecision != nil {
+		return *holdoutDecision, reasons, nil
 	}
 
 	experimentDecisionContext := getExperimentDecisionContext(experiment)

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -196,7 +196,7 @@ func (r RolloutService) getLocalHoldoutDecision(exp *entities.Experiment, decisi
 	if r.holdoutService == nil {
 		return nil, reasons
 	}
-	holdoutDecision, holdoutReasons, _ := r.holdoutService.GetDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
+	holdoutDecision, holdoutReasons, _ := r.holdoutService.GetLocalDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
 	reasons.Append(holdoutReasons)
 	if holdoutDecision.Variation != nil {
 		return &holdoutDecision, reasons

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -100,20 +100,6 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 		return nil
 	}
 
-	// checkForLocalHoldout checks if a user is in a local holdout for the given rollout rule.
-	// Returns a FeatureDecision if the user is in a holdout, nil otherwise.
-	checkForLocalHoldout := func(exp *entities.Experiment) *FeatureDecision {
-		if r.holdoutService == nil {
-			return nil
-		}
-		holdoutDecision, holdoutReasons, _ := r.holdoutService.GetDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
-		reasons.Append(holdoutReasons)
-		if holdoutDecision.Variation != nil {
-			return &holdoutDecision
-		}
-		return nil
-	}
-
 	for index := 0; index < numberOfExperiments-1; index++ {
 		loggingKey := strconv.Itoa(index + 1)
 		experiment := &rollout.Experiments[index]
@@ -125,7 +111,8 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 
 		// [FSSDK-12369] Check local holdouts targeting this rollout rule.
 		// Local holdouts are evaluated after forced decisions but before audience/traffic checks.
-		if holdoutDecision := checkForLocalHoldout(experiment); holdoutDecision != nil {
+		if holdoutDecision, holdoutReasons := r.getLocalHoldoutDecision(experiment, decisionContext, userContext, options); holdoutDecision != nil {
+			reasons.Append(holdoutReasons)
 			return *holdoutDecision, reasons, nil
 		}
 
@@ -160,7 +147,8 @@ func (r RolloutService) GetDecision(decisionContext FeatureDecisionContext, user
 	}
 
 	// [FSSDK-12369] Check local holdouts for the fallback/everyone else rule
-	if holdoutDecision := checkForLocalHoldout(experiment); holdoutDecision != nil {
+	if holdoutDecision, holdoutReasons := r.getLocalHoldoutDecision(experiment, decisionContext, userContext, options); holdoutDecision != nil {
+		reasons.Append(holdoutReasons)
 		return *holdoutDecision, reasons, nil
 	}
 
@@ -201,6 +189,19 @@ func (r RolloutService) getFeatureDecision(featureDecision *FeatureDecision, use
 	}
 	r.logger.Debug(fmt.Sprintf(`Decision made for user %q for feature rollout with key %q: %s.`, userContext.ID, feature.Key, featureDecision.Reason))
 	return *featureDecision
+}
+
+func (r RolloutService) getLocalHoldoutDecision(exp *entities.Experiment, decisionContext FeatureDecisionContext, userContext entities.UserContext, options *decide.Options) (*FeatureDecision, decide.DecisionReasons) {
+	reasons := decide.NewDecisionReasons(options)
+	if r.holdoutService == nil {
+		return nil, reasons
+	}
+	holdoutDecision, holdoutReasons, _ := r.holdoutService.GetDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
+	reasons.Append(holdoutReasons)
+	if holdoutDecision.Variation != nil {
+		return &holdoutDecision, reasons
+	}
+	return nil, reasons
 }
 
 func (r RolloutService) getForcedDecision(decisionContext FeatureDecisionContext, experiment entities.Experiment, options *decide.Options) (variation *entities.Variation, reasons decide.DecisionReasons) {

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -381,6 +381,170 @@ func (s *RolloutServiceTestSuite) TestGetDecisionFailsTargeting() {
 	s.mockLogger.AssertExpectations(s.T())
 }
 
+// TestGetDecisionLocalHoldout_RegularRule_UserBucketed verifies that when a user is bucketed
+// into a local holdout targeting a regular rollout rule, the holdout decision is returned
+// immediately — audience and traffic checks for the rule are skipped.
+func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_RegularRule_UserBucketed() {
+	holdoutVar := entities.Variation{ID: "ho_var_1", Key: "holdout_variation"}
+	localHoldout := entities.Holdout{
+		ID:     "local_holdout_rule",
+		Key:    "local_holdout_for_rule",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"ho_var_1": holdoutVar,
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "ho_var_1", EndOfRange: 10000}, // 100% — user always bucketed
+		},
+	}
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{localHoldout})
+	s.mockLogger.On("Debug", mock.Anything).Return()
+	s.mockLogger.On("Info", mock.Anything).Return()
+
+	testRolloutService := RolloutService{
+		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
+		experimentBucketerService: s.mockExperimentService,
+		holdoutService:            NewHoldoutService("test_sdk_key"),
+		logger:                    s.mockLogger,
+	}
+
+	decision, _, err := testRolloutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Equal(Holdout, decision.Source)
+	// Audience and experiment bucketer must not be called — holdout returned early
+	s.mockAudienceTreeEvaluator.AssertNotCalled(s.T(), "Evaluate")
+	s.mockExperimentService.AssertNotCalled(s.T(), "GetDecision")
+}
+
+// TestGetDecisionLocalHoldout_RegularRule_UserMisses verifies that when a user misses a local
+// holdout (not bucketed), rule evaluation proceeds normally through audience and traffic checks.
+func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_RegularRule_UserMisses() {
+	localHoldout := entities.Holdout{
+		ID:     "local_holdout_miss",
+		Key:    "local_holdout_miss_for_rule",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"ho_var_1": {ID: "ho_var_1", Key: "holdout_variation"},
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "ho_var_1", EndOfRange: 0}, // 0% — user never bucketed
+		},
+	}
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{localHoldout})
+	s.mockAudienceTreeEvaluator.On("Evaluate", testExp1112.AudienceConditionTree, s.testConditionTreeParams, mock.Anything).Return(true, true, s.reasons)
+
+	expectedVariation := testExp1112Var2222
+	s.mockExperimentService.On("GetDecision", s.testExperiment1112DecisionContext, s.testUserContext, s.options).Return(ExperimentDecision{
+		Variation: &expectedVariation,
+		Decision:  Decision{Reason: reasons.BucketedIntoVariation},
+	}, s.reasons, nil)
+	s.mockLogger.On("Debug", mock.Anything).Return()
+	s.mockLogger.On("Info", mock.Anything).Return()
+
+	testRolloutService := RolloutService{
+		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
+		experimentBucketerService: s.mockExperimentService,
+		holdoutService:            NewHoldoutService("test_sdk_key"),
+		logger:                    s.mockLogger,
+	}
+
+	decision, _, err := testRolloutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Equal(Rollout, decision.Source)
+	s.Equal(reasons.BucketedIntoRollout, decision.Reason)
+	s.mockExperimentService.AssertExpectations(s.T())
+	s.mockAudienceTreeEvaluator.AssertExpectations(s.T())
+}
+
+// TestGetDecisionLocalHoldout_FallbackRule_UserBucketed verifies that a local holdout
+// targeting the everyone-else (fallback) rule is evaluated and returns a holdout decision
+// when the user is bucketed into it.
+func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_FallbackRule_UserBucketed() {
+	holdoutVar := entities.Variation{ID: "ho_var_1", Key: "holdout_variation"}
+	holdoutMiss := entities.Holdout{
+		ID:     "local_holdout_miss",
+		Key:    "local_holdout_miss",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"ho_var_1": holdoutVar,
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "ho_var_1", EndOfRange: 0}, // 0% — never bucketed
+		},
+	}
+	holdoutHit := entities.Holdout{
+		ID:     "local_holdout_hit",
+		Key:    "local_holdout_hit",
+		Status: entities.HoldoutStatusRunning,
+		Variations: map[string]entities.Variation{
+			"ho_var_1": holdoutVar,
+		},
+		TrafficAllocation: []entities.Range{
+			{EntityID: "ho_var_1", EndOfRange: 10000}, // 100% — always bucketed
+		},
+	}
+
+	// Regular rules miss the holdout; fallback rule hits it
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{holdoutMiss})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1117.ID).Return([]entities.Holdout{holdoutMiss})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1118.ID).Return([]entities.Holdout{holdoutHit})
+
+	// Audience fails for both regular rules so they continue to the next rule
+	s.mockAudienceTreeEvaluator.On("Evaluate", testExp1112.AudienceConditionTree, s.testConditionTreeParams, mock.Anything).Return(false, true, s.reasons)
+	s.mockAudienceTreeEvaluator.On("Evaluate", testExp1117.AudienceConditionTree, s.testConditionTreeParams, mock.Anything).Return(false, true, s.reasons)
+	s.mockLogger.On("Debug", mock.Anything).Return()
+	s.mockLogger.On("Info", mock.Anything).Return()
+
+	testRolloutService := RolloutService{
+		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
+		experimentBucketerService: s.mockExperimentService,
+		holdoutService:            NewHoldoutService("test_sdk_key"),
+		logger:                    s.mockLogger,
+	}
+
+	decision, _, err := testRolloutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Equal(Holdout, decision.Source)
+	s.mockExperimentService.AssertNotCalled(s.T(), "GetDecision")
+	s.mockConfig.AssertExpectations(s.T())
+}
+
+// TestForcedDecisionBeatsLocalHoldout_Rollout verifies that a forced decision takes priority
+// over a local holdout in the rollout path — the mandatory FD → HO ordering.
+func (s *RolloutServiceTestSuite) TestForcedDecisionBeatsLocalHoldout_Rollout() {
+	flagVariationsMap := map[string][]entities.Variation{
+		s.testFeatureDecisionContext.Feature.Key: {testExp1112Var2222},
+	}
+	s.mockConfig.On("GetFlagVariationsMap").Return(flagVariationsMap)
+	s.testFeatureDecisionContext.ForcedDecisionService.SetForcedDecision(
+		OptimizelyDecisionContext{FlagKey: s.testFeatureDecisionContext.Feature.Key, RuleKey: testExp1112.Key},
+		OptimizelyForcedDecision{VariationKey: testExp1112Var2222.Key},
+	)
+	s.mockLogger.On("Debug", mock.Anything).Return()
+
+	testRolloutService := RolloutService{
+		audienceTreeEvaluator:     s.mockAudienceTreeEvaluator,
+		experimentBucketerService: s.mockExperimentService,
+		holdoutService:            NewHoldoutService("test_sdk_key"),
+		logger:                    s.mockLogger,
+	}
+
+	decision, _, err := testRolloutService.GetDecision(s.testFeatureDecisionContext, s.testUserContext, s.options)
+
+	s.NoError(err)
+	s.NotNil(decision.Variation)
+	s.Equal(testExp1112Var2222.Key, decision.Variation.Key)
+	s.Equal(reasons.ForcedDecisionFound, decision.Reason)
+	// GetHoldoutsForRule must not be called — forced decision wins before local HO check
+	s.mockConfig.AssertNotCalled(s.T(), "GetHoldoutsForRule")
+}
+
 func TestNewRolloutService(t *testing.T) {
 	rolloutService := NewRolloutService("")
 	assert.IsType(t, &evaluator.MixedTreeEvaluator{}, rolloutService.audienceTreeEvaluator)

--- a/pkg/entities/experiment.go
+++ b/pkg/entities/experiment.go
@@ -90,4 +90,15 @@ type Holdout struct {
 	Variations            map[string]Variation // keyed by variation ID
 	TrafficAllocation     []Range
 	AudienceConditionTree *TreeNode
+	// IncludedRules is nil for global holdouts (applies to all rules across all flags).
+	// Non-nil for local holdouts (applies only to the specified rule IDs).
+	// An empty non-nil slice means a local holdout that targets no rules.
+	IncludedRules *[]string
+}
+
+// IsGlobal returns true if this holdout is a global holdout (applies to all rules across all flags).
+// A holdout is global when IncludedRules is nil.
+// An empty non-nil IncludedRules slice is NOT global — it is a local holdout that targets no rules.
+func (h *Holdout) IsGlobal() bool {
+	return h.IncludedRules == nil
 }


### PR DESCRIPTION
## Summary
Adds local holdouts support to the Go SDK. Local holdouts allow targeting specific experiment and delivery rules within a flag, while global holdouts continue to apply across all rules in all flags. This introduces a rule-level targeting system using an optional `includedRules` field on the holdout data model.

## Changes
- Added `IncludedRules *[]string` field to the `Holdout` entity with `IsGlobal()` helper method
- Extended `HoldoutConfig` with `GetGlobalHoldouts()` and `GetHoldoutsForRule(ruleID)` APIs and updated the holdout mapper to build the rule-to-holdout index
- Integrated local holdout evaluation per-rule in both `FeatureExperimentService` and `RolloutService`, evaluated after forced decisions and before audience/traffic checks
- Added `GetDecisionForRule` method to `HoldoutService` for local holdout bucketing logic
- Preserved backward compatibility: datafiles without `includedRules` default to global holdout behavior

## Jira Ticket
[FSSDK-12369](https://optimizely-ext.atlassian.net/browse/FSSDK-12369)

[FSSDK-12369]: https://optimizely-ext.atlassian.net/browse/FSSDK-12369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ