### PR TITLE
fix: use rule Key instead of ID for local holdout lookup

### DIFF
--- a/pkg/decision/feature_experiment_service.go
+++ b/pkg/decision/feature_experiment_service.go
@@ -65,7 +65,7 @@ func (f FeatureExperimentService) GetDecision(decisionContext FeatureDecisionCon
 		// [FSSDK-12369] Check local holdouts targeting this experiment rule.
 		// Local holdouts are evaluated after forced decisions but before audience/traffic checks.
 		if f.holdoutService != nil {
-			holdoutDecision, holdoutReasons, _ := f.holdoutService.GetLocalDecisionForRule(featureExperiment.ID, decisionContext.ProjectConfig, userContext, options)
+			holdoutDecision, holdoutReasons, _ := f.holdoutService.GetLocalDecisionForRule(featureExperiment.Key, decisionContext.ProjectConfig, userContext, options)
 			reasons.Append(holdoutReasons)
 			if holdoutDecision.Variation != nil {
 				// User is in a local holdout — return holdout decision, skip rule evaluation

--- a/pkg/decision/rollout_service.go
+++ b/pkg/decision/rollout_service.go
@@ -196,7 +196,7 @@ func (r RolloutService) getLocalHoldoutDecision(exp *entities.Experiment, decisi
 	if r.holdoutService == nil {
 		return nil, reasons
 	}
-	holdoutDecision, holdoutReasons, _ := r.holdoutService.GetLocalDecisionForRule(exp.ID, decisionContext.ProjectConfig, userContext, options)
+	holdoutDecision, holdoutReasons, _ := r.holdoutService.GetLocalDecisionForRule(exp.Key, decisionContext.ProjectConfig, userContext, options)
 	reasons.Append(holdoutReasons)
 	if holdoutDecision.Variation != nil {
 		return &holdoutDecision, reasons

--- a/pkg/decision/rollout_service_test.go
+++ b/pkg/decision/rollout_service_test.go
@@ -397,7 +397,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_RegularRule_UserBu
 			{EntityID: "ho_var_1", EndOfRange: 10000}, // 100% — user always bucketed
 		},
 	}
-	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{localHoldout})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.Key).Return([]entities.Holdout{localHoldout})
 	s.mockLogger.On("Debug", mock.Anything).Return()
 	s.mockLogger.On("Info", mock.Anything).Return()
 
@@ -432,7 +432,7 @@ func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_RegularRule_UserMi
 			{EntityID: "ho_var_1", EndOfRange: 0}, // 0% — user never bucketed
 		},
 	}
-	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{localHoldout})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.Key).Return([]entities.Holdout{localHoldout})
 	s.mockAudienceTreeEvaluator.On("Evaluate", testExp1112.AudienceConditionTree, s.testConditionTreeParams, mock.Anything).Return(true, true, s.reasons)
 
 	expectedVariation := testExp1112Var2222
@@ -489,9 +489,9 @@ func (s *RolloutServiceTestSuite) TestGetDecisionLocalHoldout_FallbackRule_UserB
 	}
 
 	// Regular rules miss the holdout; fallback rule hits it
-	s.mockConfig.On("GetHoldoutsForRule", testExp1112.ID).Return([]entities.Holdout{holdoutMiss})
-	s.mockConfig.On("GetHoldoutsForRule", testExp1117.ID).Return([]entities.Holdout{holdoutMiss})
-	s.mockConfig.On("GetHoldoutsForRule", testExp1118.ID).Return([]entities.Holdout{holdoutHit})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1112.Key).Return([]entities.Holdout{holdoutMiss})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1117.Key).Return([]entities.Holdout{holdoutMiss})
+	s.mockConfig.On("GetHoldoutsForRule", testExp1118.Key).Return([]entities.Holdout{holdoutHit})
 
 	// Audience fails for both regular rules so they continue to the next rule
 	s.mockAudienceTreeEvaluator.On("Evaluate", testExp1112.AudienceConditionTree, s.testConditionTreeParams, mock.Anything).Return(false, true, s.reasons)


### PR DESCRIPTION
## Summary
- Local holdout lookup in `GetLocalDecisionForRule` was using experiment **ID** but `ruleHoldoutsMap` is keyed by rule **Key** (from datafile `includedRules`). This caused local holdouts to silently never match.
- Fixed in both `feature_experiment_service.go` and `rollout_service.go`
- Updated rollout_service_test.go mocks to use `.Key` instead of `.ID`

## Test plan
- [x] All `decision` package tests pass locally
- [ ] FSC holdout scenarios should now pass (the 7 local holdout failures)

https://optimizely-ext.atlassian.net/browse/FSSDK-12786

🤖 Generated with [Claude Code](https://claude.com/claude-code)