### PR TITLE
[AI-FSSDK] [FSSDK-12750] Use attribute ID instead of key for CMAB prediction requests

### DIFF
--- a/pkg/cmab/service.go
+++ b/pkg/cmab/service.go
@@ -233,7 +233,7 @@ func (s *DefaultCmabService) filterAttributes(
 		}
 
 		if value, exists := userContext.Attributes[attributeKey]; exists {
-			filteredAttributes[attributeKey] = value
+			filteredAttributes[attributeID] = value
 		}
 	}
 

--- a/pkg/cmab/service_test.go
+++ b/pkg/cmab/service_test.go
@@ -359,8 +359,12 @@ func (s *CmabServiceTestSuite) TestGetDecisionWithCache() {
 	// Setup cache key
 	cacheKey := s.cmabService.getCacheKey(s.testUserID, s.testRuleID)
 
-	// Calculate attributes hash using murmur3 as in your implementation
-	attributesJSON, _ := s.cmabService.getAttributesJSON(s.testAttributes)
+	// Calculate attributes hash using the ID-keyed filtered attributes (matching service behavior)
+	filteredByID := map[string]interface{}{
+		"attr1": 30,
+		"attr2": "San Francisco",
+	}
+	attributesJSON, _ := s.cmabService.getAttributesJSON(filteredByID)
 	hasher := murmur3.SeedNew32(1)
 	hasher.Write([]byte(attributesJSON))
 	attributesHash := strconv.FormatUint(uint64(hasher.Sum32()), 10)
@@ -624,11 +628,11 @@ func (s *CmabServiceTestSuite) TestFilterAttributes() {
 	// Call filterAttributes directly
 	filteredAttrs := s.cmabService.filterAttributes(s.mockConfig, userContext, s.testRuleID)
 
-	// Verify only the configured attributes are included
+	// Verify only the configured attributes are included, keyed by attribute ID
 	s.Equal(2, len(filteredAttrs))
-	s.Equal(30, filteredAttrs["age"])
-	s.Equal("San Francisco", filteredAttrs["location"])
-	s.NotContains(filteredAttrs, "extra_key")
+	s.Equal(30, filteredAttrs["attr1"])
+	s.Equal("San Francisco", filteredAttrs["attr2"])
+	s.NotContains(filteredAttrs, "attr3")
 }
 
 func (s *CmabServiceTestSuite) TestOnlyFilteredAttributesPassedToClient() {
@@ -663,10 +667,10 @@ func (s *CmabServiceTestSuite) TestOnlyFilteredAttributesPassedToClient() {
 		},
 	}
 
-	// Expected filtered attributes
+	// Expected filtered attributes keyed by attribute ID
 	expectedFilteredAttrs := map[string]interface{}{
-		"age":      30,
-		"location": "San Francisco",
+		"attr1": 30,
+		"attr2": "San Francisco",
 	}
 
 	// Setup cache key
@@ -678,14 +682,13 @@ func (s *CmabServiceTestSuite) TestOnlyFilteredAttributesPassedToClient() {
 	// Setup mock API response with attribute verification
 	expectedVariationID := "variant-1"
 	s.mockClient.On("FetchDecision", s.testRuleID, s.testUserID, mock.MatchedBy(func(attrs map[string]interface{}) bool {
-		// Verify only the filtered attributes are passed
 		if len(attrs) != 2 {
 			return false
 		}
-		if attrs["age"] != 30 {
+		if attrs["attr1"] != 30 {
 			return false
 		}
-		if attrs["location"] != "San Francisco" {
+		if attrs["attr2"] != "San Francisco" {
 			return false
 		}
 		if _, exists := attrs["extra_key"]; exists {


### PR DESCRIPTION
## Summary

The CMAB service's attribute filtering was using attribute keys as map keys in the filtered attributes passed to the prediction endpoint. The CMAB prediction API expects the attribute ID (not key) in the `"id"` field of each attribute object. This fix ensures the filtered attributes map uses attribute IDs as keys so the downstream HTTP request sends the correct identifiers.

## Changes

- Updated `filterAttributes()` to store filtered attributes by attribute ID instead of attribute key
- Updated related tests to verify attributes are keyed by ID in filtered output, client calls, and cache hash computation

## Jira Ticket

[FSSDK-12750](https://optimizely-ext.atlassian.net/browse/FSSDK-12750)

[FSSDK-12750]: https://optimizely-ext.atlassian.net/browse/FSSDK-12750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ