### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify events with single identifier

### DIFF
--- a/pkg/odp/event/event_manager.go
+++ b/pkg/odp/event/event_manager.go
@@ -52,7 +52,7 @@ func getRetryInterval(retryCount int) time.Duration {
 type Manager interface {
 	// odpConfig is required here since it can be updated anytime and ticker needs to be aware of latest changes
 	Start(ctx context.Context, odpConfig config.Config)
-	IdentifyUser(apiKey, apiHost, userID string)
+	IdentifyUser(apiKey, apiHost string, identifiers map[string]string)
 	ProcessEvent(apiKey, apiHost string, odpEvent Event) error
 	FlushEvents(apiKey, apiHost string)
 }
@@ -162,16 +162,29 @@ func (bm *BatchEventManager) Start(ctx context.Context, odpConfig config.Config)
 }
 
 // IdentifyUser associates a full-stack userid with an established VUID
-func (bm *BatchEventManager) IdentifyUser(apiKey, apiHost, userID string) {
+func (bm *BatchEventManager) IdentifyUser(apiKey, apiHost string, identifiers map[string]string) {
 	if !bm.IsOdpServiceIntegrated(apiKey, apiHost) {
 		bm.logger.Debug(utils.IdentityOdpNotIntegrated)
 		return
 	}
-	identifiers := map[string]string{utils.OdpFSUserIDKey: userID}
+
+	// Filter out empty identifier values
+	validIdentifiers := make(map[string]string)
+	for k, v := range identifiers {
+		if v != "" {
+			validIdentifiers[k] = v
+		}
+	}
+
+	if len(validIdentifiers) < 2 {
+		bm.logger.Debug("ODP identify event is not dispatched (only one identifier provided).")
+		return
+	}
+
 	odpEvent := Event{
 		Type:        utils.OdpEventType,
 		Action:      utils.OdpActionIdentified,
-		Identifiers: identifiers,
+		Identifiers: validIdentifiers,
 	}
 	_ = bm.ProcessEvent(apiKey, apiHost, odpEvent)
 }

--- a/pkg/odp/event/event_manager.go
+++ b/pkg/odp/event/event_manager.go
@@ -176,6 +176,8 @@ func (bm *BatchEventManager) IdentifyUser(apiKey, apiHost string, identifiers ma
 		}
 	}
 
+	// Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+	// A single identifier has no cross-reference value and generates unnecessary traffic.
 	if len(validIdentifiers) < 2 {
 		bm.logger.Debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).")
 		return

--- a/pkg/odp/event/event_manager.go
+++ b/pkg/odp/event/event_manager.go
@@ -177,7 +177,7 @@ func (bm *BatchEventManager) IdentifyUser(apiKey, apiHost string, identifiers ma
 	}
 
 	if len(validIdentifiers) < 2 {
-		bm.logger.Debug("ODP identify event is not dispatched (only one identifier provided).")
+		bm.logger.Debug("ODP identify event is not dispatched (fewer than 2 valid identifiers).")
 		return
 	}
 

--- a/pkg/odp/event/event_manager_test.go
+++ b/pkg/odp/event/event_manager_test.go
@@ -178,18 +178,19 @@ func (e *EventManagerTestSuite) TestEventsDispatchedWhenFlushIntervalReached() {
 }
 
 func (e *EventManagerTestSuite) TestIdentifyUserWhenODPNotIntegrated() {
-	e.eventManager.IdentifyUser("", "1", "123")
+	identifiers := map[string]string{utils.OdpFSUserIDKey: "123", "vuid": "vuid-123"}
+	e.eventManager.IdentifyUser("", "1", identifiers)
 	e.Nil(e.eventManager.ticker)
 	e.Equal(0, e.eventAPIManager.timesSendEventsCalled)
 }
 
-func (e *EventManagerTestSuite) TestIdentifyUserWhenODPIntegrated() {
-	userID := "123"
-	expectedEvent := Event{Identifiers: map[string]string{utils.OdpFSUserIDKey: userID}, Type: utils.OdpEventType, Action: utils.OdpActionIdentified}
+func (e *EventManagerTestSuite) TestIdentifyUserWhenODPIntegratedWithTwoIdentifiers() {
+	identifiers := map[string]string{utils.OdpFSUserIDKey: "123", "vuid": "vuid-456"}
+	expectedEvent := Event{Identifiers: identifiers, Type: utils.OdpEventType, Action: utils.OdpActionIdentified}
 	e.eventManager.addCommonData(&expectedEvent)
 	e.eventAPIManager.wg.Add(1)
 	e.eventManager.batchSize = 1
-	e.eventManager.IdentifyUser("1", "2", userID)
+	e.eventManager.IdentifyUser("1", "2", identifiers)
 	e.eventAPIManager.wg.Wait()
 	e.Equal(1, e.eventAPIManager.timesSendEventsCalled)
 
@@ -198,6 +199,20 @@ func (e *EventManagerTestSuite) TestIdentifyUserWhenODPIntegrated() {
 	// Making idempotence_id similar for both for comparison purposes
 	actualEvent.Data["idempotence_id"] = expectedEvent.Data["idempotence_id"]
 	e.Equal(expectedEvent, actualEvent)
+}
+
+func (e *EventManagerTestSuite) TestIdentifyUserSkippedWithSingleIdentifier() {
+	identifiers := map[string]string{utils.OdpFSUserIDKey: "123"}
+	e.eventManager.IdentifyUser("1", "2", identifiers)
+	e.Equal(0, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(0, e.eventManager.eventQueue.Size())
+}
+
+func (e *EventManagerTestSuite) TestIdentifyUserSkippedWithEmptyValues() {
+	identifiers := map[string]string{utils.OdpFSUserIDKey: "123", "vuid": ""}
+	e.eventManager.IdentifyUser("1", "2", identifiers)
+	e.Equal(0, e.eventAPIManager.timesSendEventsCalled)
+	e.Equal(0, e.eventManager.eventQueue.Size())
 }
 
 func (e *EventManagerTestSuite) TestProcessEventWithInvalidODPConfig() {
@@ -442,7 +457,8 @@ func (e *EventManagerTestSuite) TestEventManagerAsyncBehaviour() {
 	eventAPIManager.shouldNotInformWaitgroup = true
 	eg := newExecutionContext()
 	callAllMethods := func(id string) {
-		eventManager.IdentifyUser("-1", "-1", id)
+		identifiers := map[string]string{utils.OdpFSUserIDKey: id, "vuid": "vuid-" + id}
+		eventManager.IdentifyUser("-1", "-1", identifiers)
 		eventManager.ProcessEvent("-1", "-1", Event{Action: "123"})
 	}
 	for i := 0; i < iterations; i++ {

--- a/pkg/odp/odp_manager.go
+++ b/pkg/odp/odp_manager.go
@@ -40,6 +40,13 @@ type Manager interface {
 	Update(apiKey, apiHost string, segmentsToCheck []string)
 }
 
+// identifyUserIdentifiers builds the identifiers map for an identify event.
+// Server-side SDKs only have fs_user_id (no VUID), so identify events
+// will be skipped by the event manager's count check (requires 2+ identifiers).
+func identifyUserIdentifiers(userID string) map[string]string {
+	return map[string]string{utils.OdpFSUserIDKey: userID}
+}
+
 // DefaultOdpManager represents default implementation of odp manager
 type DefaultOdpManager struct {
 	enabled              bool
@@ -141,7 +148,8 @@ func (om *DefaultOdpManager) IdentifyUser(userID string) {
 		om.logger.Debug(utils.IdentityOdpDisabled)
 		return
 	}
-	om.EventManager.IdentifyUser(om.OdpConfig.GetAPIKey(), om.OdpConfig.GetAPIHost(), userID)
+	identifiers := identifyUserIdentifiers(userID)
+	om.EventManager.IdentifyUser(om.OdpConfig.GetAPIKey(), om.OdpConfig.GetAPIHost(), identifiers)
 }
 
 // SendOdpEvent sends an event to the ODP server.

--- a/pkg/odp/odp_manager_test.go
+++ b/pkg/odp/odp_manager_test.go
@@ -41,8 +41,8 @@ func (m *MockEventManager) Start(ctx context.Context, odpConfig config.Config) {
 	m.Called(ctx, odpConfig)
 }
 
-func (m *MockEventManager) IdentifyUser(apiKey, apiHost, userID string) {
-	m.Called(apiKey, apiHost, userID)
+func (m *MockEventManager) IdentifyUser(apiKey, apiHost string, identifiers map[string]string) {
+	m.Called(apiKey, apiHost, identifiers)
 }
 
 func (m *MockEventManager) ProcessEvent(apiKey, apiHost string, odpEvent event.Event) error {
@@ -192,7 +192,8 @@ func (o *ODPManagerTestSuite) TestFetchQualifiedSegments() {
 func (o *ODPManagerTestSuite) TestIdentifyUser() {
 	o.config.On("GetAPIKey").Return("")
 	o.config.On("GetAPIHost").Return("")
-	o.eventManager.On("IdentifyUser", "", "", o.userID)
+	expectedIdentifiers := map[string]string{utils.OdpFSUserIDKey: o.userID}
+	o.eventManager.On("IdentifyUser", "", "", expectedIdentifiers)
 	o.odpManager.IdentifyUser(o.userID)
 	o.segmentManager.AssertExpectations(o.T())
 }


### PR DESCRIPTION
## Summary

Block ODP identify events when only a single valid identifier is provided. Identify events exist to link multiple user identifiers together; sending them with a single identifier provides no value and wastes network calls.

**Jira:** [FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Changes

### `pkg/odp/event/event_manager.go`
- Changed `IdentifyUser` signature from `(apiKey, apiHost, userID string)` to `(apiKey, apiHost string, identifiers map[string]string)`
- Added filtering of empty identifier values before count check
- Added guard: requires 2+ valid identifiers to dispatch identify event
- Added debug log message when skipping: "ODP identify event is not dispatched (only one identifier provided)."

### `pkg/odp/odp_manager.go`
- Updated `IdentifyUser` to build identifiers map from userID and pass to event manager
- Added `identifyUserIdentifiers` helper function
- Updated `event.Manager` interface to match new signature

### Tests
- Updated existing identify tests to use new map-based signature
- Added `TestIdentifyUserSkippedWithSingleIdentifier` - verifies single identifier blocked
- Added `TestIdentifyUserSkippedWithEmptyValues` - verifies empty values filtered out
- Updated async behavior test to use two identifiers

## Notes
- Go SDK is server-side only (no VUID), so `IdentifyUser` will always have a single `fs_user_id` identifier and identify events will be correctly skipped
- The `OdpManager.Manager` public interface (`IdentifyUser(userID string)`) is unchanged for backward compatibility
- The signature change is internal to the `event.Manager` interface

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ